### PR TITLE
Issue/7/interp cdf fix addresses issue #7

### DIFF
--- a/qp/interp_pdf.py
+++ b/qp/interp_pdf.py
@@ -89,8 +89,10 @@ class interp_gen(Pdf_rows_gen):
         # pylint: disable=arguments-differ
         factored, xr, rr, _ = self._sliceargs(x, row)
         if factored:
-            return interpolate_x_multi_y(xr, self._xvals, self._yvals[rr]).reshape(x.shape)
-        return interpolate_unfactored_x_multi_y(xr, rr, self._xvals, self._yvals)
+            return interpolate_x_multi_y(xr, self._xvals, self._yvals[rr], bounds_error=False,
+                                         fill_value=0.).reshape(x.shape)
+        return interpolate_unfactored_x_multi_y(xr, rr, self._xvals, self._yvals,
+                                                bounds_error=False, fill_value=0.)
 
     def _cdf(self, x, row):
         # pylint: disable=arguments-differ
@@ -98,8 +100,10 @@ class interp_gen(Pdf_rows_gen):
             self._compute_ycumul()
         factored, xr, rr, _ = self._sliceargs(x, row)
         if factored:
-            return interpolate_x_multi_y(xr, self._xvals, self._ycumul[rr]).reshape(x.shape)
-        return interpolate_unfactored_x_multi_y(xr, rr, self._xvals, self._ycumul)
+            return interpolate_x_multi_y(xr, self._xvals, self._ycumul[rr],
+                                         bounds_error=False, fill_value=(0.,1.)).reshape(x.shape)
+        return interpolate_unfactored_x_multi_y(xr, rr, self._xvals, self._ycumul,
+                                                bounds_error=False, fill_value=(0.,1.))
 
     def _ppf(self, x, row):
         # pylint: disable=arguments-differ
@@ -107,8 +111,10 @@ class interp_gen(Pdf_rows_gen):
         if self._ycumul is None:  # pragma: no cover
             self._compute_ycumul()
         if factored:
-            return interpolate_multi_x_y(xr, self._ycumul[rr], self._xvals).reshape(x.shape)
-        return interpolate_unfactored_multi_x_y(xr, rr, self._ycumul, self._xvals)
+            return interpolate_multi_x_y(xr, self._ycumul[rr], self._xvals, bounds_error=False,
+                                         fill_value=(0.,1.)).reshape(x.shape)
+        return interpolate_unfactored_multi_x_y(xr, rr, self._ycumul, self._xvals,
+                                                bounds_error=False, fill_value=(0.,1.))
 
     def _updated_ctor_param(self):
         """

--- a/qp/interp_pdf.py
+++ b/qp/interp_pdf.py
@@ -70,8 +70,10 @@ class interp_gen(Pdf_rows_gen):
     def _compute_ycumul(self):
         copy_shape = np.array(self._yvals.shape)
         self._ycumul = np.ndarray(copy_shape)
-        self._ycumul[:,0] = 0.
-        self._ycumul[:,1:] = np.cumsum((self._xvals[1:]-self._xvals[0:-1])*self._yvals[:,1:], axis=1)
+        self._ycumul[:, 0] = 0.5 * self._yvals[:, 0] * (self._xvals[1] - self._xvals[0])
+        self._ycumul[:, 1:] = np.cumsum((self._xvals[1:] - self._xvals[:-1]) *
+                                        0.5 * np.add(self._yvals[:,1:],
+                                                     self._yvals[:,:-1]), axis=1)
 
     @property
     def xvals(self):


### PR DESCRIPTION
This PR addresses issue #7 and improves the agreement of CDF and PPF by switching from tophat to trapz integration, which should be exact for linear interpolation.  

Only a couple lines, and all tests are passing.