### PR TITLE
Issue/58/iterator

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
+    branches: [ issue/58/iterator ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ issue/58/iterator ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/qp/ensemble.py
+++ b/qp/ensemble.py
@@ -592,6 +592,31 @@ class Ensemble:
         """
         return self._gen_class.plot_native(self[key], **kwargs)
 
+    def _get_allocation_kwds(self, npdf):
+        return self._gen_class.get_allocation_kwds(npdf, **self.metadata())
+
+
+    def initializeHdf5Write(self, filename, npdf):
+        """set up the output write for an ensemble, but set size to npdf rather than
+        the size of the ensemble, as the "initial chunk" will not contain the full data
+        """
+        kwds = self._get_allocation_kwds(npdf)
+        group, fout = io.initializeHdf5Write(filename, 'data', **kwds)
+        return group, fout
+
+    def writeHdf5Chunk(self, fname, start, end):
+        """write ensemble data chunk to file
+        Parameters
+        ----------
+        fname : h5py `File object` file or group
+        start : `int` starting index of h5py file
+        end : `int` ending index in h5py file
+        """
+        io.writeDictToHdf5Chunk(fname, self.objdata(), start, end)
+
+    def finalizeHdf5Write(self, filename):
+        mdata = self.metadata()
+        io.finalizeHdf5Write(filename, 'meta', **mdata)
 
     # def stack(self, loc, using, vb=True):
     #     """

--- a/qp/hist_pdf.py
+++ b/qp/hist_pdf.py
@@ -143,6 +143,13 @@ class hist_gen(Pdf_rows_gen):
         return dct
 
     @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        if 'bins' not in kwargs: #pragma: no cover
+            raise ValueError("required argument 'bins' not included in kwargs")
+        nbins = len(kwargs['bins'].flatten())
+        return dict(pdfs=((npdf, nbins-1), 'f4'))
+
+    @classmethod
     def plot_native(cls, pdf, **kwargs):
         """Plot the PDF in a way that is particular to this type of distibution
 

--- a/qp/interp_pdf.py
+++ b/qp/interp_pdf.py
@@ -150,6 +150,22 @@ class interp_gen(Pdf_rows_gen):
         return dct
 
     @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        """
+        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        for iterative file writeout.  We only need to allocate the objdata columns, as
+        the metadata can be written when we finalize the file.
+        Parameters
+        ----------
+        npdf: (int) number of *total* PDFs that will be written out
+        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        """
+        if 'xvals' not in kwargs: #pragma: no cover
+            raise ValueError("required argument xvals not included in kwargs")
+        ngrid = len(kwargs['xvals'].flatten())
+        return dict(yvals=((npdf, ngrid), 'f4'))
+
+    @classmethod
     def plot_native(cls, pdf, **kwargs):
         """Plot the PDF in a way that is particular to this type of distibution
 

--- a/qp/interp_pdf.py
+++ b/qp/interp_pdf.py
@@ -162,7 +162,7 @@ class interp_gen(Pdf_rows_gen):
         """
         if 'xvals' not in kwargs: #pragma: no cover
             raise ValueError("required argument xvals not included in kwargs")
-        ngrid = len(kwargs['xvals'].flatten())
+        ngrid = np.shape(kwargs['xvals'])[-1]
         return dict(yvals=((npdf, ngrid), 'f4'))
 
     @classmethod
@@ -304,6 +304,22 @@ class interp_irregular_gen(Pdf_rows_gen):
         dct['xvals'] = self._xvals
         dct['yvals'] = self._yvals
         return dct
+
+    @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        """
+        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        for iterative file writeout.  We only need to allocate the objdata columns, as
+        the metadata can be written when we finalize the file.
+        Parameters
+        ----------
+        npdf: (int) number of *total* PDFs that will be written out
+        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        """
+        if 'xvals' not in kwargs: #pragma: no cover
+            raise ValueError("required argument xvals not included in kwargs")
+        ngrid = np.shape(kwargs['xvals'])[-1]
+        return dict(xvals=((npdf, ngrid), 'f4'), yvals=((npdf, ngrid), 'f4'))
 
     @classmethod
     def plot_native(cls, pdf, **kwargs):

--- a/qp/mixmod_pdf.py
+++ b/qp/mixmod_pdf.py
@@ -115,6 +115,25 @@ class mixmod_gen(Pdf_rows_gen):
         dct['weights'] = self._weights
         return dct
 
+
+    @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        """
+        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        for iterative file writeout.  We only need to allocate the objdata columns, as
+        the metadata can be written when we finalize the file.
+        Parameters
+        ----------
+        npdf: (int) number of *total* PDFs that will be written out
+        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        """
+        if 'means' not in kwargs: #pragma: no cover
+            raise ValueError("required argument means not included in kwargs")
+
+        ncomp = np.shape(kwargs['means'])[-1]        
+        return dict(means=((npdf, ncomp), 'f4'), stds=((npdf, ncomp), 'f4'), weights=((npdf, ncomp), 'f4'))
+
+
     @classmethod
     def add_mappings(cls):
         """

--- a/qp/pdf_gen.py
+++ b/qp/pdf_gen.py
@@ -63,6 +63,9 @@ class Pdf_gen:
     def _addobjdata(self, key, val):
         self._objdata[key] = val
 
+    def _clearobjdata(self):
+        self._objdata = {}
+
     @property
     def metadata(self):
         """Return the metadata for this set of PDFs"""

--- a/qp/pdf_gen.py
+++ b/qp/pdf_gen.py
@@ -147,6 +147,13 @@ class Pdf_gen:
         """
         return plot_dist_pdf(pdf, **kwargs)
 
+    @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        """Return kwds necessary to create 'empty' hdf5 file with npdf entries
+        for iterative writeout
+        """
+        raise NotImplementedError()  #pragma: no cover
+
     def _moment_fix(self, n, *args, **kwds):
         """Hack fix for the moments calculation in scipy.stats, which can't handle
         the case of multiple PDFs.
@@ -415,6 +422,12 @@ class Pdf_gen_wrap(Pdf_gen):
     def _my_argcheck(self, *args):
         # pylint: disable=no-member,protected-access
         return np.atleast_1d(self._other_argcheck(*args))
+
+
+    @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        return {key:((npdf,1), val.dtype) for key, val in kwargs.items()}
+
 
     @classmethod
     def add_mappings(cls):

--- a/qp/quant_pdf.py
+++ b/qp/quant_pdf.py
@@ -161,14 +161,15 @@ class quant_gen(Pdf_rows_gen):
         for iterative writeout
         """
         try:
-            quants = kwargs['quants'].flatten()
+            quants = kwargs['quants']
         except ValueError: #pragma: no cover
             print("required argument 'quants' not included in kwargs")
-        nquants = quants.size
-        if quants[0] > sys.float_info.epsilon:
-            nquants += 1
-        if quants[-1] < 1.:
-            nquants += 1
+        nquants = np.shape(quants)[-1]
+        # EC, I don't thing you need these lines, as you don't actually store the ends
+        #if quants[0] > sys.float_info.epsilon:
+        #    nquants += 1
+        #if quants[-1] < 1.:
+        #    nquants += 1
         return dict(locs=((npdf, nquants), 'f4'))
 
     @classmethod
@@ -292,6 +293,18 @@ class quant_piecewise_gen(Pdf_rows_gen):
         dct['quants'] = self._quants
         dct['locs'] = self._locs
         return dct
+
+    @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        """Return kwds necessary to create 'empty' hdf5 file with npdf entries
+        for iterative writeout
+        """
+        try:
+            quants = kwargs['quants']
+        except ValueError: #pragma: no cover
+            print("required argument 'quants' not included in kwargs")
+        nquants = np.shape(quants)[-1]
+        return dict(locs=((npdf, nquants), 'f4'))
 
     @classmethod
     def plot_native(cls, pdf, **kwargs):

--- a/qp/quant_pdf.py
+++ b/qp/quant_pdf.py
@@ -156,6 +156,22 @@ class quant_gen(Pdf_rows_gen):
         return dct
 
     @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        """Return kwds necessary to create 'empty' hdf5 file with npdf entries
+        for iterative writeout
+        """
+        try:
+            quants = kwargs['quants'].flatten()
+        except ValueError: #pragma: no cover
+            print("required argument 'quants' not included in kwargs")
+        nquants = quants.size
+        if quants[0] > sys.float_info.epsilon:
+            nquants += 1
+        if quants[-1] < 1.:
+            nquants += 1
+        return dict(locs=((npdf, nquants), 'f4'))
+
+    @classmethod
     def plot_native(cls, pdf, **kwargs):
         """Plot the PDF in a way that is particular to this type of distibution
 

--- a/qp/sparse_pdf.py
+++ b/qp/sparse_pdf.py
@@ -72,6 +72,14 @@ class sparse_gen(interp_gen):
         return dct
 
     @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        if 'dims' not in kwargs:
+            raise ValueError("required argument dims not in kwargs")
+        nsp = kwargs['dims'].flatten()[4]
+        nmu = kwargs['dims'].flatten()[0]
+        return dict(yvals=((npdf, nmu), 'f4'), sparse_indices=((npdf, nsp), 'i8'))
+
+    @classmethod
     def add_mappings(cls):
         """
         Add this classes mappings to the conversion dictionary

--- a/qp/sparse_pdf.py
+++ b/qp/sparse_pdf.py
@@ -74,10 +74,10 @@ class sparse_gen(interp_gen):
     @classmethod
     def get_allocation_kwds(cls, npdf, **kwargs):
         if 'dims' not in kwargs:
-            raise ValueError("required argument dims not in kwargs")
-        nsp = kwargs['dims'].flatten()[4]
-        nmu = kwargs['dims'].flatten()[0]
-        return dict(yvals=((npdf, nmu), 'f4'), sparse_indices=((npdf, nsp), 'i8'))
+            raise ValueError("required argument dims not in kwargs") #pragma: no cover
+        nsp = np.array(kwargs['dims']).flatten()[4]
+        nmu = np.array(kwargs['dims']).flatten()[0]
+        return dict(sparse_indices=((npdf, nsp), 'i8'))
 
     @classmethod
     def add_mappings(cls):

--- a/qp/sparse_pdf.py
+++ b/qp/sparse_pdf.py
@@ -53,6 +53,7 @@ class sparse_gen(interp_gen):
         kwargs.setdefault('yvals', y.T)
         super(sparse_gen, self).__init__(*args, **kwargs)
 
+        self._clearobjdata()
         self._addmetadata('xvals', self._xvals)
         self._addmetadata('mu', self.mu)
         self._addmetadata('sig', self.sig)

--- a/qp/spline_pdf.py
+++ b/qp/spline_pdf.py
@@ -133,7 +133,7 @@ class spline_gen(Pdf_rows_gen):
         spln = kwargs.pop('spln', None)
 
         if splx is None:  # pragma: no cover
-            raise ValueError("Either splx must be provided")
+            raise ValueError("splx must be provided")
         if splx.shape != sply.shape:  # pragma: no cover
             raise ValueError("Shape of xvals (%s) != shape of yvals (%s)" % (splx.shape, sply.shape))
         #kwargs['a'] = self.a = np.min(splx)
@@ -267,6 +267,24 @@ class spline_gen(Pdf_rows_gen):
         dct['sply'] = self._sply
         dct['spln'] = self._spln
         return dct
+
+    @classmethod
+    def get_allocation_kwds(cls, npdf, **kwargs):
+        """
+        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        for iterative file writeout.  We only need to allocate the objdata columns, as
+        the metadata can be written when we finalize the file.
+        Parameters
+        ----------
+        npdf: (int) number of *total* PDFs that will be written out
+        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        """
+        if 'splx' not in kwargs: #pragma: no cover
+            raise ValueError("required argument splx not included in kwargs")
+
+        shape = np.shape(kwargs['splx'])        
+        return dict(splx=(shape, 'f4'), sply=(shape, 'f4'), spln=((shape[0],1), 'i4'))
+
 
     @classmethod
     def plot_native(cls, pdf, **kwargs):

--- a/qp/test_funcs.py
+++ b/qp/test_funcs.py
@@ -110,6 +110,11 @@ def run_pdf_func_tests(test_class, test_data, short=False, check_props=True):
     except Exception as exep: #pragma: no cover
         print("Failed to make %s %s %s" % (ctor_func, test_data['ctor_data'], exep))
         raise ValueError from exep
+
+    alloc_kwds = pdf.dist.get_allocation_kwds(pdf.npdf, **test_data['ctor_data'])
+    for key, val in alloc_kwds.items():
+        assert val[0] == np.shape(test_data['ctor_data'][key])
+
     return pdf_func_tests(pdf, test_data, short=short, check_props=check_props)
 
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -110,10 +110,8 @@ class EnsembleTestCase(unittest.TestCase):
             ens.writeHdf5Chunk(group, 0, ens.npdf)
             ens.finalizeHdf5Write(fout)
             readens = qp.read("testwrite.hdf5")
-            for key in readens.metadata().keys():
-                assert key in ens.metadata().keys()
-            for key in readens.objdata().keys():
-                assert key in ens.objdata().keys()
+            assert readens.metadata().keys() == ens.metadata().keys()
+            assert readens.objdata().keys() == ens.objdata().keys()
             os.remove("testwrite.hdf5")
 
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -6,6 +6,7 @@ import numpy as np
 import unittest
 import qp
 from qp import test_data
+import os
 
 from qp.test_funcs import assert_all_small, assert_all_close, build_ensemble
 
@@ -103,6 +104,18 @@ class EnsembleTestCase(unittest.TestCase):
 
         check_red = red_pdf - pdfs[0:5]
         assert_all_small(check_red, atol=1e-5, test_name="red")
+
+        if hasattr(ens.gen_obj, 'npdf'): # skip scipy norm
+            group, fout = ens.initializeHdf5Write("testwrite.hdf5", ens.npdf)
+            ens.writeHdf5Chunk(group, 0, ens.npdf)
+            ens.finalizeHdf5Write(fout)
+            readens = qp.read("testwrite.hdf5")
+            for key in readens.metadata().keys():
+                assert key in ens.metadata().keys()
+            for key in readens.objdata().keys():
+                assert key in ens.objdata().keys()
+            os.remove("testwrite.hdf5")
+
 
     @staticmethod
     def _run_merge_tests(ens, xpts):


### PR DESCRIPTION
This is a draft PR of the hack-y way that I implemented an iterative write method.  The only thing that we really need is the list of kwds to feed into tables_io.io.initializeHdf5Write (where we have resized the array shapes to be Npdf rows where Npdf is the total number to be written to file rather than the number in a single chunk).  

The way I have done things here, you can either get the kwds for a specific subclass type from a dictionary with the required metadata arguments and use this to initialize a file with tables_io.io.initializeHdf5Write, e.g.
`exdict = dict(dims=np.array([300, 50, 3, 32001, 20]))`
`kwds = qp.sparse_gen.get_allocation_kwds(Npdf, **exdict)`

Or, if you have the first chunk of data for the big ensemble that you want to write, you can just call ens.initializeHdf5Write directly and it will figure out the shapes from the ens.metadata automatically, e.g.:
`ens = qp.Ensemble(qp.interp, data=dict(xvals=x, yvals=y))`
`group, outf = ens.initializeHdf5Write("xtestfile.hdf5", Npdf)`


This seems to work for interp, sparse, hist, and quant parameterizations just fine, though I'm not sure exactly how to handle the scipy distributions.