### PR TITLE
Issue/34/packdata closing issue #34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,11 @@ setup(
     author="Alex Malz, Phil Marshall, Eric Charles",
     author_email="aimalz@nyu.edu, pjm@slac.stanford.edu, echarles@slac.stanford.edu",
     url = "https://github.com/aimalz/qp",
-    packages=["qp"],
+    packages=["qp", "docs/notebooks"],
     description="Quantile parametrization of probability distribution functions",
     long_description=open("README.md").read(),
-    package_data={"": ["README.md", "LICENSE"]},
+    package_data={"": ["README.md", "LICENSE", "*.npy"],
+                      "docs/notebooks": ["*.npy"]},
     include_package_data=True,
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR addresses issue #34 where a required .npy file is missing from the package repo, which causes `import qp` to fail when installed.  The simple fix here is to add docs/notebooks/*.npy to the package data in setup.py.  As this is related to the new sparse representation, I'll assign Johann to review