### PR TITLE
add objdata to dict passed to get_allocation_kwds

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -83,6 +83,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;
 }
 
+/* tiny scrollbar */
+
+.jp-scrollbar-tiny {
+  scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;
+  scrollbar-width: thin;
+}
+
 /*
  * Webkit scrollbar styling
  */
@@ -146,6 +153,29 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   .CodeMirror-vscrollbar::-webkit-scrollbar-track:vertical {
   border-top: var(--jp-scrollbar-endpad) solid transparent;
   border-bottom: var(--jp-scrollbar-endpad) solid transparent;
+}
+
+/* tiny scrollbar */
+
+.jp-scrollbar-tiny::-webkit-scrollbar,
+.jp-scrollbar-tiny::-webkit-scrollbar-corner {
+  background-color: transparent;
+  height: 4px;
+  width: 4px;
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-thumb {
+  background: rgba(var(--jp-scrollbar-thumb-color), 0.5);
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-track:horizontal {
+  border-left: 0px solid transparent;
+  border-right: 0px solid transparent;
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-track:vertical {
+  border-top: 0px solid transparent;
+  border-bottom: 0px solid transparent;
 }
 
 /*
@@ -338,6 +368,33 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.lm-close-icon {
+	border:1px solid transparent;
+  background-color: transparent;
+  position: absolute;
+	z-index:1;
+	right:3%;
+	top: 0;
+	bottom: 0;
+	margin: auto;
+	padding: 7px 0;
+	display: none;
+	vertical-align: middle;
+  outline: 0;
+  cursor: pointer;
+}
+.lm-close-icon:after {
+	content: "X";
+	display: block;
+	width: 15px;
+	height: 15px;
+	text-align: center;
+	color:#000;
+	font-weight: normal;
+	font-size: 12px;
+	cursor: pointer;
 }
 
 /*-----------------------------------------------------------------------------
@@ -776,6 +833,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 }
 
 
+.lm-TabBar-tabInput {
+  user-select: all;
+  width: 100%;
+  box-sizing : border-box;
+}
+
+
 /* <DEPRECATED> */ .p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-hidden {
   display: none !important;
@@ -807,7 +871,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 
 
 /* <DEPRECATED> */
-.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging
+.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging,
 /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
   transition: none;
@@ -844,12 +908,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 |----------------------------------------------------------------------------*/
 
 @charset "UTF-8";
-/*!
-
-Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
-Licensed under the Apache License, Version 2.0.
-
-*/
 html{
   -webkit-box-sizing:border-box;
           box-sizing:border-box; }
@@ -861,17 +919,17 @@ html{
           box-sizing:inherit; }
 
 body{
-  text-transform:none;
-  line-height:1.28581;
-  letter-spacing:0;
   font-size:14px;
   font-weight:400;
+  letter-spacing:0;
+  line-height:1.28581;
+  text-transform:none;
   color:#182026;
   font-family:-apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", "Icons16", sans-serif; }
 
 p{
-  margin-top:0;
-  margin-bottom:10px; }
+  margin-bottom:10px;
+  margin-top:0; }
 
 small{
   font-size:12px; }
@@ -893,38 +951,38 @@ strong{
     color:#f5f8fa; }
 
 h1.bp3-heading, .bp3-running-text h1{
-  line-height:40px;
-  font-size:36px; }
+  font-size:36px;
+  line-height:40px; }
 
 h2.bp3-heading, .bp3-running-text h2{
-  line-height:32px;
-  font-size:28px; }
+  font-size:28px;
+  line-height:32px; }
 
 h3.bp3-heading, .bp3-running-text h3{
-  line-height:25px;
-  font-size:22px; }
+  font-size:22px;
+  line-height:25px; }
 
 h4.bp3-heading, .bp3-running-text h4{
-  line-height:21px;
-  font-size:18px; }
+  font-size:18px;
+  line-height:21px; }
 
 h5.bp3-heading, .bp3-running-text h5{
-  line-height:19px;
-  font-size:16px; }
+  font-size:16px;
+  line-height:19px; }
 
 h6.bp3-heading, .bp3-running-text h6{
-  line-height:16px;
-  font-size:14px; }
-.bp3-ui-text{
-  text-transform:none;
-  line-height:1.28581;
-  letter-spacing:0;
   font-size:14px;
-  font-weight:400; }
+  line-height:16px; }
+.bp3-ui-text{
+  font-size:14px;
+  font-weight:400;
+  letter-spacing:0;
+  line-height:1.28581;
+  text-transform:none; }
 
 .bp3-monospace-text{
-  text-transform:none;
-  font-family:monospace; }
+  font-family:monospace;
+  text-transform:none; }
 
 .bp3-text-muted{
   color:#5c7080; }
@@ -942,54 +1000,54 @@ h6.bp3-heading, .bp3-running-text h6{
   white-space:nowrap;
   word-wrap:normal; }
 .bp3-running-text{
-  line-height:1.5;
-  font-size:14px; }
+  font-size:14px;
+  line-height:1.5; }
   .bp3-running-text h1{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h1{
       color:#f5f8fa; }
   .bp3-running-text h2{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h2{
       color:#f5f8fa; }
   .bp3-running-text h3{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h3{
       color:#f5f8fa; }
   .bp3-running-text h4{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h4{
       color:#f5f8fa; }
   .bp3-running-text h5{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h5{
       color:#f5f8fa; }
   .bp3-running-text h6{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h6{
       color:#f5f8fa; }
   .bp3-running-text hr{
-    margin:20px 0;
     border:none;
-    border-bottom:1px solid rgba(16, 22, 26, 0.15); }
+    border-bottom:1px solid rgba(16, 22, 26, 0.15);
+    margin:20px 0; }
     .bp3-dark .bp3-running-text hr{
       border-color:rgba(255, 255, 255, 0.15); }
   .bp3-running-text p{
@@ -1002,12 +1060,12 @@ h6.bp3-heading, .bp3-running-text h6{
 .bp3-text-small{
   font-size:12px; }
 a{
-  text-decoration:none;
-  color:#106ba3; }
+  color:#106ba3;
+  text-decoration:none; }
   a:hover{
+    color:#106ba3;
     cursor:pointer;
-    text-decoration:underline;
-    color:#106ba3; }
+    text-decoration:underline; }
   a .bp3-icon, a .bp3-icon-standard, a .bp3-icon-large{
     color:inherit; }
   a code,
@@ -1022,19 +1080,19 @@ a{
     .bp3-dark a:hover .bp3-icon-large{
       color:inherit; }
 .bp3-running-text code, .bp3-code{
-  text-transform:none;
   font-family:monospace;
+  text-transform:none;
+  background:rgba(255, 255, 255, 0.7);
   border-radius:3px;
   -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
           box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
-  background:rgba(255, 255, 255, 0.7);
-  padding:2px 5px;
   color:#5c7080;
-  font-size:smaller; }
+  font-size:smaller;
+  padding:2px 5px; }
   .bp3-dark .bp3-running-text code, .bp3-running-text .bp3-dark code, .bp3-dark .bp3-code{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#a7b6c2; }
   .bp3-running-text a > code, a > .bp3-code{
     color:#137cbd; }
@@ -1042,65 +1100,65 @@ a{
       color:inherit; }
 
 .bp3-running-text pre, .bp3-code-block{
-  text-transform:none;
   font-family:monospace;
-  display:block;
-  margin:10px 0;
+  text-transform:none;
+  background:rgba(255, 255, 255, 0.7);
   border-radius:3px;
   -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
           box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
-  background:rgba(255, 255, 255, 0.7);
-  padding:13px 15px 12px;
-  line-height:1.4;
   color:#182026;
+  display:block;
   font-size:13px;
+  line-height:1.4;
+  margin:10px 0;
+  padding:13px 15px 12px;
   word-break:break-all;
   word-wrap:break-word; }
   .bp3-dark .bp3-running-text pre, .bp3-running-text .bp3-dark pre, .bp3-dark .bp3-code-block{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa; }
   .bp3-running-text pre > code, .bp3-code-block > code{
+    background:none;
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:none;
-    padding:0;
     color:inherit;
-    font-size:inherit; }
+    font-size:inherit;
+    padding:0; }
 
 .bp3-running-text kbd, .bp3-key{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
+  background:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  min-width:24px;
-  height:24px;
-  padding:3px 6px;
-  vertical-align:middle;
-  line-height:24px;
   color:#5c7080;
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
   font-family:inherit;
-  font-size:12px; }
+  font-size:12px;
+  height:24px;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  line-height:24px;
+  min-width:24px;
+  padding:3px 6px;
+  vertical-align:middle; }
   .bp3-running-text kbd .bp3-icon, .bp3-key .bp3-icon, .bp3-running-text kbd .bp3-icon-standard, .bp3-key .bp3-icon-standard, .bp3-running-text kbd .bp3-icon-large, .bp3-key .bp3-icon-large{
     margin-right:5px; }
   .bp3-dark .bp3-running-text kbd, .bp3-running-text .bp3-dark kbd, .bp3-dark .bp3-key{
+    background:#394b59;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:#394b59;
     color:#a7b6c2; }
 .bp3-running-text blockquote, .bp3-blockquote{
-  margin:0 0 10px;
   border-left:solid 4px rgba(167, 182, 194, 0.5);
+  margin:0 0 10px;
   padding:0 20px; }
   .bp3-dark .bp3-running-text blockquote, .bp3-running-text .bp3-dark blockquote, .bp3-dark .bp3-blockquote{
     border-color:rgba(115, 134, 148, 0.5); }
@@ -1117,9 +1175,9 @@ a{
     margin-top:5px; }
 
 .bp3-list-unstyled{
+  list-style:none;
   margin:0;
-  padding:0;
-  list-style:none; }
+  padding:0; }
   .bp3-list-unstyled li{
     padding:0; }
 .bp3-rtl{
@@ -1147,9 +1205,12 @@ a{
   display:-ms-flexbox;
   display:flex; }
   .bp3-alert-body .bp3-icon{
-    margin-top:0;
+    font-size:40px;
     margin-right:20px;
-    font-size:40px; }
+    margin-top:0; }
+
+.bp3-alert-contents{
+  word-break:break-word; }
 
 .bp3-alert-footer{
   display:-webkit-box;
@@ -1163,45 +1224,45 @@ a{
   .bp3-alert-footer .bp3-button{
     margin-left:10px; }
 .bp3-breadcrumbs{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  cursor:default;
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -ms-flex-wrap:wrap;
       flex-wrap:wrap;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  margin:0;
-  cursor:default;
   height:30px;
-  padding:0;
-  list-style:none; }
+  list-style:none;
+  margin:0;
+  padding:0; }
   .bp3-breadcrumbs > li{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
     -webkit-box-align:center;
         -ms-flex-align:center;
-            align-items:center; }
+            align-items:center;
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex; }
     .bp3-breadcrumbs > li::after{
+      background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z' fill='%235C7080'/%3e%3c/svg%3e");
+      content:"";
       display:block;
-      margin:0 5px;
-      background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.71 7.29l-4-4a1.003 1.003 0 0 0-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z' fill='%235C7080'/%3e%3c/svg%3e");
-      width:16px;
       height:16px;
-      content:""; }
+      margin:0 5px;
+      width:16px; }
     .bp3-breadcrumbs > li:last-of-type::after{
       display:none; }
 
 .bp3-breadcrumb,
 .bp3-breadcrumb-current,
 .bp3-breadcrumbs-collapsed{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
   font-size:16px; }
 
 .bp3-breadcrumb,
@@ -1212,8 +1273,8 @@ a{
   text-decoration:none; }
 
 .bp3-breadcrumb.bp3-disabled{
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-breadcrumb .bp3-icon{
   margin-right:5px; }
@@ -1222,28 +1283,28 @@ a{
   color:inherit;
   font-weight:600; }
   .bp3-breadcrumb-current .bp3-input{
-    vertical-align:baseline;
     font-size:inherit;
-    font-weight:inherit; }
+    font-weight:inherit;
+    vertical-align:baseline; }
 
 .bp3-breadcrumbs-collapsed{
-  margin-right:2px;
+  background:#ced9e0;
   border:none;
   border-radius:3px;
-  background:#ced9e0;
   cursor:pointer;
+  margin-right:2px;
   padding:1px 5px;
   vertical-align:text-bottom; }
   .bp3-breadcrumbs-collapsed::before{
-    display:block;
     background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cg fill='%235C7080'%3e%3ccircle cx='2' cy='8.03' r='2'/%3e%3ccircle cx='14' cy='8.03' r='2'/%3e%3ccircle cx='8' cy='8.03' r='2'/%3e%3c/g%3e%3c/svg%3e") center no-repeat;
-    width:16px;
+    content:"";
+    display:block;
     height:16px;
-    content:""; }
+    width:16px; }
   .bp3-breadcrumbs-collapsed:hover{
     background:#bfccd6;
-    text-decoration:none;
-    color:#182026; }
+    color:#182026;
+    text-decoration:none; }
 
 .bp3-dark .bp3-breadcrumb,
 .bp3-dark .bp3-breadcrumbs-collapsed{
@@ -1274,18 +1335,18 @@ a{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
   border:none;
   border-radius:3px;
   cursor:pointer;
-  padding:5px 10px;
-  vertical-align:middle;
-  text-align:left;
   font-size:14px;
-  min-width:30px;
-  min-height:30px; }
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  padding:5px 10px;
+  text-align:left;
+  vertical-align:middle;
+  min-height:30px;
+  min-width:30px; }
   .bp3-button > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -1320,140 +1381,140 @@ a{
   .bp3-align-left .bp3-button{
     text-align:left; }
   .bp3-button:not([class*="bp3-intent-"]){
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-color:#f5f8fa;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     color:#182026; }
     .bp3-button:not([class*="bp3-intent-"]):hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
       background-clip:padding-box;
-      background-color:#ebf1f5; }
+      background-color:#ebf1f5;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
     .bp3-button:not([class*="bp3-intent-"]):active, .bp3-button:not([class*="bp3-intent-"]).bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#d8e1e8;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
-      outline:none;
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(206, 217, 224, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:rgba(92, 112, 128, 0.6);
       cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      outline:none; }
       .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active:hover, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active:hover{
         background:rgba(206, 217, 224, 0.7); }
   .bp3-button.bp3-intent-primary{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#137cbd;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-primary:hover, .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-primary:hover{
+      background-color:#106ba3;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#106ba3; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#0e5a8a;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-primary:disabled, .bp3-button.bp3-intent-primary.bp3-disabled{
+      background-color:rgba(19, 124, 189, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(19, 124, 189, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button.bp3-intent-success{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#0f9960;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-success:hover, .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-success:hover{
+      background-color:#0d8050;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#0d8050; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#0a6640;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-success:disabled, .bp3-button.bp3-intent-success.bp3-disabled{
+      background-color:rgba(15, 153, 96, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(15, 153, 96, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button.bp3-intent-warning{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#d9822b;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-warning:hover, .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-warning:hover{
+      background-color:#bf7326;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#bf7326; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#a66321;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-warning:disabled, .bp3-button.bp3-intent-warning.bp3-disabled{
+      background-color:rgba(217, 130, 43, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(217, 130, 43, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button.bp3-intent-danger{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#db3737;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-danger:hover, .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-danger:hover{
+      background-color:#c23030;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#c23030; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#a82a2a;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-danger:disabled, .bp3-button.bp3-intent-danger.bp3-disabled{
+      background-color:rgba(219, 55, 55, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(219, 55, 55, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
     stroke:#ffffff; }
   .bp3-button.bp3-large,
   .bp3-large .bp3-button{
-    min-width:40px;
     min-height:40px;
-    padding:5px 15px;
-    font-size:16px; }
+    min-width:40px;
+    font-size:16px;
+    padding:5px 15px; }
     .bp3-button.bp3-large::before,
     .bp3-button.bp3-large > *,
     .bp3-large .bp3-button::before,
@@ -1466,24 +1527,24 @@ a{
       margin-right:0; }
   .bp3-button.bp3-small,
   .bp3-small .bp3-button{
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     padding:0 7px; }
   .bp3-button.bp3-loading{
     position:relative; }
     .bp3-button.bp3-loading[class*="bp3-icon-"]::before{
       visibility:hidden; }
     .bp3-button.bp3-loading .bp3-button-spinner{
-      position:absolute;
-      margin:0; }
+      margin:0;
+      position:absolute; }
     .bp3-button.bp3-loading > :not(.bp3-button-spinner){
       visibility:hidden; }
   .bp3-button[class*="bp3-icon-"]::before{
-    line-height:1;
     font-family:"Icons16", sans-serif;
     font-size:16px;
-    font-weight:400;
     font-style:normal;
+    font-weight:400;
+    line-height:1;
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased;
     color:#5c7080; }
@@ -1495,28 +1556,28 @@ a{
   .bp3-button .bp3-spinner + .bp3-icon:last-child{
     margin:0 -7px; }
   .bp3-dark .bp3-button:not([class*="bp3-intent-"]){
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     background-color:#394b59;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     color:#f5f8fa; }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover, .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
       color:#f5f8fa; }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover{
+      background-color:#30404d;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#202b33;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(57, 75, 89, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:rgba(167, 182, 194, 0.6); }
       .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active{
         background:rgba(57, 75, 89, 0.7); }
@@ -1537,9 +1598,9 @@ a{
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-button[class*="bp3-intent-"]:disabled, .bp3-dark .bp3-button[class*="bp3-intent-"].bp3-disabled{
+      background-image:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-image:none;
       color:rgba(255, 255, 255, 0.3); }
     .bp3-dark .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
       stroke:#8a9ba8; }
@@ -1549,35 +1610,35 @@ a{
   .bp3-button[class*="bp3-intent-"] .bp3-icon, .bp3-button[class*="bp3-intent-"] .bp3-icon-standard, .bp3-button[class*="bp3-intent-"] .bp3-icon-large{
     color:inherit !important; }
   .bp3-button.bp3-minimal{
+    background:none;
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none; }
+            box-shadow:none; }
     .bp3-button.bp3-minimal:hover{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background:rgba(167, 182, 194, 0.3);
-      text-decoration:none;
-      color:#182026; }
-    .bp3-button.bp3-minimal:active, .bp3-button.bp3-minimal.bp3-active{
       -webkit-box-shadow:none;
               box-shadow:none;
+      color:#182026;
+      text-decoration:none; }
+    .bp3-button.bp3-minimal:active, .bp3-button.bp3-minimal.bp3-active{
       background:rgba(115, 134, 148, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:#182026; }
     .bp3-button.bp3-minimal:disabled, .bp3-button.bp3-minimal:disabled:hover, .bp3-button.bp3-minimal.bp3-disabled, .bp3-button.bp3-minimal.bp3-disabled:hover{
       background:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed; }
       .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
         background:rgba(115, 134, 148, 0.3); }
     .bp3-dark .bp3-button.bp3-minimal{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:inherit; }
       .bp3-dark .bp3-button.bp3-minimal:hover, .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none; }
+                box-shadow:none; }
       .bp3-dark .bp3-button.bp3-minimal:hover{
         background:rgba(138, 155, 168, 0.15); }
       .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
@@ -1585,16 +1646,16 @@ a{
         color:#f5f8fa; }
       .bp3-dark .bp3-button.bp3-minimal:disabled, .bp3-dark .bp3-button.bp3-minimal:disabled:hover, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover{
         background:none;
-        cursor:not-allowed;
-        color:rgba(167, 182, 194, 0.6); }
+        color:rgba(167, 182, 194, 0.6);
+        cursor:not-allowed; }
         .bp3-dark .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
           background:rgba(138, 155, 168, 0.3); }
     .bp3-button.bp3-minimal.bp3-intent-primary{
       color:#106ba3; }
       .bp3-button.bp3-minimal.bp3-intent-primary:hover, .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#106ba3; }
       .bp3-button.bp3-minimal.bp3-intent-primary:hover{
         background:rgba(19, 124, 189, 0.15);
@@ -1625,9 +1686,9 @@ a{
     .bp3-button.bp3-minimal.bp3-intent-success{
       color:#0d8050; }
       .bp3-button.bp3-minimal.bp3-intent-success:hover, .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#0d8050; }
       .bp3-button.bp3-minimal.bp3-intent-success:hover{
         background:rgba(15, 153, 96, 0.15);
@@ -1658,9 +1719,9 @@ a{
     .bp3-button.bp3-minimal.bp3-intent-warning{
       color:#bf7326; }
       .bp3-button.bp3-minimal.bp3-intent-warning:hover, .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#bf7326; }
       .bp3-button.bp3-minimal.bp3-intent-warning:hover{
         background:rgba(217, 130, 43, 0.15);
@@ -1691,9 +1752,9 @@ a{
     .bp3-button.bp3-minimal.bp3-intent-danger{
       color:#c23030; }
       .bp3-button.bp3-minimal.bp3-intent-danger:hover, .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#c23030; }
       .bp3-button.bp3-minimal.bp3-intent-danger:hover{
         background:rgba(219, 55, 55, 0.15);
@@ -1721,6 +1782,220 @@ a{
           color:rgba(255, 115, 115, 0.5); }
           .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active{
             background:rgba(219, 55, 55, 0.3); }
+  .bp3-button.bp3-outlined{
+    background:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    border:1px solid rgba(24, 32, 38, 0.2);
+    -webkit-box-sizing:border-box;
+            box-sizing:border-box; }
+    .bp3-button.bp3-outlined:hover{
+      background:rgba(167, 182, 194, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:#182026;
+      text-decoration:none; }
+    .bp3-button.bp3-outlined:active, .bp3-button.bp3-outlined.bp3-active{
+      background:rgba(115, 134, 148, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:#182026; }
+    .bp3-button.bp3-outlined:disabled, .bp3-button.bp3-outlined:disabled:hover, .bp3-button.bp3-outlined.bp3-disabled, .bp3-button.bp3-outlined.bp3-disabled:hover{
+      background:none;
+      color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed; }
+      .bp3-button.bp3-outlined:disabled.bp3-active, .bp3-button.bp3-outlined:disabled:hover.bp3-active, .bp3-button.bp3-outlined.bp3-disabled.bp3-active, .bp3-button.bp3-outlined.bp3-disabled:hover.bp3-active{
+        background:rgba(115, 134, 148, 0.3); }
+    .bp3-dark .bp3-button.bp3-outlined{
+      background:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:inherit; }
+      .bp3-dark .bp3-button.bp3-outlined:hover, .bp3-dark .bp3-button.bp3-outlined:active, .bp3-dark .bp3-button.bp3-outlined.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none; }
+      .bp3-dark .bp3-button.bp3-outlined:hover{
+        background:rgba(138, 155, 168, 0.15); }
+      .bp3-dark .bp3-button.bp3-outlined:active, .bp3-dark .bp3-button.bp3-outlined.bp3-active{
+        background:rgba(138, 155, 168, 0.3);
+        color:#f5f8fa; }
+      .bp3-dark .bp3-button.bp3-outlined:disabled, .bp3-dark .bp3-button.bp3-outlined:disabled:hover, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled:hover{
+        background:none;
+        color:rgba(167, 182, 194, 0.6);
+        cursor:not-allowed; }
+        .bp3-dark .bp3-button.bp3-outlined:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined:disabled:hover.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled:hover.bp3-active{
+          background:rgba(138, 155, 168, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-primary{
+      color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:hover, .bp3-button.bp3-outlined.bp3-intent-primary:active, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:hover{
+        background:rgba(19, 124, 189, 0.15);
+        color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:active, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-active{
+        background:rgba(19, 124, 189, 0.3);
+        color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+        background:none;
+        color:rgba(16, 107, 163, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-primary:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled.bp3-active{
+          background:rgba(19, 124, 189, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
+        stroke:#106ba3; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary{
+        color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:hover{
+          background:rgba(19, 124, 189, 0.2);
+          color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-active{
+          background:rgba(19, 124, 189, 0.3);
+          color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+          background:none;
+          color:rgba(72, 175, 240, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled.bp3-active{
+            background:rgba(19, 124, 189, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-success{
+      color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:hover, .bp3-button.bp3-outlined.bp3-intent-success:active, .bp3-button.bp3-outlined.bp3-intent-success.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:hover{
+        background:rgba(15, 153, 96, 0.15);
+        color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:active, .bp3-button.bp3-outlined.bp3-intent-success.bp3-active{
+        background:rgba(15, 153, 96, 0.3);
+        color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+        background:none;
+        color:rgba(13, 128, 80, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-success:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled.bp3-active{
+          background:rgba(15, 153, 96, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
+        stroke:#0d8050; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success{
+        color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:hover{
+          background:rgba(15, 153, 96, 0.2);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-active{
+          background:rgba(15, 153, 96, 0.3);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+          background:none;
+          color:rgba(61, 204, 145, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled.bp3-active{
+            background:rgba(15, 153, 96, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-warning{
+      color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:hover, .bp3-button.bp3-outlined.bp3-intent-warning:active, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:hover{
+        background:rgba(217, 130, 43, 0.15);
+        color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:active, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-active{
+        background:rgba(217, 130, 43, 0.3);
+        color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+        background:none;
+        color:rgba(191, 115, 38, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-warning:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled.bp3-active{
+          background:rgba(217, 130, 43, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
+        stroke:#bf7326; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning{
+        color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:hover{
+          background:rgba(217, 130, 43, 0.2);
+          color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-active{
+          background:rgba(217, 130, 43, 0.3);
+          color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+          background:none;
+          color:rgba(255, 179, 102, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled.bp3-active{
+            background:rgba(217, 130, 43, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-danger{
+      color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:hover, .bp3-button.bp3-outlined.bp3-intent-danger:active, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:hover{
+        background:rgba(219, 55, 55, 0.15);
+        color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:active, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-active{
+        background:rgba(219, 55, 55, 0.3);
+        color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+        background:none;
+        color:rgba(194, 48, 48, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-danger:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled.bp3-active{
+          background:rgba(219, 55, 55, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
+        stroke:#c23030; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger{
+        color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:hover{
+          background:rgba(219, 55, 55, 0.2);
+          color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-active{
+          background:rgba(219, 55, 55, 0.3);
+          color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+          background:none;
+          color:rgba(255, 115, 115, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled.bp3-active{
+            background:rgba(219, 55, 55, 0.3); }
+    .bp3-button.bp3-outlined:disabled, .bp3-button.bp3-outlined.bp3-disabled, .bp3-button.bp3-outlined:disabled:hover, .bp3-button.bp3-outlined.bp3-disabled:hover{
+      border-color:rgba(92, 112, 128, 0.1); }
+    .bp3-dark .bp3-button.bp3-outlined{
+      border-color:rgba(255, 255, 255, 0.4); }
+      .bp3-dark .bp3-button.bp3-outlined:disabled, .bp3-dark .bp3-button.bp3-outlined:disabled:hover, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled:hover{
+        border-color:rgba(255, 255, 255, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-primary{
+      border-color:rgba(16, 107, 163, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+        border-color:rgba(16, 107, 163, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary{
+        border-color:rgba(72, 175, 240, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+          border-color:rgba(72, 175, 240, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-success{
+      border-color:rgba(13, 128, 80, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+        border-color:rgba(13, 128, 80, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success{
+        border-color:rgba(61, 204, 145, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+          border-color:rgba(61, 204, 145, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-warning{
+      border-color:rgba(191, 115, 38, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+        border-color:rgba(191, 115, 38, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning{
+        border-color:rgba(255, 179, 102, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+          border-color:rgba(255, 179, 102, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-danger{
+      border-color:rgba(194, 48, 48, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+        border-color:rgba(194, 48, 48, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger{
+        border-color:rgba(255, 115, 115, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+          border-color:rgba(255, 115, 115, 0.2); }
 
 a.bp3-button{
   text-align:center;
@@ -1773,43 +2048,43 @@ a.bp3-button{
         z-index:8; }
   .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:first-child) .bp3-button,
   .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:first-child){
-    border-top-left-radius:0;
-    border-bottom-left-radius:0; }
+    border-bottom-left-radius:0;
+    border-top-left-radius:0; }
   .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
   .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child){
-    margin-right:-1px;
+    border-bottom-right-radius:0;
     border-top-right-radius:0;
-    border-bottom-right-radius:0; }
+    margin-right:-1px; }
   .bp3-button-group.bp3-minimal .bp3-button{
+    background:none;
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none; }
+            box-shadow:none; }
     .bp3-button-group.bp3-minimal .bp3-button:hover{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background:rgba(167, 182, 194, 0.3);
-      text-decoration:none;
-      color:#182026; }
-    .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
       -webkit-box-shadow:none;
               box-shadow:none;
+      color:#182026;
+      text-decoration:none; }
+    .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
       background:rgba(115, 134, 148, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:#182026; }
     .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
       background:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed; }
       .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
         background:rgba(115, 134, 148, 0.3); }
     .bp3-dark .bp3-button-group.bp3-minimal .bp3-button{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:inherit; }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none; }
+                box-shadow:none; }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover{
         background:rgba(138, 155, 168, 0.15); }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
@@ -1817,16 +2092,16 @@ a.bp3-button{
         color:#f5f8fa; }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
         background:none;
-        cursor:not-allowed;
-        color:rgba(167, 182, 194, 0.6); }
+        color:rgba(167, 182, 194, 0.6);
+        cursor:not-allowed; }
         .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
           background:rgba(138, 155, 168, 0.3); }
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary{
       color:#106ba3; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#106ba3; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover{
         background:rgba(19, 124, 189, 0.15);
@@ -1857,9 +2132,9 @@ a.bp3-button{
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success{
       color:#0d8050; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#0d8050; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover{
         background:rgba(15, 153, 96, 0.15);
@@ -1890,9 +2165,9 @@ a.bp3-button{
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning{
       color:#bf7326; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#bf7326; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover{
         background:rgba(217, 130, 43, 0.15);
@@ -1923,9 +2198,9 @@ a.bp3-button{
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger{
       color:#c23030; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#c23030; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover{
         background:rgba(219, 55, 55, 0.15);
@@ -1972,17 +2247,17 @@ a.bp3-button{
         -ms-flex:1 1 auto;
             flex:1 1 auto; }
   .bp3-button-group.bp3-vertical{
+    -webkit-box-align:stretch;
+        -ms-flex-align:stretch;
+            align-items:stretch;
     -webkit-box-orient:vertical;
     -webkit-box-direction:normal;
         -ms-flex-direction:column;
             flex-direction:column;
-    -webkit-box-align:stretch;
-        -ms-flex-align:stretch;
-            align-items:stretch;
     vertical-align:top; }
     .bp3-button-group.bp3-vertical.bp3-fill{
-      width:unset;
-      height:100%; }
+      height:100%;
+      width:unset; }
     .bp3-button-group.bp3-vertical .bp3-button{
       margin-right:0 !important;
       width:100%; }
@@ -2004,38 +2279,38 @@ a.bp3-button{
   .bp3-dark .bp3-button-group.bp3-vertical > .bp3-button:not(:last-child){
     margin-bottom:1px; }
 .bp3-callout{
-  line-height:1.5;
   font-size:14px;
-  position:relative;
-  border-radius:3px;
+  line-height:1.5;
   background-color:rgba(138, 155, 168, 0.15);
-  width:100%;
-  padding:10px 12px 9px; }
+  border-radius:3px;
+  padding:10px 12px 9px;
+  position:relative;
+  width:100%; }
   .bp3-callout[class*="bp3-icon-"]{
     padding-left:40px; }
     .bp3-callout[class*="bp3-icon-"]::before{
-      line-height:1;
       font-family:"Icons20", sans-serif;
       font-size:20px;
-      font-weight:400;
       font-style:normal;
+      font-weight:400;
+      line-height:1;
       -moz-osx-font-smoothing:grayscale;
       -webkit-font-smoothing:antialiased;
-      position:absolute;
-      top:10px;
+      color:#5c7080;
       left:10px;
-      color:#5c7080; }
+      position:absolute;
+      top:10px; }
   .bp3-callout.bp3-callout-icon{
     padding-left:40px; }
     .bp3-callout.bp3-callout-icon > .bp3-icon:first-child{
-      position:absolute;
-      top:10px;
+      color:#5c7080;
       left:10px;
-      color:#5c7080; }
+      position:absolute;
+      top:10px; }
   .bp3-callout .bp3-heading{
-    margin-top:0;
+    line-height:20px;
     margin-bottom:5px;
-    line-height:20px; }
+    margin-top:0; }
     .bp3-callout .bp3-heading:last-child{
       margin-bottom:0; }
   .bp3-dark .bp3-callout{
@@ -2093,10 +2368,10 @@ a.bp3-button{
   .bp3-running-text .bp3-callout{
     margin:20px 0; }
 .bp3-card{
+  background-color:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-  background-color:#ffffff;
   padding:20px;
   -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
@@ -2104,9 +2379,9 @@ a.bp3-button{
   transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-card.bp3-dark,
   .bp3-dark .bp3-card{
+    background-color:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-    background-color:#30404d; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0); }
 
 .bp3-elevation-0{
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
@@ -2158,9 +2433,9 @@ a.bp3-button{
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
 
 .bp3-card.bp3-interactive:active{
-  opacity:0.9;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+  opacity:0.9;
   -webkit-transition-duration:0;
           transition-duration:0; }
   .bp3-card.bp3-interactive:active.bp3-dark,
@@ -2188,31 +2463,31 @@ a.bp3-button{
   position:fixed; }
 
 .bp3-divider{
-  margin:5px;
+  border-bottom:1px solid rgba(16, 22, 26, 0.15);
   border-right:1px solid rgba(16, 22, 26, 0.15);
-  border-bottom:1px solid rgba(16, 22, 26, 0.15); }
+  margin:5px; }
   .bp3-dark .bp3-divider{
     border-color:rgba(16, 22, 26, 0.4); }
 .bp3-dialog-container{
   opacity:1;
   -webkit-transform:scale(1);
           transform:scale(1);
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   -webkit-box-pack:center;
       -ms-flex-pack:center;
           justify-content:center;
-  width:100%;
   min-height:100%;
   pointer-events:none;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
-          user-select:none; }
+          user-select:none;
+  width:100%; }
   .bp3-dialog-container.bp3-overlay-enter > .bp3-dialog, .bp3-dialog-container.bp3-overlay-appear > .bp3-dialog{
     opacity:0;
     -webkit-transform:scale(0.5);
@@ -2221,16 +2496,16 @@ a.bp3-button{
     opacity:1;
     -webkit-transform:scale(1);
             transform:scale(1);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:opacity, -webkit-transform;
     transition-property:opacity, -webkit-transform;
     transition-property:opacity, transform;
     transition-property:opacity, transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-dialog-container.bp3-overlay-exit > .bp3-dialog{
     opacity:1;
     -webkit-transform:scale(1);
@@ -2239,18 +2514,22 @@ a.bp3-button{
     opacity:0;
     -webkit-transform:scale(0.5);
             transform:scale(0.5);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:opacity, -webkit-transform;
     transition-property:opacity, -webkit-transform;
     transition-property:opacity, transform;
     transition-property:opacity, transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
 
 .bp3-dialog{
+  background:#ebf1f5;
+  border-radius:6px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
@@ -2259,50 +2538,46 @@ a.bp3-button{
       -ms-flex-direction:column;
           flex-direction:column;
   margin:30px 0;
-  border-radius:6px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background:#ebf1f5;
-  width:500px;
   padding-bottom:20px;
   pointer-events:all;
   -webkit-user-select:text;
      -moz-user-select:text;
       -ms-user-select:text;
-          user-select:text; }
+          user-select:text;
+  width:500px; }
   .bp3-dialog:focus{
     outline:0; }
   .bp3-dialog.bp3-dark,
   .bp3-dark .bp3-dialog{
+    background:#293742;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background:#293742;
     color:#f5f8fa; }
 
 .bp3-dialog-header{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  background:#ffffff;
+  border-radius:6px 6px 0 0;
+  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  border-radius:6px 6px 0 0;
-  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-  background:#ffffff;
   min-height:40px;
-  padding-right:5px;
-  padding-left:20px; }
+  padding-left:20px;
+  padding-right:5px; }
   .bp3-dialog-header .bp3-icon-large,
   .bp3-dialog-header .bp3-icon{
+    color:#5c7080;
     -webkit-box-flex:0;
         -ms-flex:0 0 auto;
             flex:0 0 auto;
-    margin-right:10px;
-    color:#5c7080; }
+    margin-right:10px; }
   .bp3-dialog-header .bp3-heading{
     overflow:hidden;
     text-overflow:ellipsis;
@@ -2311,14 +2586,14 @@ a.bp3-button{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
             flex:1 1 auto;
-    margin:0;
-    line-height:inherit; }
+    line-height:inherit;
+    margin:0; }
     .bp3-dialog-header .bp3-heading:last-child{
       margin-right:20px; }
   .bp3-dark .bp3-dialog-header{
+    background:#30404d;
     -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
-            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
-    background:#30404d; }
+            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-dialog-header .bp3-icon-large,
     .bp3-dark .bp3-dialog-header .bp3-icon{
       color:#a7b6c2; }
@@ -2327,8 +2602,8 @@ a.bp3-button{
   -webkit-box-flex:1;
       -ms-flex:1 1 auto;
           flex:1 1 auto;
-  margin:20px;
-  line-height:18px; }
+  line-height:18px;
+  margin:20px; }
 
 .bp3-dialog-footer{
   -webkit-box-flex:0;
@@ -2346,6 +2621,9 @@ a.bp3-button{
   .bp3-dialog-footer-actions .bp3-button{
     margin-left:10px; }
 .bp3-drawer{
+  background:#ffffff;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
@@ -2354,90 +2632,87 @@ a.bp3-button{
       -ms-flex-direction:column;
           flex-direction:column;
   margin:0;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
   padding:0; }
   .bp3-drawer:focus{
     outline:0; }
   .bp3-drawer.bp3-position-top{
-    top:0;
-    right:0;
+    height:50%;
     left:0;
-    height:50%; }
+    right:0;
+    top:0; }
     .bp3-drawer.bp3-position-top.bp3-overlay-enter, .bp3-drawer.bp3-position-top.bp3-overlay-appear{
       -webkit-transform:translateY(-100%);
               transform:translateY(-100%); }
     .bp3-drawer.bp3-position-top.bp3-overlay-enter-active, .bp3-drawer.bp3-position-top.bp3-overlay-appear-active{
       -webkit-transform:translateY(0);
               transform:translateY(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-top.bp3-overlay-exit{
       -webkit-transform:translateY(0);
               transform:translateY(0); }
     .bp3-drawer.bp3-position-top.bp3-overlay-exit-active{
       -webkit-transform:translateY(-100%);
               transform:translateY(-100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-position-bottom{
-    right:0;
     bottom:0;
+    height:50%;
     left:0;
-    height:50%; }
+    right:0; }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-enter, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear{
       -webkit-transform:translateY(100%);
               transform:translateY(100%); }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-enter-active, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear-active{
       -webkit-transform:translateY(0);
               transform:translateY(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-exit{
       -webkit-transform:translateY(0);
               transform:translateY(0); }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-exit-active{
       -webkit-transform:translateY(100%);
               transform:translateY(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-position-left{
-    top:0;
     bottom:0;
     left:0;
+    top:0;
     width:50%; }
     .bp3-drawer.bp3-position-left.bp3-overlay-enter, .bp3-drawer.bp3-position-left.bp3-overlay-appear{
       -webkit-transform:translateX(-100%);
@@ -2445,36 +2720,36 @@ a.bp3-button{
     .bp3-drawer.bp3-position-left.bp3-overlay-enter-active, .bp3-drawer.bp3-position-left.bp3-overlay-appear-active{
       -webkit-transform:translateX(0);
               transform:translateX(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-left.bp3-overlay-exit{
       -webkit-transform:translateX(0);
               transform:translateX(0); }
     .bp3-drawer.bp3-position-left.bp3-overlay-exit-active{
       -webkit-transform:translateX(-100%);
               transform:translateX(-100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-position-right{
-    top:0;
-    right:0;
     bottom:0;
+    right:0;
+    top:0;
     width:50%; }
     .bp3-drawer.bp3-position-right.bp3-overlay-enter, .bp3-drawer.bp3-position-right.bp3-overlay-appear{
       -webkit-transform:translateX(100%);
@@ -2482,37 +2757,37 @@ a.bp3-button{
     .bp3-drawer.bp3-position-right.bp3-overlay-enter-active, .bp3-drawer.bp3-position-right.bp3-overlay-appear-active{
       -webkit-transform:translateX(0);
               transform:translateX(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-right.bp3-overlay-exit{
       -webkit-transform:translateX(0);
               transform:translateX(0); }
     .bp3-drawer.bp3-position-right.bp3-overlay-exit-active{
       -webkit-transform:translateX(100%);
               transform:translateX(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
   .bp3-position-right):not(.bp3-vertical){
-    top:0;
-    right:0;
     bottom:0;
+    right:0;
+    top:0;
     width:50%; }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
@@ -2524,16 +2799,16 @@ a.bp3-button{
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-appear-active{
       -webkit-transform:translateX(0);
               transform:translateX(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit{
       -webkit-transform:translateX(0);
@@ -2542,22 +2817,22 @@ a.bp3-button{
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit-active{
       -webkit-transform:translateX(100%);
               transform:translateX(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
   .bp3-position-right).bp3-vertical{
-    right:0;
     bottom:0;
+    height:50%;
     left:0;
-    height:50%; }
+    right:0; }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right).bp3-vertical.bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right).bp3-vertical.bp3-overlay-appear{
@@ -2568,16 +2843,16 @@ a.bp3-button{
     .bp3-position-right).bp3-vertical.bp3-overlay-appear-active{
       -webkit-transform:translateY(0);
               transform:translateY(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right).bp3-vertical.bp3-overlay-exit{
       -webkit-transform:translateY(0);
@@ -2586,47 +2861,47 @@ a.bp3-button{
     .bp3-position-right).bp3-vertical.bp3-overlay-exit-active{
       -webkit-transform:translateY(100%);
               transform:translateY(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-dark,
   .bp3-dark .bp3-drawer{
+    background:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background:#30404d;
     color:#f5f8fa; }
 
 .bp3-drawer-header{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  border-radius:0;
+  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  position:relative;
-  border-radius:0;
-  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
   min-height:40px;
   padding:5px;
-  padding-left:20px; }
+  padding-left:20px;
+  position:relative; }
   .bp3-drawer-header .bp3-icon-large,
   .bp3-drawer-header .bp3-icon{
+    color:#5c7080;
     -webkit-box-flex:0;
         -ms-flex:0 0 auto;
             flex:0 0 auto;
-    margin-right:10px;
-    color:#5c7080; }
+    margin-right:10px; }
   .bp3-drawer-header .bp3-heading{
     overflow:hidden;
     text-overflow:ellipsis;
@@ -2635,8 +2910,8 @@ a.bp3-button{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
             flex:1 1 auto;
-    margin:0;
-    line-height:inherit; }
+    line-height:inherit;
+    margin:0; }
     .bp3-drawer-header .bp3-heading:last-child{
       margin-right:20px; }
   .bp3-dark .bp3-drawer-header{
@@ -2650,33 +2925,33 @@ a.bp3-button{
   -webkit-box-flex:1;
       -ms-flex:1 1 auto;
           flex:1 1 auto;
-  overflow:auto;
-  line-height:18px; }
+  line-height:18px;
+  overflow:auto; }
 
 .bp3-drawer-footer{
+  -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  position:relative;
-  -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-  padding:10px 20px; }
+  padding:10px 20px;
+  position:relative; }
   .bp3-dark .bp3-drawer-footer{
     -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4); }
 .bp3-editable-text{
-  display:inline-block;
-  position:relative;
   cursor:text;
+  display:inline-block;
   max-width:100%;
+  position:relative;
   vertical-align:top;
   white-space:nowrap; }
   .bp3-editable-text::before{
-    position:absolute;
-    top:-3px;
-    right:-3px;
     bottom:-3px;
     left:-3px;
+    position:absolute;
+    right:-3px;
+    top:-3px;
     border-radius:3px;
     content:"";
     -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
@@ -2687,9 +2962,9 @@ a.bp3-button{
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
   .bp3-editable-text.bp3-editable-text-editing::before{
+    background-color:#ffffff;
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-    background-color:#ffffff; }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
   .bp3-editable-text.bp3-disabled::before{
     -webkit-box-shadow:none;
             box-shadow:none; }
@@ -2733,9 +3008,9 @@ a.bp3-button{
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15); }
   .bp3-dark .bp3-editable-text.bp3-editable-text-editing::before{
+    background-color:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background-color:rgba(16, 22, 26, 0.3); }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-editable-text.bp3-disabled::before{
     -webkit-box-shadow:none;
             box-shadow:none; }
@@ -2774,40 +3049,40 @@ a.bp3-button{
 
 .bp3-editable-text-input,
 .bp3-editable-text-content{
-  display:inherit;
-  position:relative;
-  min-width:inherit;
-  max-width:inherit;
-  vertical-align:top;
-  text-transform:inherit;
-  letter-spacing:inherit;
   color:inherit;
+  display:inherit;
   font:inherit;
-  resize:none; }
+  letter-spacing:inherit;
+  max-width:inherit;
+  min-width:inherit;
+  position:relative;
+  resize:none;
+  text-transform:inherit;
+  vertical-align:top; }
 
 .bp3-editable-text-input{
+  background:none;
   border:none;
   -webkit-box-shadow:none;
           box-shadow:none;
-  background:none;
-  width:100%;
   padding:0;
-  white-space:pre-wrap; }
+  white-space:pre-wrap;
+  width:100%; }
   .bp3-editable-text-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input:focus{
     outline:none; }
   .bp3-editable-text-input::-ms-clear{
@@ -2819,8 +3094,8 @@ a.bp3-button{
   text-overflow:ellipsis;
   white-space:pre; }
   .bp3-editable-text-editing > .bp3-editable-text-content{
-    position:absolute;
     left:0;
+    position:absolute;
     visibility:hidden; }
   .bp3-editable-text-placeholder > .bp3-editable-text-content{
     color:rgba(92, 112, 128, 0.6); }
@@ -2833,6 +3108,12 @@ a.bp3-button{
     overflow:auto;
     white-space:pre-wrap;
     word-wrap:break-word; }
+.bp3-divider{
+  border-bottom:1px solid rgba(16, 22, 26, 0.15);
+  border-right:1px solid rgba(16, 22, 26, 0.15);
+  margin:5px; }
+  .bp3-dark .bp3-divider{
+    border-color:rgba(16, 22, 26, 0.4); }
 .bp3-control-group{
   -webkit-transform:translateZ(0);
           transform:translateZ(0);
@@ -2864,11 +3145,11 @@ a.bp3-button{
   .bp3-control-group .bp3-select{
     position:relative; }
   .bp3-control-group .bp3-input{
-    z-index:2;
-    border-radius:inherit; }
+    border-radius:inherit;
+    z-index:2; }
     .bp3-control-group .bp3-input:focus{
-      z-index:14;
-      border-radius:3px; }
+      border-radius:3px;
+      z-index:14; }
     .bp3-control-group .bp3-input[class*="bp3-intent"]{
       z-index:13; }
       .bp3-control-group .bp3-input[class*="bp3-intent"]:focus{
@@ -2884,8 +3165,8 @@ a.bp3-button{
   .bp3-control-group .bp3-select select{
     -webkit-transform:translateZ(0);
             transform:translateZ(0);
-    z-index:4;
-    border-radius:inherit; }
+    border-radius:inherit;
+    z-index:4; }
     .bp3-control-group .bp3-button:focus,
     .bp3-control-group .bp3-html-select select:focus,
     .bp3-control-group .bp3-select select:focus{
@@ -2939,9 +3220,13 @@ a.bp3-button{
   .bp3-control-group .bp3-select > .bp3-icon,
   .bp3-control-group .bp3-html-select > .bp3-icon{
     z-index:17; }
-  .bp3-control-group:not(.bp3-vertical) > *{
+  .bp3-control-group .bp3-select:focus-within{
+    z-index:5; }
+  .bp3-control-group:not(.bp3-vertical) > *:not(.bp3-divider){
     margin-right:-1px; }
-  .bp3-dark .bp3-control-group:not(.bp3-vertical) > *{
+  .bp3-control-group:not(.bp3-vertical) > .bp3-divider:not(:first-child){
+    margin-left:6px; }
+  .bp3-dark .bp3-control-group:not(.bp3-vertical) > *:not(.bp3-divider){
     margin-right:0; }
   .bp3-dark .bp3-control-group:not(.bp3-vertical) > .bp3-button + .bp3-button{
     margin-left:1px; }
@@ -2951,13 +3236,18 @@ a.bp3-button{
   .bp3-control-group > :first-child{
     border-radius:3px 0 0 3px; }
   .bp3-control-group > :last-child{
-    margin-right:0;
-    border-radius:0 3px 3px 0; }
+    border-radius:0 3px 3px 0;
+    margin-right:0; }
   .bp3-control-group > :only-child{
-    margin-right:0;
-    border-radius:3px; }
+    border-radius:3px;
+    margin-right:0; }
   .bp3-control-group .bp3-input-group .bp3-button{
     border-radius:3px; }
+  .bp3-control-group .bp3-numeric-input:not(:first-child) .bp3-input-group{
+    border-bottom-left-radius:0;
+    border-top-left-radius:0; }
+  .bp3-control-group.bp3-fill{
+    width:100%; }
   .bp3-control-group > .bp3-fill{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
@@ -2974,50 +3264,50 @@ a.bp3-button{
     .bp3-control-group.bp3-vertical > *{
       margin-top:-1px; }
     .bp3-control-group.bp3-vertical > :first-child{
-      margin-top:0;
-      border-radius:3px 3px 0 0; }
+      border-radius:3px 3px 0 0;
+      margin-top:0; }
     .bp3-control-group.bp3-vertical > :last-child{
       border-radius:0 0 3px 3px; }
 .bp3-control{
-  display:block;
-  position:relative;
-  margin-bottom:10px;
   cursor:pointer;
+  display:block;
+  margin-bottom:10px;
+  position:relative;
   text-transform:none; }
   .bp3-control input:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#137cbd;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-  .bp3-control:hover input:checked ~ .bp3-control-indicator{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#106ba3; }
+    color:#ffffff; }
+  .bp3-control:hover input:checked ~ .bp3-control-indicator{
+    background-color:#106ba3;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
   .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
+    background:#0e5a8a;
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#0e5a8a; }
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-control input:disabled:checked ~ .bp3-control-indicator{
+    background:rgba(19, 124, 189, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(19, 124, 189, 0.5); }
+            box-shadow:none; }
   .bp3-dark .bp3-control input:checked ~ .bp3-control-indicator{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control:hover input:checked ~ .bp3-control-indicator{
+    background-color:#106ba3;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#106ba3; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
+    background-color:#0e5a8a;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#0e5a8a; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-dark .bp3-control input:disabled:checked ~ .bp3-control-indicator{
+    background:rgba(14, 90, 138, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(14, 90, 138, 0.5); }
+            box-shadow:none; }
   .bp3-control:not(.bp3-align-right){
     padding-left:26px; }
     .bp3-control:not(.bp3-align-right) .bp3-control-indicator{
@@ -3027,53 +3317,53 @@ a.bp3-button{
     .bp3-control.bp3-align-right .bp3-control-indicator{
       margin-right:-26px; }
   .bp3-control.bp3-disabled{
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
   .bp3-control.bp3-inline{
     display:inline-block;
     margin-right:20px; }
   .bp3-control input{
-    position:absolute;
-    top:0;
     left:0;
     opacity:0;
+    position:absolute;
+    top:0;
     z-index:-1; }
   .bp3-control .bp3-control-indicator{
-    display:inline-block;
-    position:relative;
-    margin-top:-3px;
-    margin-right:10px;
-    border:none;
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
     background-color:#f5f8fa;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    border:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     cursor:pointer;
-    width:1em;
-    height:1em;
-    vertical-align:middle;
+    display:inline-block;
     font-size:16px;
+    height:1em;
+    margin-right:10px;
+    margin-top:-3px;
+    position:relative;
     -webkit-user-select:none;
        -moz-user-select:none;
         -ms-user-select:none;
-            user-select:none; }
+            user-select:none;
+    vertical-align:middle;
+    width:1em; }
     .bp3-control .bp3-control-indicator::before{
+      content:"";
       display:block;
-      width:1em;
       height:1em;
-      content:""; }
+      width:1em; }
   .bp3-control:hover .bp3-control-indicator{
     background-color:#ebf1f5; }
   .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
+    background:#d8e1e8;
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#d8e1e8; }
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-control input:disabled ~ .bp3-control-indicator{
+    background:rgba(206, 217, 224, 0.5);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
     cursor:not-allowed; }
   .bp3-control input:focus ~ .bp3-control-indicator{
     outline:rgba(19, 124, 189, 0.6) auto 2px;
@@ -3081,8 +3371,8 @@ a.bp3-button{
     -moz-outline-radius:6px; }
   .bp3-control.bp3-align-right .bp3-control-indicator{
     float:right;
-    margin-top:1px;
-    margin-left:10px; }
+    margin-left:10px;
+    margin-top:1px; }
   .bp3-control.bp3-large{
     font-size:16px; }
     .bp3-control.bp3-large:not(.bp3-align-right){
@@ -3098,43 +3388,43 @@ a.bp3-button{
     .bp3-control.bp3-large.bp3-align-right .bp3-control-indicator{
       margin-top:0; }
   .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#137cbd;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-  .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#106ba3; }
+    color:#ffffff; }
+  .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
+    background-color:#106ba3;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
   .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
+    background:#0e5a8a;
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#0e5a8a; }
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
+    background:rgba(19, 124, 189, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(19, 124, 189, 0.5); }
+            box-shadow:none; }
   .bp3-dark .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
+    background-color:#106ba3;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#106ba3; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
+    background-color:#0e5a8a;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#0e5a8a; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
+    background:rgba(14, 90, 138, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(14, 90, 138, 0.5); }
+            box-shadow:none; }
   .bp3-control.bp3-checkbox .bp3-control-indicator{
     border-radius:3px; }
   .bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator::before{
-    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='white'/%3e%3c/svg%3e"); }
+    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='white'/%3e%3c/svg%3e"); }
   .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator::before{
     background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M11 7H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z' fill='white'/%3e%3c/svg%3e"); }
   .bp3-control.bp3-radio .bp3-control-indicator{
@@ -3178,22 +3468,22 @@ a.bp3-button{
     border-radius:1.75em;
     -webkit-box-shadow:none !important;
             box-shadow:none !important;
-    width:auto;
     min-width:1.75em;
     -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    width:auto; }
     .bp3-control.bp3-switch .bp3-control-indicator::before{
-      position:absolute;
-      left:0;
-      margin:2px;
+      background:#ffffff;
       border-radius:50%;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-      background:#ffffff;
-      width:calc(1em - 4px);
       height:calc(1em - 4px);
+      left:0;
+      margin:2px;
+      position:absolute;
       -webkit-transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-      transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+      transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+      width:calc(1em - 4px); }
   .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
     left:calc(100% - 1em); }
   .bp3-control.bp3-switch.bp3-large:not(.bp3-align-right){
@@ -3225,96 +3515,96 @@ a.bp3-button{
     .bp3-dark .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator::before{
       background:rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-switch .bp3-control-indicator::before{
+    background:#394b59;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:#394b59; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-control.bp3-switch .bp3-switch-inner-text{
-    text-align:center;
-    font-size:0.7em; }
+    font-size:0.7em;
+    text-align:center; }
   .bp3-control.bp3-switch .bp3-control-indicator-child:first-child{
-    visibility:hidden;
-    margin-right:1.2em;
+    line-height:0;
     margin-left:0.5em;
-    line-height:0; }
+    margin-right:1.2em;
+    visibility:hidden; }
   .bp3-control.bp3-switch .bp3-control-indicator-child:last-child{
-    visibility:visible;
-    margin-right:0.5em;
+    line-height:1em;
     margin-left:1.2em;
-    line-height:1em; }
+    margin-right:0.5em;
+    visibility:visible; }
   .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:first-child{
-    visibility:visible;
-    line-height:1em; }
+    line-height:1em;
+    visibility:visible; }
   .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:last-child{
-    visibility:hidden;
-    line-height:0; }
+    line-height:0;
+    visibility:hidden; }
   .bp3-dark .bp3-control{
     color:#f5f8fa; }
     .bp3-dark .bp3-control.bp3-disabled{
       color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-control .bp3-control-indicator{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
       background-color:#394b59;
       background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
-      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0)); }
+      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-control:hover .bp3-control-indicator{
       background-color:#30404d; }
     .bp3-dark .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
+      background:#202b33;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background:#202b33; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-control input:disabled ~ .bp3-control-indicator{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       cursor:not-allowed; }
     .bp3-dark .bp3-control.bp3-checkbox input:disabled:checked ~ .bp3-control-indicator, .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
       color:rgba(167, 182, 194, 0.6); }
 .bp3-file-input{
-  display:inline-block;
-  position:relative;
   cursor:pointer;
-  height:30px; }
+  display:inline-block;
+  height:30px;
+  position:relative; }
   .bp3-file-input input{
-    opacity:0;
     margin:0;
-    min-width:200px; }
+    min-width:200px;
+    opacity:0; }
     .bp3-file-input input:disabled + .bp3-file-upload-input,
     .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
+      background:rgba(206, 217, 224, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(206, 217, 224, 0.5);
-      cursor:not-allowed;
       color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed;
       resize:none; }
       .bp3-file-input input:disabled + .bp3-file-upload-input::after,
       .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
-        outline:none;
-        -webkit-box-shadow:none;
-                box-shadow:none;
         background-color:rgba(206, 217, 224, 0.5);
         background-image:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:rgba(92, 112, 128, 0.6);
         cursor:not-allowed;
-        color:rgba(92, 112, 128, 0.6); }
+        outline:none; }
         .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active:hover,
         .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active,
         .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active:hover{
           background:rgba(206, 217, 224, 0.7); }
       .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input, .bp3-dark
       .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
+        background:rgba(57, 75, 89, 0.5);
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:rgba(57, 75, 89, 0.5);
         color:rgba(167, 182, 194, 0.6); }
         .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after, .bp3-dark
         .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
-          -webkit-box-shadow:none;
-                  box-shadow:none;
           background-color:rgba(57, 75, 89, 0.5);
           background-image:none;
+          -webkit-box-shadow:none;
+                  box-shadow:none;
           color:rgba(167, 182, 194, 0.6); }
           .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-dark
           .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active{
@@ -3332,55 +3622,55 @@ a.bp3-button{
     content:attr(bp3-button-text); }
 
 .bp3-file-upload-input{
-  outline:none;
+  -webkit-appearance:none;
+     -moz-appearance:none;
+          appearance:none;
+  background:#ffffff;
   border:none;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  height:30px;
-  padding:0 10px;
-  vertical-align:middle;
-  line-height:30px;
   color:#182026;
   font-size:14px;
   font-weight:400;
+  height:30px;
+  line-height:30px;
+  outline:none;
+  padding:0 10px;
   -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  -webkit-appearance:none;
-     -moz-appearance:none;
-          appearance:none;
+  vertical-align:middle;
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
   word-wrap:normal;
-  position:absolute;
-  top:0;
-  right:0;
+  color:rgba(92, 112, 128, 0.6);
   left:0;
   padding-right:80px;
-  color:rgba(92, 112, 128, 0.6);
+  position:absolute;
+  right:0;
+  top:0;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
           user-select:none; }
   .bp3-file-upload-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input:focus, .bp3-file-upload-input.bp3-active{
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
@@ -3393,81 +3683,81 @@ a.bp3-button{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
   .bp3-file-upload-input:disabled, .bp3-file-upload-input.bp3-disabled{
+    background:rgba(206, 217, 224, 0.5);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
-    cursor:not-allowed;
     color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed;
     resize:none; }
   .bp3-file-upload-input::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-color:#f5f8fa;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     color:#182026;
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     overflow:hidden;
     text-overflow:ellipsis;
     white-space:nowrap;
     word-wrap:normal;
-    position:absolute;
-    top:0;
-    right:0;
-    margin:3px;
     border-radius:3px;
-    width:70px;
-    text-align:center;
+    content:"Browse";
     line-height:24px;
-    content:"Browse"; }
+    margin:3px;
+    position:absolute;
+    right:0;
+    text-align:center;
+    top:0;
+    width:70px; }
     .bp3-file-upload-input::after:hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
       background-clip:padding-box;
-      background-color:#ebf1f5; }
+      background-color:#ebf1f5;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
     .bp3-file-upload-input::after:active, .bp3-file-upload-input::after.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#d8e1e8;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-file-upload-input::after:disabled, .bp3-file-upload-input::after.bp3-disabled{
-      outline:none;
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(206, 217, 224, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:rgba(92, 112, 128, 0.6);
       cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      outline:none; }
       .bp3-file-upload-input::after:disabled.bp3-active, .bp3-file-upload-input::after:disabled.bp3-active:hover, .bp3-file-upload-input::after.bp3-disabled.bp3-active, .bp3-file-upload-input::after.bp3-disabled.bp3-active:hover{
         background:rgba(206, 217, 224, 0.7); }
   .bp3-file-upload-input:hover::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
-    background-color:#ebf1f5; }
+    background-color:#ebf1f5;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
   .bp3-file-upload-input:active::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-large .bp3-file-upload-input{
+    font-size:16px;
     height:40px;
     line-height:40px;
-    font-size:16px;
     padding-right:95px; }
     .bp3-large .bp3-file-upload-input[type="search"], .bp3-large .bp3-file-upload-input.bp3-round{
       padding:0 15px; }
     .bp3-large .bp3-file-upload-input::after{
-      min-width:30px;
       min-height:30px;
+      min-width:30px;
+      line-height:30px;
       margin:5px;
-      width:85px;
-      line-height:30px; }
+      width:85px; }
   .bp3-dark .bp3-file-upload-input{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa;
     color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-file-upload-input::-webkit-input-placeholder{
@@ -3487,33 +3777,33 @@ a.bp3-button{
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
               box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-file-upload-input:disabled, .bp3-dark .bp3-file-upload-input.bp3-disabled{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-file-upload-input::after{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
       background-color:#394b59;
       background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
       background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
       color:#f5f8fa; }
       .bp3-dark .bp3-file-upload-input::after:hover, .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
         color:#f5f8fa; }
       .bp3-dark .bp3-file-upload-input::after:hover{
+        background-color:#30404d;
         -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-        background-color:#30404d; }
+                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
       .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
-        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
         background-color:#202b33;
-        background-image:none; }
+        background-image:none;
+        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
       .bp3-dark .bp3-file-upload-input::after:disabled, .bp3-dark .bp3-file-upload-input::after.bp3-disabled{
-        -webkit-box-shadow:none;
-                box-shadow:none;
         background-color:rgba(57, 75, 89, 0.5);
         background-image:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
         color:rgba(167, 182, 194, 0.6); }
         .bp3-dark .bp3-file-upload-input::after:disabled.bp3-active, .bp3-dark .bp3-file-upload-input::after.bp3-disabled.bp3-active{
           background:rgba(57, 75, 89, 0.7); }
@@ -3521,15 +3811,14 @@ a.bp3-button{
         background:rgba(16, 22, 26, 0.5);
         stroke:#8a9ba8; }
     .bp3-dark .bp3-file-upload-input:hover::after{
+      background-color:#30404d;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-file-upload-input:active::after{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#202b33;
-      background-image:none; }
-
+      background-image:none;
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
 .bp3-file-upload-input::after{
   -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
           box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
@@ -3547,9 +3836,9 @@ a.bp3-button{
   .bp3-form-group .bp3-control{
     margin-top:7px; }
   .bp3-form-group .bp3-form-helper-text{
-    margin-top:5px;
     color:#5c7080;
-    font-size:12px; }
+    font-size:12px;
+    margin-top:5px; }
   .bp3-form-group.bp3-intent-primary .bp3-form-helper-text{
     color:#106ba3; }
   .bp3-form-group.bp3-intent-success .bp3-form-helper-text{
@@ -3559,19 +3848,19 @@ a.bp3-button{
   .bp3-form-group.bp3-intent-danger .bp3-form-helper-text{
     color:#c23030; }
   .bp3-form-group.bp3-inline{
+    -webkit-box-align:start;
+        -ms-flex-align:start;
+            align-items:flex-start;
     -webkit-box-orient:horizontal;
     -webkit-box-direction:normal;
         -ms-flex-direction:row;
-            flex-direction:row;
-    -webkit-box-align:start;
-        -ms-flex-align:start;
-            align-items:flex-start; }
+            flex-direction:row; }
     .bp3-form-group.bp3-inline.bp3-large label.bp3-label{
-      margin:0 10px 0 0;
-      line-height:40px; }
+      line-height:40px;
+      margin:0 10px 0 0; }
     .bp3-form-group.bp3-inline label.bp3-label{
-      margin:0 10px 0 0;
-      line-height:30px; }
+      line-height:30px;
+      margin:0 10px 0 0; }
   .bp3-form-group.bp3-disabled .bp3-label,
   .bp3-form-group.bp3-disabled .bp3-text-muted,
   .bp3-form-group.bp3-disabled .bp3-form-helper-text{
@@ -3601,36 +3890,44 @@ a.bp3-button{
     .bp3-input-group .bp3-input:not(:last-child){
       padding-right:30px; }
   .bp3-input-group .bp3-input-action,
+  .bp3-input-group > .bp3-input-left-container,
   .bp3-input-group > .bp3-button,
   .bp3-input-group > .bp3-icon{
     position:absolute;
     top:0; }
     .bp3-input-group .bp3-input-action:first-child,
+    .bp3-input-group > .bp3-input-left-container:first-child,
     .bp3-input-group > .bp3-button:first-child,
     .bp3-input-group > .bp3-icon:first-child{
       left:0; }
     .bp3-input-group .bp3-input-action:last-child,
+    .bp3-input-group > .bp3-input-left-container:last-child,
     .bp3-input-group > .bp3-button:last-child,
     .bp3-input-group > .bp3-icon:last-child{
       right:0; }
   .bp3-input-group .bp3-button{
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     margin:3px;
     padding:0 7px; }
     .bp3-input-group .bp3-button:empty{
       padding:0; }
+  .bp3-input-group > .bp3-input-left-container,
   .bp3-input-group > .bp3-icon{
-    z-index:1;
+    z-index:1; }
+  .bp3-input-group > .bp3-input-left-container > .bp3-icon,
+  .bp3-input-group > .bp3-icon{
     color:#5c7080; }
+    .bp3-input-group > .bp3-input-left-container > .bp3-icon:empty,
     .bp3-input-group > .bp3-icon:empty{
-      line-height:1;
       font-family:"Icons16", sans-serif;
       font-size:16px;
-      font-weight:400;
       font-style:normal;
+      font-weight:400;
+      line-height:1;
       -moz-osx-font-smoothing:grayscale;
       -webkit-font-smoothing:antialiased; }
+  .bp3-input-group > .bp3-input-left-container > .bp3-icon,
   .bp3-input-group > .bp3-icon,
   .bp3-input-group .bp3-input-action > .bp3-spinner{
     margin:7px; }
@@ -3660,16 +3957,17 @@ a.bp3-button{
     .bp3-input-group.bp3-disabled .bp3-icon{
       color:rgba(92, 112, 128, 0.6); }
   .bp3-input-group.bp3-large .bp3-button{
-    min-width:30px;
     min-height:30px;
+    min-width:30px;
     margin:5px; }
+  .bp3-input-group.bp3-large > .bp3-input-left-container > .bp3-icon,
   .bp3-input-group.bp3-large > .bp3-icon,
   .bp3-input-group.bp3-large .bp3-input-action > .bp3-spinner{
     margin:12px; }
   .bp3-input-group.bp3-large .bp3-input{
+    font-size:16px;
     height:40px;
-    line-height:40px;
-    font-size:16px; }
+    line-height:40px; }
     .bp3-input-group.bp3-large .bp3-input[type="search"], .bp3-input-group.bp3-large .bp3-input.bp3-round{
       padding:0 15px; }
     .bp3-input-group.bp3-large .bp3-input:not(:first-child){
@@ -3677,22 +3975,23 @@ a.bp3-button{
     .bp3-input-group.bp3-large .bp3-input:not(:last-child){
       padding-right:40px; }
   .bp3-input-group.bp3-small .bp3-button{
-    min-width:20px;
     min-height:20px;
+    min-width:20px;
     margin:2px; }
   .bp3-input-group.bp3-small .bp3-tag{
-    min-width:20px;
     min-height:20px;
+    min-width:20px;
     margin:2px; }
+  .bp3-input-group.bp3-small > .bp3-input-left-container > .bp3-icon,
   .bp3-input-group.bp3-small > .bp3-icon,
   .bp3-input-group.bp3-small .bp3-input-action > .bp3-spinner{
     margin:4px; }
   .bp3-input-group.bp3-small .bp3-input{
+    font-size:12px;
     height:24px;
-    padding-right:8px;
-    padding-left:8px;
     line-height:24px;
-    font-size:12px; }
+    padding-left:8px;
+    padding-right:8px; }
     .bp3-input-group.bp3-small .bp3-input[type="search"], .bp3-input-group.bp3-small .bp3-input.bp3-round{
       padding:0 12px; }
     .bp3-input-group.bp3-small .bp3-input:not(:first-child){
@@ -3777,41 +4076,41 @@ a.bp3-button{
     .bp3-dark .bp3-input-group.bp3-intent-danger > .bp3-icon{
       color:#ff7373; }
 .bp3-input{
-  outline:none;
+  -webkit-appearance:none;
+     -moz-appearance:none;
+          appearance:none;
+  background:#ffffff;
   border:none;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  height:30px;
-  padding:0 10px;
-  vertical-align:middle;
-  line-height:30px;
   color:#182026;
   font-size:14px;
   font-weight:400;
+  height:30px;
+  line-height:30px;
+  outline:none;
+  padding:0 10px;
   -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  -webkit-appearance:none;
-     -moz-appearance:none;
-          appearance:none; }
+  vertical-align:middle; }
   .bp3-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input:focus, .bp3-input.bp3-active{
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
@@ -3824,24 +4123,24 @@ a.bp3-button{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
   .bp3-input:disabled, .bp3-input.bp3-disabled{
+    background:rgba(206, 217, 224, 0.5);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
-    cursor:not-allowed;
     color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed;
     resize:none; }
   .bp3-input.bp3-large{
+    font-size:16px;
     height:40px;
-    line-height:40px;
-    font-size:16px; }
+    line-height:40px; }
     .bp3-input.bp3-large[type="search"], .bp3-input.bp3-large.bp3-round{
       padding:0 15px; }
   .bp3-input.bp3-small{
+    font-size:12px;
     height:24px;
-    padding-right:8px;
-    padding-left:8px;
     line-height:24px;
-    font-size:12px; }
+    padding-left:8px;
+    padding-right:8px; }
     .bp3-input.bp3-small[type="search"], .bp3-input.bp3-small.bp3-round{
       padding:0 12px; }
   .bp3-input.bp3-fill{
@@ -3850,9 +4149,9 @@ a.bp3-button{
             flex:1 1 auto;
     width:100%; }
   .bp3-dark .bp3-input{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa; }
     .bp3-dark .bp3-input::-webkit-input-placeholder{
       color:rgba(167, 182, 194, 0.6); }
@@ -3871,9 +4170,9 @@ a.bp3-button{
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
               box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-input:disabled, .bp3-dark .bp3-input.bp3-disabled{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       color:rgba(167, 182, 194, 0.6); }
   .bp3-input.bp3-intent-primary{
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
@@ -3982,9 +4281,9 @@ textarea.bp3-input{
   textarea.bp3-input.bp3-small{
     padding:8px; }
   .bp3-dark textarea.bp3-input{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa; }
     .bp3-dark textarea.bp3-input::-webkit-input-placeholder{
       color:rgba(167, 182, 194, 0.6); }
@@ -4003,14 +4302,14 @@ textarea.bp3-input{
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
               box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark textarea.bp3-input:disabled, .bp3-dark textarea.bp3-input.bp3-disabled{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       color:rgba(167, 182, 194, 0.6); }
 label.bp3-label{
   display:block;
-  margin-top:0;
-  margin-bottom:15px; }
+  margin-bottom:15px;
+  margin-top:0; }
   label.bp3-label .bp3-html-select,
   label.bp3-label .bp3-input,
   label.bp3-label .bp3-select,
@@ -4023,9 +4322,9 @@ label.bp3-label{
     margin-top:5px; }
   label.bp3-label .bp3-select select,
   label.bp3-label .bp3-html-select select{
-    width:100%;
+    font-weight:400;
     vertical-align:top;
-    font-weight:400; }
+    width:100%; }
   label.bp3-label.bp3-disabled,
   label.bp3-label.bp3-disabled .bp3-text-muted{
     color:rgba(92, 112, 128, 0.6); }
@@ -4056,9 +4355,9 @@ label.bp3-label{
   -webkit-box-flex:1;
       -ms-flex:1 1 14px;
           flex:1 1 14px;
-  width:30px;
   min-height:0;
-  padding:0; }
+  padding:0;
+  width:30px; }
   .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:first-child{
     border-radius:0 3px 0 0; }
   .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:last-child{
@@ -4087,28 +4386,28 @@ form{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
   border:none;
   border-radius:3px;
   cursor:pointer;
-  padding:5px 10px;
-  vertical-align:middle;
-  text-align:left;
   font-size:14px;
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  padding:5px 10px;
+  text-align:left;
+  vertical-align:middle;
   background-color:#f5f8fa;
   background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
   background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
   color:#182026;
+  -moz-appearance:none;
+  -webkit-appearance:none;
   border-radius:3px;
-  width:100%;
   height:30px;
   padding:0 25px 0 10px;
-  -moz-appearance:none;
-  -webkit-appearance:none; }
+  width:100%; }
   .bp3-html-select select > *, .bp3-select select > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -4131,27 +4430,27 @@ form{
     margin-right:0; }
   .bp3-html-select select:hover,
   .bp3-select select:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
-    background-color:#ebf1f5; }
+    background-color:#ebf1f5;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
   .bp3-html-select select:active,
   .bp3-select select:active, .bp3-html-select select.bp3-active,
   .bp3-select select.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-html-select select:disabled,
   .bp3-select select:disabled, .bp3-html-select select.bp3-disabled,
   .bp3-select select.bp3-disabled{
-    outline:none;
-    -webkit-box-shadow:none;
-            box-shadow:none;
     background-color:rgba(206, 217, 224, 0.5);
     background-image:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    color:rgba(92, 112, 128, 0.6);
     cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    outline:none; }
     .bp3-html-select select:disabled.bp3-active,
     .bp3-select select:disabled.bp3-active, .bp3-html-select select:disabled.bp3-active:hover,
     .bp3-select select:disabled.bp3-active:hover, .bp3-html-select select.bp3-disabled.bp3-active,
@@ -4161,22 +4460,22 @@ form{
 
 .bp3-html-select.bp3-minimal select,
 .bp3-select.bp3-minimal select{
+  background:none;
   -webkit-box-shadow:none;
-          box-shadow:none;
-  background:none; }
+          box-shadow:none; }
   .bp3-html-select.bp3-minimal select:hover,
   .bp3-select.bp3-minimal select:hover{
+    background:rgba(167, 182, 194, 0.3);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(167, 182, 194, 0.3);
-    text-decoration:none;
-    color:#182026; }
+    color:#182026;
+    text-decoration:none; }
   .bp3-html-select.bp3-minimal select:active,
   .bp3-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal select.bp3-active,
   .bp3-select.bp3-minimal select.bp3-active{
+    background:rgba(115, 134, 148, 0.3);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(115, 134, 148, 0.3);
     color:#182026; }
   .bp3-html-select.bp3-minimal select:disabled,
   .bp3-select.bp3-minimal select:disabled, .bp3-html-select.bp3-minimal select:disabled:hover,
@@ -4184,8 +4483,8 @@ form{
   .bp3-select.bp3-minimal select.bp3-disabled, .bp3-html-select.bp3-minimal select.bp3-disabled:hover,
   .bp3-select.bp3-minimal select.bp3-disabled:hover{
     background:none;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
     .bp3-html-select.bp3-minimal select:disabled.bp3-active,
     .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active,
     .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active,
@@ -4194,17 +4493,17 @@ form{
       background:rgba(115, 134, 148, 0.3); }
   .bp3-dark .bp3-html-select.bp3-minimal select, .bp3-html-select.bp3-minimal .bp3-dark select,
   .bp3-dark .bp3-select.bp3-minimal select, .bp3-select.bp3-minimal .bp3-dark select{
+    background:none;
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:none;
     color:inherit; }
     .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
     .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover, .bp3-dark .bp3-html-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal .bp3-dark select:active,
     .bp3-dark .bp3-select.bp3-minimal select:active, .bp3-select.bp3-minimal .bp3-dark select:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
     .bp3-dark .bp3-select.bp3-minimal select.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none; }
+              box-shadow:none; }
     .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
     .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover{
       background:rgba(138, 155, 168, 0.15); }
@@ -4219,8 +4518,8 @@ form{
     .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover,
     .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover{
       background:none;
-      cursor:not-allowed;
-      color:rgba(167, 182, 194, 0.6); }
+      color:rgba(167, 182, 194, 0.6);
+      cursor:not-allowed; }
       .bp3-dark .bp3-html-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled.bp3-active,
       .bp3-dark .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active,
       .bp3-dark .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active,
@@ -4234,9 +4533,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
     .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#106ba3; }
     .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
     .bp3-select.bp3-minimal select.bp3-intent-primary:hover{
@@ -4286,9 +4585,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-success:hover, .bp3-html-select.bp3-minimal select.bp3-intent-success:active,
     .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#0d8050; }
     .bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
     .bp3-select.bp3-minimal select.bp3-intent-success:hover{
@@ -4338,9 +4637,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
     .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#bf7326; }
     .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
     .bp3-select.bp3-minimal select.bp3-intent-warning:hover{
@@ -4390,9 +4689,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
     .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#c23030; }
     .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
     .bp3-select.bp3-minimal select.bp3-intent-danger:hover{
@@ -4438,33 +4737,33 @@ form{
 
 .bp3-html-select.bp3-large select,
 .bp3-select.bp3-large select{
+  font-size:16px;
   height:40px;
-  padding-right:35px;
-  font-size:16px; }
+  padding-right:35px; }
 
 .bp3-dark .bp3-html-select select, .bp3-dark .bp3-select select{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
   background-color:#394b59;
   background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
   background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
   color:#f5f8fa; }
   .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover, .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
     color:#f5f8fa; }
   .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover{
+    background-color:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#30404d; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#202b33;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-dark .bp3-html-select select:disabled, .bp3-dark .bp3-select select:disabled, .bp3-dark .bp3-html-select select.bp3-disabled, .bp3-dark .bp3-select select.bp3-disabled{
-    -webkit-box-shadow:none;
-            box-shadow:none;
     background-color:rgba(57, 75, 89, 0.5);
     background-image:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
     color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-html-select select:disabled.bp3-active, .bp3-dark .bp3-select select:disabled.bp3-active, .bp3-dark .bp3-html-select select.bp3-disabled.bp3-active, .bp3-dark .bp3-select select.bp3-disabled.bp3-active{
       background:rgba(57, 75, 89, 0.7); }
@@ -4474,28 +4773,28 @@ form{
 
 .bp3-html-select select:disabled,
 .bp3-select select:disabled{
+  background-color:rgba(206, 217, 224, 0.5);
   -webkit-box-shadow:none;
           box-shadow:none;
-  background-color:rgba(206, 217, 224, 0.5);
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-html-select .bp3-icon,
 .bp3-select .bp3-icon, .bp3-select::after{
-  position:absolute;
-  top:7px;
-  right:7px;
   color:#5c7080;
-  pointer-events:none; }
+  pointer-events:none;
+  position:absolute;
+  right:7px;
+  top:7px; }
   .bp3-html-select .bp3-disabled.bp3-icon,
   .bp3-select .bp3-disabled.bp3-icon, .bp3-disabled.bp3-select::after{
     color:rgba(92, 112, 128, 0.6); }
 .bp3-html-select,
 .bp3-select{
   display:inline-block;
+  letter-spacing:normal;
   position:relative;
-  vertical-align:middle;
-  letter-spacing:normal; }
+  vertical-align:middle; }
   .bp3-html-select select::-ms-expand,
   .bp3-select select::-ms-expand{
     display:none; }
@@ -4515,8 +4814,8 @@ form{
   .bp3-html-select.bp3-large .bp3-icon,
   .bp3-select.bp3-large::after,
   .bp3-select.bp3-large .bp3-icon{
-    top:12px;
-    right:12px; }
+    right:12px;
+    top:12px; }
   .bp3-html-select.bp3-fill,
   .bp3-html-select.bp3-fill select,
   .bp3-select.bp3-fill,
@@ -4526,16 +4825,19 @@ form{
   .bp3-select option{
     background-color:#30404d;
     color:#f5f8fa; }
+  .bp3-dark .bp3-html-select option:disabled, .bp3-dark
+  .bp3-select option:disabled{
+    color:rgba(167, 182, 194, 0.6); }
   .bp3-dark .bp3-html-select::after, .bp3-dark
   .bp3-select::after{
     color:#a7b6c2; }
 
 .bp3-select::after{
-  line-height:1;
   font-family:"Icons16", sans-serif;
   font-size:16px;
-  font-weight:400;
   font-style:normal;
+  font-weight:400;
+  line-height:1;
   -moz-osx-font-smoothing:grayscale;
   -webkit-font-smoothing:antialiased;
   content:""; }
@@ -4546,8 +4848,8 @@ form{
   .bp3-running-text table td,
   table.bp3-html-table td{
     padding:11px;
-    vertical-align:top;
-    text-align:left; }
+    text-align:left;
+    vertical-align:top; }
   .bp3-running-text table th, table.bp3-html-table th{
     color:#182026;
     font-weight:600; }
@@ -4574,8 +4876,8 @@ form{
 table.bp3-html-table.bp3-html-table-condensed th,
 table.bp3-html-table.bp3-html-table-condensed td, table.bp3-html-table.bp3-small th,
 table.bp3-html-table.bp3-small td{
-  padding-top:6px;
-  padding-bottom:6px; }
+  padding-bottom:6px;
+  padding-top:6px; }
 
 table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
   background:rgba(191, 204, 214, 0.15); }
@@ -4605,33 +4907,29 @@ table.bp3-html-table.bp3-interactive tbody tr:hover td{
 table.bp3-html-table.bp3-interactive tbody tr:active td{
   background-color:rgba(191, 204, 214, 0.4); }
 
-.bp3-dark table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
-  background:rgba(92, 112, 128, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
-  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td{
-  -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
-  .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
-    -webkit-box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
-            box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
-  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
-  .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:first-child{
-    -webkit-box-shadow:none;
-            box-shadow:none; }
-
-.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:hover td{
-  background-color:rgba(92, 112, 128, 0.3);
-  cursor:pointer; }
-
-.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:active td{
-  background-color:rgba(92, 112, 128, 0.4); }
+.bp3-dark table.bp3-html-table{ }
+  .bp3-dark table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
+    background:rgba(92, 112, 128, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
+    -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td{
+    -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
+    .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
+      -webkit-box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
+              box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
+    -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
+    .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:first-child{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-dark table.bp3-html-table.bp3-interactive tbody tr:hover td{
+    background-color:rgba(92, 112, 128, 0.3);
+    cursor:pointer; }
+  .bp3-dark table.bp3-html-table.bp3-interactive tbody tr:active td{
+    background-color:rgba(92, 112, 128, 0.4); }
 
 .bp3-key-combo{
   display:-webkit-box;
@@ -4664,8 +4962,8 @@ table.bp3-html-table.bp3-interactive tbody tr:active td{
     margin-right:0; }
 
 .bp3-hotkey-dialog{
-  top:40px;
-  padding-bottom:0; }
+  padding-bottom:0;
+  top:40px; }
   .bp3-hotkey-dialog .bp3-dialog-body{
     margin:0;
     padding:0; }
@@ -4685,17 +4983,17 @@ table.bp3-html-table.bp3-interactive tbody tr:active td{
       margin-top:40px; }
 
 .bp3-hotkey{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   -webkit-box-pack:justify;
       -ms-flex-pack:justify;
           justify-content:space-between;
-  margin-right:0;
-  margin-left:0; }
+  margin-left:0;
+  margin-right:0; }
   .bp3-hotkey:not(:last-child){
     margin-bottom:10px; }
 .bp3-icon{
@@ -4733,31 +5031,31 @@ table.bp3-html-table.bp3-interactive tbody tr:active td{
     color:#ff7373; }
 
 span.bp3-icon-standard{
-  line-height:1;
   font-family:"Icons16", sans-serif;
   font-size:16px;
-  font-weight:400;
   font-style:normal;
+  font-weight:400;
+  line-height:1;
   -moz-osx-font-smoothing:grayscale;
   -webkit-font-smoothing:antialiased;
   display:inline-block; }
 
 span.bp3-icon-large{
-  line-height:1;
   font-family:"Icons20", sans-serif;
   font-size:20px;
-  font-weight:400;
   font-style:normal;
+  font-weight:400;
+  line-height:1;
   -moz-osx-font-smoothing:grayscale;
   -webkit-font-smoothing:antialiased;
   display:inline-block; }
 
 span.bp3-icon:empty{
-  line-height:1;
   font-family:"Icons20";
   font-size:inherit;
+  font-style:normal;
   font-weight:400;
-  font-style:normal; }
+  line-height:1; }
   span.bp3-icon:empty::before{
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased; }
@@ -5070,6 +5368,9 @@ span.bp3-icon:empty{
 
 .bp3-icon-desktop::before{
   content:""; }
+
+.bp3-icon-diagnosis::before{
+  content:""; }
 
 .bp3-icon-diagram-tree::before{
   content:""; }
@@ -5505,6 +5806,9 @@ span.bp3-icon:empty{
 
 .bp3-icon-known-vehicle::before{
   content:""; }
+
+.bp3-icon-lab-test::before{
+  content:""; }
 
 .bp3-icon-label::before{
   content:""; }
@@ -6218,6 +6522,7 @@ span.bp3-icon:empty{
 
 .bp3-submenu .bp3-popover-target{
   display:block; }
+  .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{ }
 
 .bp3-submenu.bp3-popover{
   -webkit-box-shadow:none;
@@ -6233,19 +6538,19 @@ span.bp3-icon:empty{
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
 .bp3-menu{
-  margin:0;
-  border-radius:3px;
   background:#ffffff;
+  border-radius:3px;
+  color:#182026;
+  list-style:none;
+  margin:0;
   min-width:180px;
   padding:5px;
-  list-style:none;
-  text-align:left;
-  color:#182026; }
+  text-align:left; }
 
 .bp3-menu-divider{
+  border-top:1px solid rgba(16, 22, 26, 0.15);
   display:block;
-  margin:5px;
-  border-top:1px solid rgba(16, 22, 26, 0.15); }
+  margin:5px; }
   .bp3-dark .bp3-menu-divider{
     border-top-color:rgba(255, 255, 255, 0.15); }
 
@@ -6261,10 +6566,10 @@ span.bp3-icon:empty{
       -ms-flex-align:start;
           align-items:flex-start;
   border-radius:2px;
+  color:inherit;
+  line-height:20px;
   padding:5px 7px;
   text-decoration:none;
-  line-height:20px;
-  color:inherit;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
@@ -6295,8 +6600,8 @@ span.bp3-icon:empty{
     text-decoration:none; }
   .bp3-menu-item.bp3-disabled{
     background-color:inherit;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
   .bp3-dark .bp3-menu-item{
     color:inherit; }
     .bp3-dark .bp3-menu-item:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
@@ -6374,18 +6679,18 @@ span.bp3-icon:empty{
     .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
       color:#ffffff; }
   .bp3-menu-item::before{
-    line-height:1;
     font-family:"Icons16", sans-serif;
     font-size:16px;
-    font-weight:400;
     font-style:normal;
+    font-weight:400;
+    line-height:1;
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased;
     margin-right:7px; }
   .bp3-menu-item::before,
   .bp3-menu-item > .bp3-icon{
-    margin-top:2px;
-    color:#5c7080; }
+    color:#5c7080;
+    margin-top:2px; }
   .bp3-menu-item .bp3-menu-item-label{
     color:#5c7080; }
   .bp3-menu-item:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
@@ -6393,40 +6698,40 @@ span.bp3-icon:empty{
   .bp3-menu-item.bp3-active, .bp3-menu-item:active{
     background-color:rgba(115, 134, 148, 0.3); }
   .bp3-menu-item.bp3-disabled{
-    outline:none !important;
     background-color:inherit !important;
+    color:rgba(92, 112, 128, 0.6) !important;
     cursor:not-allowed !important;
-    color:rgba(92, 112, 128, 0.6) !important; }
+    outline:none !important; }
     .bp3-menu-item.bp3-disabled::before,
     .bp3-menu-item.bp3-disabled > .bp3-icon,
     .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
       color:rgba(92, 112, 128, 0.6) !important; }
   .bp3-large .bp3-menu-item{
-    padding:9px 7px;
+    font-size:16px;
     line-height:22px;
-    font-size:16px; }
+    padding:9px 7px; }
     .bp3-large .bp3-menu-item .bp3-icon{
       margin-top:3px; }
     .bp3-large .bp3-menu-item::before{
-      line-height:1;
       font-family:"Icons20", sans-serif;
       font-size:20px;
-      font-weight:400;
       font-style:normal;
+      font-weight:400;
+      line-height:1;
       -moz-osx-font-smoothing:grayscale;
       -webkit-font-smoothing:antialiased;
-      margin-top:1px;
-      margin-right:10px; }
+      margin-right:10px;
+      margin-top:1px; }
 
 button.bp3-menu-item{
-  border:none;
   background:none;
-  width:100%;
-  text-align:left; }
+  border:none;
+  text-align:left;
+  width:100%; }
 .bp3-menu-header{
+  border-top:1px solid rgba(16, 22, 26, 0.15);
   display:block;
   margin:5px;
-  border-top:1px solid rgba(16, 22, 26, 0.15);
   cursor:default;
   padding-left:2px; }
   .bp3-dark .bp3-menu-header{
@@ -6440,17 +6745,17 @@ button.bp3-menu-item{
     text-overflow:ellipsis;
     white-space:nowrap;
     word-wrap:normal;
+    line-height:17px;
     margin:0;
-    padding:10px 7px 0 1px;
-    line-height:17px; }
+    padding:10px 7px 0 1px; }
     .bp3-dark .bp3-menu-header > h6{
       color:#f5f8fa; }
   .bp3-menu-header:first-of-type > h6{
     padding-top:0; }
   .bp3-large .bp3-menu-header > h6{
-    padding-top:15px;
+    font-size:18px;
     padding-bottom:5px;
-    font-size:18px; }
+    padding-top:15px; }
   .bp3-large .bp3-menu-header:first-of-type > h6{
     padding-top:0; }
 
@@ -6458,98 +6763,92 @@ button.bp3-menu-item{
   background:#30404d;
   color:#f5f8fa; }
 
-.bp3-dark .bp3-menu-item.bp3-intent-primary{
-  color:#48aff0; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary::before, .bp3-dark .bp3-menu-item.bp3-intent-primary::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
+.bp3-dark .bp3-menu-item{ }
+  .bp3-dark .bp3-menu-item.bp3-intent-primary{
     color:#48aff0; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active{
-    background-color:#137cbd; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:active{
-    background-color:#106ba3; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary:active, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-success{
-  color:#3dcc91; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success::before, .bp3-dark .bp3-menu-item.bp3-intent-success::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary::before, .bp3-dark .bp3-menu-item.bp3-intent-primary::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
+      color:#48aff0; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active{
+      background-color:#137cbd; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:active{
+      background-color:#106ba3; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary:active, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item.bp3-intent-success{
     color:#3dcc91; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active{
-    background-color:#0f9960; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:active{
-    background-color:#0d8050; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success:active, .bp3-dark .bp3-menu-item.bp3-intent-success:active::before, .bp3-dark .bp3-menu-item.bp3-intent-success:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-warning{
-  color:#ffb366; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning::before, .bp3-dark .bp3-menu-item.bp3-intent-warning::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success::before, .bp3-dark .bp3-menu-item.bp3-intent-success::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
+      color:#3dcc91; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active{
+      background-color:#0f9960; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success:active{
+      background-color:#0d8050; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success:active, .bp3-dark .bp3-menu-item.bp3-intent-success:active::before, .bp3-dark .bp3-menu-item.bp3-intent-success:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item.bp3-intent-warning{
     color:#ffb366; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active{
-    background-color:#d9822b; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:active{
-    background-color:#bf7326; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning:active, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-danger{
-  color:#ff7373; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger::before, .bp3-dark .bp3-menu-item.bp3-intent-danger::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning::before, .bp3-dark .bp3-menu-item.bp3-intent-warning::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
+      color:#ffb366; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active{
+      background-color:#d9822b; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:active{
+      background-color:#bf7326; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning:active, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item.bp3-intent-danger{
     color:#ff7373; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active{
-    background-color:#db3737; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:active{
-    background-color:#c23030; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger:active, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item::before,
-.bp3-dark .bp3-menu-item > .bp3-icon{
-  color:#a7b6c2; }
-
-.bp3-dark .bp3-menu-item .bp3-menu-item-label{
-  color:#a7b6c2; }
-
-.bp3-dark .bp3-menu-item.bp3-active, .bp3-dark .bp3-menu-item:active{
-  background-color:rgba(138, 155, 168, 0.3); }
-
-.bp3-dark .bp3-menu-item.bp3-disabled{
-  color:rgba(167, 182, 194, 0.6) !important; }
-  .bp3-dark .bp3-menu-item.bp3-disabled::before,
-  .bp3-dark .bp3-menu-item.bp3-disabled > .bp3-icon,
-  .bp3-dark .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger::before, .bp3-dark .bp3-menu-item.bp3-intent-danger::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
+      color:#ff7373; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active{
+      background-color:#db3737; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:active{
+      background-color:#c23030; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger:active, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item::before,
+  .bp3-dark .bp3-menu-item > .bp3-icon{
+    color:#a7b6c2; }
+  .bp3-dark .bp3-menu-item .bp3-menu-item-label{
+    color:#a7b6c2; }
+  .bp3-dark .bp3-menu-item.bp3-active, .bp3-dark .bp3-menu-item:active{
+    background-color:rgba(138, 155, 168, 0.3); }
+  .bp3-dark .bp3-menu-item.bp3-disabled{
     color:rgba(167, 182, 194, 0.6) !important; }
+    .bp3-dark .bp3-menu-item.bp3-disabled::before,
+    .bp3-dark .bp3-menu-item.bp3-disabled > .bp3-icon,
+    .bp3-dark .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
+      color:rgba(167, 182, 194, 0.6) !important; }
 
 .bp3-dark .bp3-menu-divider,
 .bp3-dark .bp3-menu-header{
@@ -6561,14 +6860,14 @@ button.bp3-menu-item{
 .bp3-label .bp3-menu{
   margin-top:5px; }
 .bp3-navbar{
-  position:relative;
-  z-index:10;
+  background-color:#ffffff;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  width:100%;
   height:50px;
-  padding:0 15px; }
+  padding:0 15px;
+  position:relative;
+  width:100%;
+  z-index:10; }
   .bp3-navbar.bp3-dark,
   .bp3-dark .bp3-navbar{
     background-color:#394b59; }
@@ -6579,22 +6878,22 @@ button.bp3-menu-item{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
   .bp3-navbar.bp3-fixed-top{
+    left:0;
     position:fixed;
-    top:0;
     right:0;
-    left:0; }
+    top:0; }
 
 .bp3-navbar-heading{
-  margin-right:15px;
-  font-size:16px; }
+  font-size:16px;
+  margin-right:15px; }
 
 .bp3-navbar-group{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   height:50px; }
   .bp3-navbar-group.bp3-align-left{
     float:left; }
@@ -6602,9 +6901,9 @@ button.bp3-menu-item{
     float:right; }
 
 .bp3-navbar-divider{
-  margin:0 10px;
   border-left:1px solid rgba(16, 22, 26, 0.15);
-  height:20px; }
+  height:20px;
+  margin:0 10px; }
   .bp3-dark .bp3-navbar-divider{
     border-left-color:rgba(255, 255, 255, 0.15); }
 .bp3-non-ideal-state{
@@ -6618,12 +6917,12 @@ button.bp3-menu-item{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  height:100%;
   -webkit-box-pack:center;
       -ms-flex-pack:center;
           justify-content:center;
-  width:100%;
-  height:100%;
-  text-align:center; }
+  text-align:center;
+  width:100%; }
   .bp3-non-ideal-state > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -6668,22 +6967,22 @@ body.bp3-overlay-open{
   overflow:hidden; }
 
 .bp3-overlay{
-  position:static;
-  top:0;
-  right:0;
   bottom:0;
   left:0;
+  position:static;
+  right:0;
+  top:0;
   z-index:20; }
   .bp3-overlay:not(.bp3-overlay-open){
     pointer-events:none; }
   .bp3-overlay.bp3-overlay-container{
-    position:fixed;
-    overflow:hidden; }
+    overflow:hidden;
+    position:fixed; }
     .bp3-overlay.bp3-overlay-container.bp3-overlay-inline{
       position:absolute; }
   .bp3-overlay.bp3-overlay-scroll-container{
-    position:fixed;
-    overflow:auto; }
+    overflow:auto;
+    position:fixed; }
     .bp3-overlay.bp3-overlay-scroll-container.bp3-overlay-inline{
       position:absolute; }
   .bp3-overlay.bp3-overlay-inline{
@@ -6698,77 +6997,77 @@ body.bp3-overlay-open{
     position:absolute; }
 
 .bp3-overlay-backdrop{
-  position:fixed;
-  top:0;
-  right:0;
   bottom:0;
   left:0;
+  position:fixed;
+  right:0;
+  top:0;
   opacity:1;
-  z-index:20;
   background-color:rgba(16, 22, 26, 0.7);
   overflow:auto;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
-          user-select:none; }
+          user-select:none;
+  z-index:20; }
   .bp3-overlay-backdrop.bp3-overlay-enter, .bp3-overlay-backdrop.bp3-overlay-appear{
     opacity:0; }
   .bp3-overlay-backdrop.bp3-overlay-enter-active, .bp3-overlay-backdrop.bp3-overlay-appear-active{
     opacity:1;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:200ms;
             transition-duration:200ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-overlay-backdrop.bp3-overlay-exit{
     opacity:1; }
   .bp3-overlay-backdrop.bp3-overlay-exit-active{
     opacity:0;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:200ms;
             transition-duration:200ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-overlay-backdrop:focus{
     outline:none; }
   .bp3-overlay-inline .bp3-overlay-backdrop{
     position:absolute; }
 .bp3-panel-stack{
-  position:relative;
-  overflow:hidden; }
+  overflow:hidden;
+  position:relative; }
 
 .bp3-panel-stack-header{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-shadow:0 1px rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -ms-flex-negative:0;
       flex-shrink:0;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  z-index:1;
-  -webkit-box-shadow:0 1px rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px rgba(16, 22, 26, 0.15);
-  height:30px; }
+  height:30px;
+  z-index:1; }
   .bp3-dark .bp3-panel-stack-header{
     -webkit-box-shadow:0 1px rgba(255, 255, 255, 0.15);
             box-shadow:0 1px rgba(255, 255, 255, 0.15); }
   .bp3-panel-stack-header > span{
+    -webkit-box-align:stretch;
+        -ms-flex-align:stretch;
+            align-items:stretch;
     display:-webkit-box;
     display:-ms-flexbox;
     display:flex;
     -webkit-box-flex:1;
         -ms-flex:1;
-            flex:1;
-    -webkit-box-align:stretch;
-        -ms-flex-align:stretch;
-            align-items:stretch; }
+            flex:1; }
   .bp3-panel-stack-header .bp3-heading{
     margin:0 5px; }
 
@@ -6780,11 +7079,13 @@ body.bp3-overlay-open{
     margin:0 2px; }
 
 .bp3-panel-stack-view{
-  position:absolute;
-  top:0;
-  right:0;
   bottom:0;
   left:0;
+  position:absolute;
+  right:0;
+  top:0;
+  background-color:#ffffff;
+  border-right:1px solid rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
@@ -6793,11 +7094,12 @@ body.bp3-overlay-open{
       -ms-flex-direction:column;
           flex-direction:column;
   margin-right:-1px;
-  border-right:1px solid rgba(16, 22, 26, 0.15);
-  background-color:#ffffff;
-  overflow-y:auto; }
+  overflow-y:auto;
+  z-index:1; }
   .bp3-dark .bp3-panel-stack-view{
     background-color:#30404d; }
+  .bp3-panel-stack-view:nth-last-child(n + 4){
+    display:none; }
 
 .bp3-panel-stack-push .bp3-panel-stack-enter, .bp3-panel-stack-push .bp3-panel-stack-appear{
   -webkit-transform:translateX(100%);
@@ -6808,16 +7110,16 @@ body.bp3-overlay-open{
   -webkit-transform:translate(0%);
           transform:translate(0%);
   opacity:1;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 
 .bp3-panel-stack-push .bp3-panel-stack-exit{
   -webkit-transform:translate(0%);
@@ -6828,16 +7130,16 @@ body.bp3-overlay-open{
   -webkit-transform:translateX(-50%);
           transform:translateX(-50%);
   opacity:0;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 
 .bp3-panel-stack-pop .bp3-panel-stack-enter, .bp3-panel-stack-pop .bp3-panel-stack-appear{
   -webkit-transform:translateX(-50%);
@@ -6848,16 +7150,16 @@ body.bp3-overlay-open{
   -webkit-transform:translate(0%);
           transform:translate(0%);
   opacity:1;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 
 .bp3-panel-stack-pop .bp3-panel-stack-exit{
   -webkit-transform:translate(0%);
@@ -6868,35 +7170,35 @@ body.bp3-overlay-open{
   -webkit-transform:translateX(100%);
           transform:translateX(100%);
   opacity:0;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 .bp3-popover{
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
   -webkit-transform:scale(1);
           transform:scale(1);
+  border-radius:3px;
   display:inline-block;
-  z-index:20;
-  border-radius:3px; }
+  z-index:20; }
   .bp3-popover .bp3-popover-arrow{
+    height:30px;
     position:absolute;
-    width:30px;
-    height:30px; }
+    width:30px; }
     .bp3-popover .bp3-popover-arrow::before{
+      height:20px;
       margin:5px;
-      width:20px;
-      height:20px; }
+      width:20px; }
   .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover{
-    margin-top:-17px;
-    margin-bottom:17px; }
+    margin-bottom:17px;
+    margin-top:-17px; }
     .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow{
       bottom:-11px; }
       .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow svg{
@@ -6917,8 +7219,8 @@ body.bp3-overlay-open{
         -webkit-transform:rotate(90deg);
                 transform:rotate(90deg); }
   .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover{
-    margin-right:17px;
-    margin-left:-17px; }
+    margin-left:-17px;
+    margin-right:17px; }
     .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow{
       right:-11px; }
       .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow svg{
@@ -6984,35 +7286,35 @@ body.bp3-overlay-open{
   .bp3-popover-enter-active > .bp3-popover, .bp3-popover-appear-active > .bp3-popover{
     -webkit-transform:scale(1);
             transform:scale(1);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-popover-exit > .bp3-popover{
     -webkit-transform:scale(1);
             transform:scale(1); }
   .bp3-popover-exit-active > .bp3-popover{
     -webkit-transform:scale(0.3);
             transform:scale(0.3);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-popover .bp3-popover-content{
-    position:relative;
-    border-radius:3px; }
+    border-radius:3px;
+    position:relative; }
   .bp3-popover.bp3-popover-content-sizing .bp3-popover-content{
     max-width:350px;
     padding:20px; }
@@ -7031,32 +7333,32 @@ body.bp3-overlay-open{
       .bp3-popover-enter-active > .bp3-popover.bp3-minimal.bp3-popover, .bp3-popover-appear-active > .bp3-popover.bp3-minimal.bp3-popover{
         -webkit-transform:scale(1);
                 transform:scale(1);
+        -webkit-transition-delay:0;
+                transition-delay:0;
+        -webkit-transition-duration:100ms;
+                transition-duration:100ms;
         -webkit-transition-property:-webkit-transform;
         transition-property:-webkit-transform;
         transition-property:transform;
         transition-property:transform, -webkit-transform;
-        -webkit-transition-duration:100ms;
-                transition-duration:100ms;
         -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-        -webkit-transition-delay:0;
-                transition-delay:0; }
+                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
       .bp3-popover-exit > .bp3-popover.bp3-minimal.bp3-popover{
         -webkit-transform:scale(1);
                 transform:scale(1); }
       .bp3-popover-exit-active > .bp3-popover.bp3-minimal.bp3-popover{
         -webkit-transform:scale(1);
                 transform:scale(1);
+        -webkit-transition-delay:0;
+                transition-delay:0;
+        -webkit-transition-duration:100ms;
+                transition-duration:100ms;
         -webkit-transition-property:-webkit-transform;
         transition-property:-webkit-transform;
         transition-property:transform;
         transition-property:transform, -webkit-transform;
-        -webkit-transition-duration:100ms;
-                transition-duration:100ms;
         -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-        -webkit-transition-delay:0;
-                transition-delay:0; }
+                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-popover.bp3-dark,
   .bp3-dark .bp3-popover{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
@@ -7078,12 +7380,12 @@ body.bp3-overlay-open{
       fill:#30404d; }
 
 .bp3-popover-arrow::before{
+  border-radius:2px;
+  content:"";
   display:block;
   position:absolute;
   -webkit-transform:rotate(45deg);
-          transform:rotate(45deg);
-  border-radius:2px;
-  content:""; }
+          transform:rotate(45deg); }
 
 .bp3-tether-pinned .bp3-popover-arrow{
   display:none; }
@@ -7101,26 +7403,26 @@ body.bp3-overlay-open{
     opacity:0; }
   .bp3-transition-container.bp3-popover-enter-active, .bp3-transition-container.bp3-popover-appear-active{
     opacity:1;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:100ms;
             transition-duration:100ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-transition-container.bp3-popover-exit{
     opacity:1; }
   .bp3-transition-container.bp3-popover-exit-active{
     opacity:0;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:100ms;
             transition-duration:100ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-transition-container:focus{
     outline:none; }
   .bp3-transition-container.bp3-popover-leave .bp3-popover-content{
@@ -7135,10 +7437,10 @@ span.bp3-popover-target{
   width:100%; }
 
 .bp3-portal{
+  left:0;
   position:absolute;
-  top:0;
   right:0;
-  left:0; }
+  top:0; }
 @-webkit-keyframes linear-progress-bar-stripes{
   from{
     background-position:0 0; }
@@ -7151,23 +7453,23 @@ span.bp3-popover-target{
     background-position:30px 0; } }
 
 .bp3-progress-bar{
-  display:block;
-  position:relative;
-  border-radius:40px;
   background:rgba(92, 112, 128, 0.2);
-  width:100%;
+  border-radius:40px;
+  display:block;
   height:8px;
-  overflow:hidden; }
+  overflow:hidden;
+  position:relative;
+  width:100%; }
   .bp3-progress-bar .bp3-progress-meter{
-    position:absolute;
-    border-radius:40px;
     background:linear-gradient(-45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%);
     background-color:rgba(92, 112, 128, 0.8);
     background-size:30px 30px;
-    width:100%;
+    border-radius:40px;
     height:100%;
+    position:absolute;
     -webkit-transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+    transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    width:100%; }
   .bp3-progress-bar:not(.bp3-no-animation):not(.bp3-no-stripes) .bp3-progress-meter{
     animation:linear-progress-bar-stripes 300ms linear infinite reverse; }
   .bp3-progress-bar.bp3-no-stripes .bp3-progress-meter{
@@ -7191,29 +7493,29 @@ span.bp3-popover-target{
   background-color:#db3737; }
 @-webkit-keyframes skeleton-glow{
   from{
-    border-color:rgba(206, 217, 224, 0.2);
-    background:rgba(206, 217, 224, 0.2); }
+    background:rgba(206, 217, 224, 0.2);
+    border-color:rgba(206, 217, 224, 0.2); }
   to{
-    border-color:rgba(92, 112, 128, 0.2);
-    background:rgba(92, 112, 128, 0.2); } }
+    background:rgba(92, 112, 128, 0.2);
+    border-color:rgba(92, 112, 128, 0.2); } }
 @keyframes skeleton-glow{
   from{
-    border-color:rgba(206, 217, 224, 0.2);
-    background:rgba(206, 217, 224, 0.2); }
+    background:rgba(206, 217, 224, 0.2);
+    border-color:rgba(206, 217, 224, 0.2); }
   to{
-    border-color:rgba(92, 112, 128, 0.2);
-    background:rgba(92, 112, 128, 0.2); } }
+    background:rgba(92, 112, 128, 0.2);
+    border-color:rgba(92, 112, 128, 0.2); } }
 .bp3-skeleton{
+  -webkit-animation:1000ms linear infinite alternate skeleton-glow;
+          animation:1000ms linear infinite alternate skeleton-glow;
+  background:rgba(206, 217, 224, 0.2);
+  background-clip:padding-box !important;
   border-color:rgba(206, 217, 224, 0.2) !important;
   border-radius:2px;
   -webkit-box-shadow:none !important;
           box-shadow:none !important;
-  background:rgba(206, 217, 224, 0.2);
-  background-clip:padding-box !important;
-  cursor:default;
   color:transparent !important;
-  -webkit-animation:1000ms linear infinite alternate skeleton-glow;
-          animation:1000ms linear infinite alternate skeleton-glow;
+  cursor:default;
   pointer-events:none;
   -webkit-user-select:none;
      -moz-user-select:none;
@@ -7223,12 +7525,12 @@ span.bp3-popover-target{
   .bp3-skeleton *{
     visibility:hidden !important; }
 .bp3-slider{
-  width:100%;
-  min-width:150px;
   height:40px;
-  position:relative;
-  outline:none;
+  min-width:150px;
+  width:100%;
   cursor:default;
+  outline:none;
+  position:relative;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
@@ -7239,17 +7541,17 @@ span.bp3-popover-target{
     cursor:-webkit-grabbing;
     cursor:grabbing; }
   .bp3-slider.bp3-disabled{
-    opacity:0.5;
-    cursor:not-allowed; }
+    cursor:not-allowed;
+    opacity:0.5; }
   .bp3-slider.bp3-slider-unlabeled{
     height:16px; }
 
 .bp3-slider-track,
 .bp3-slider-progress{
-  top:5px;
-  right:0;
-  left:0;
   height:6px;
+  left:0;
+  right:0;
+  top:5px;
   position:absolute; }
 
 .bp3-slider-track{
@@ -7270,90 +7572,90 @@ span.bp3-popover-target{
     background-color:#db3737; }
 
 .bp3-slider-handle{
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
   background-color:#f5f8fa;
   background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
   background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
   color:#182026;
-  position:absolute;
-  top:0;
-  left:0;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
   cursor:pointer;
-  width:16px;
-  height:16px; }
+  height:16px;
+  left:0;
+  position:absolute;
+  top:0;
+  width:16px; }
   .bp3-slider-handle:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
-    background-color:#ebf1f5; }
+    background-color:#ebf1f5;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
   .bp3-slider-handle:active, .bp3-slider-handle.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-slider-handle:disabled, .bp3-slider-handle.bp3-disabled{
-    outline:none;
-    -webkit-box-shadow:none;
-            box-shadow:none;
     background-color:rgba(206, 217, 224, 0.5);
     background-image:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    color:rgba(92, 112, 128, 0.6);
     cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    outline:none; }
     .bp3-slider-handle:disabled.bp3-active, .bp3-slider-handle:disabled.bp3-active:hover, .bp3-slider-handle.bp3-disabled.bp3-active, .bp3-slider-handle.bp3-disabled.bp3-active:hover{
       background:rgba(206, 217, 224, 0.7); }
   .bp3-slider-handle:focus{
     z-index:1; }
   .bp3-slider-handle:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
     background-color:#ebf1f5;
-    z-index:2;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
     cursor:-webkit-grab;
-    cursor:grab; }
+    cursor:grab;
+    z-index:2; }
   .bp3-slider-handle.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
     background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
     cursor:-webkit-grabbing;
     cursor:grabbing; }
   .bp3-disabled .bp3-slider-handle{
+    background:#bfccd6;
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:#bfccd6;
     pointer-events:none; }
   .bp3-dark .bp3-slider-handle{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     background-color:#394b59;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     color:#f5f8fa; }
     .bp3-dark .bp3-slider-handle:hover, .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
       color:#f5f8fa; }
     .bp3-dark .bp3-slider-handle:hover{
+      background-color:#30404d;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#202b33;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-slider-handle:disabled, .bp3-dark .bp3-slider-handle.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(57, 75, 89, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:rgba(167, 182, 194, 0.6); }
       .bp3-dark .bp3-slider-handle:disabled.bp3-active, .bp3-dark .bp3-slider-handle.bp3-disabled.bp3-active{
         background:rgba(57, 75, 89, 0.7); }
@@ -7365,21 +7667,21 @@ span.bp3-popover-target{
     .bp3-dark .bp3-slider-handle.bp3-active{
       background-color:#293742; }
   .bp3-dark .bp3-disabled .bp3-slider-handle{
+    background:#5c7080;
     border-color:#5c7080;
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:#5c7080; }
+            box-shadow:none; }
   .bp3-slider-handle .bp3-slider-label{
-    margin-left:8px;
+    background:#394b59;
     border-radius:3px;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-    background:#394b59;
-    color:#f5f8fa; }
+    color:#f5f8fa;
+    margin-left:8px; }
     .bp3-dark .bp3-slider-handle .bp3-slider-label{
+      background:#e1e8ed;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-      background:#e1e8ed;
       color:#394b59; }
     .bp3-disabled .bp3-slider-handle .bp3-slider-label{
       -webkit-box-shadow:none;
@@ -7387,12 +7689,12 @@ span.bp3-popover-target{
   .bp3-slider-handle.bp3-start, .bp3-slider-handle.bp3-end{
     width:8px; }
   .bp3-slider-handle.bp3-start{
-    border-top-right-radius:0;
-    border-bottom-right-radius:0; }
+    border-bottom-right-radius:0;
+    border-top-right-radius:0; }
   .bp3-slider-handle.bp3-end{
-    margin-left:8px;
+    border-bottom-left-radius:0;
     border-top-left-radius:0;
-    border-bottom-left-radius:0; }
+    margin-left:8px; }
     .bp3-slider-handle.bp3-end .bp3-slider-label{
       margin-left:0; }
 
@@ -7400,23 +7702,23 @@ span.bp3-popover-target{
   -webkit-transform:translate(-50%, 20px);
           transform:translate(-50%, 20px);
   display:inline-block;
-  position:absolute;
-  padding:2px 5px;
-  vertical-align:top;
+  font-size:12px;
   line-height:1;
-  font-size:12px; }
+  padding:2px 5px;
+  position:absolute;
+  vertical-align:top; }
 
 .bp3-slider.bp3-vertical{
-  width:40px;
+  height:150px;
   min-width:40px;
-  height:150px; }
+  width:40px; }
   .bp3-slider.bp3-vertical .bp3-slider-track,
   .bp3-slider.bp3-vertical .bp3-slider-progress{
-    top:0;
     bottom:0;
+    height:auto;
     left:5px;
-    width:6px;
-    height:auto; }
+    top:0;
+    width:6px; }
   .bp3-slider.bp3-vertical .bp3-slider-progress{
     top:auto; }
   .bp3-slider.bp3-vertical .bp3-slider-label{
@@ -7425,23 +7727,23 @@ span.bp3-popover-target{
   .bp3-slider.bp3-vertical .bp3-slider-handle{
     top:auto; }
     .bp3-slider.bp3-vertical .bp3-slider-handle .bp3-slider-label{
-      margin-top:-8px;
-      margin-left:0; }
-    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end, .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
       margin-left:0;
-      width:16px;
-      height:8px; }
+      margin-top:-8px; }
+    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end, .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
+      height:8px;
+      margin-left:0;
+      width:16px; }
     .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
-      border-top-left-radius:0;
-      border-bottom-right-radius:3px; }
+      border-bottom-right-radius:3px;
+      border-top-left-radius:0; }
       .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start .bp3-slider-label{
         -webkit-transform:translate(20px);
                 transform:translate(20px); }
     .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end{
-      margin-bottom:8px;
-      border-top-left-radius:3px;
       border-bottom-left-radius:0;
-      border-bottom-right-radius:0; }
+      border-bottom-right-radius:0;
+      border-top-left-radius:3px;
+      margin-bottom:8px; }
 
 @-webkit-keyframes pt-spinner-animation{
   from{
@@ -7460,12 +7762,12 @@ span.bp3-popover-target{
             transform:rotate(360deg); } }
 
 .bp3-spinner{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   -webkit-box-pack:center;
       -ms-flex-pack:center;
           justify-content:center;
@@ -7476,12 +7778,12 @@ span.bp3-popover-target{
   .bp3-spinner path{
     fill-opacity:0; }
   .bp3-spinner .bp3-spinner-head{
+    stroke:rgba(92, 112, 128, 0.8);
+    stroke-linecap:round;
     -webkit-transform-origin:center;
             transform-origin:center;
     -webkit-transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    stroke:rgba(92, 112, 128, 0.8);
-    stroke-linecap:round; }
+    transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-spinner .bp3-spinner-track{
     stroke:rgba(92, 112, 128, 0.2); }
 
@@ -7514,48 +7816,48 @@ span.bp3-popover-target{
   display:-ms-flexbox;
   display:flex; }
   .bp3-tabs.bp3-vertical > .bp3-tab-list{
+    -webkit-box-align:start;
+        -ms-flex-align:start;
+            align-items:flex-start;
     -webkit-box-orient:vertical;
     -webkit-box-direction:normal;
         -ms-flex-direction:column;
-            flex-direction:column;
-    -webkit-box-align:start;
-        -ms-flex-align:start;
-            align-items:flex-start; }
+            flex-direction:column; }
     .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab{
       border-radius:3px;
-      width:100%;
-      padding:0 10px; }
+      padding:0 10px;
+      width:100%; }
       .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab[aria-selected="true"]{
+        background-color:rgba(19, 124, 189, 0.2);
         -webkit-box-shadow:none;
-                box-shadow:none;
-        background-color:rgba(19, 124, 189, 0.2); }
+                box-shadow:none; }
     .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab-indicator-wrapper .bp3-tab-indicator{
-      top:0;
-      right:0;
-      bottom:0;
-      left:0;
-      border-radius:3px;
       background-color:rgba(19, 124, 189, 0.2);
-      height:auto; }
+      border-radius:3px;
+      bottom:0;
+      height:auto;
+      left:0;
+      right:0;
+      top:0; }
   .bp3-tabs.bp3-vertical > .bp3-tab-panel{
     margin-top:0;
     padding-left:20px; }
 
 .bp3-tab-list{
+  -webkit-box-align:end;
+      -ms-flex-align:end;
+          align-items:flex-end;
+  border:none;
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  -webkit-box-align:end;
-      -ms-flex-align:end;
-          align-items:flex-end;
-  position:relative;
+  list-style:none;
   margin:0;
-  border:none;
   padding:0;
-  list-style:none; }
+  position:relative; }
   .bp3-tab-list > *:not(:last-child){
     margin-right:20px; }
 
@@ -7564,27 +7866,27 @@ span.bp3-popover-target{
   text-overflow:ellipsis;
   white-space:nowrap;
   word-wrap:normal;
+  color:#182026;
+  cursor:pointer;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  position:relative;
-  cursor:pointer;
-  max-width:100%;
-  vertical-align:top;
+  font-size:14px;
   line-height:30px;
-  color:#182026;
-  font-size:14px; }
+  max-width:100%;
+  position:relative;
+  vertical-align:top; }
   .bp3-tab a{
+    color:inherit;
     display:block;
-    text-decoration:none;
-    color:inherit; }
+    text-decoration:none; }
   .bp3-tab-indicator-wrapper ~ .bp3-tab{
+    background-color:transparent !important;
     -webkit-box-shadow:none !important;
-            box-shadow:none !important;
-    background-color:transparent !important; }
+            box-shadow:none !important; }
   .bp3-tab[aria-disabled="true"]{
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
   .bp3-tab[aria-selected="true"]{
     border-radius:0;
     -webkit-box-shadow:inset 0 -3px 0 #106ba3;
@@ -7594,8 +7896,8 @@ span.bp3-popover-target{
   .bp3-tab:focus{
     -moz-outline-radius:0; }
   .bp3-large > .bp3-tab{
-    line-height:40px;
-    font-size:16px; }
+    font-size:16px;
+    line-height:40px; }
 
 .bp3-tab-panel{
   margin-top:20px; }
@@ -7603,9 +7905,10 @@ span.bp3-popover-target{
     display:none; }
 
 .bp3-tab-indicator-wrapper{
+  left:0;
+  pointer-events:none;
   position:absolute;
   top:0;
-  left:0;
   -webkit-transform:translateX(0), translateY(0);
           transform:translateX(0), translateY(0);
   -webkit-transition:height, width, -webkit-transform;
@@ -7615,15 +7918,14 @@ span.bp3-popover-target{
   -webkit-transition-duration:200ms;
           transition-duration:200ms;
   -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-          transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-  pointer-events:none; }
+          transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-tab-indicator-wrapper .bp3-tab-indicator{
-    position:absolute;
-    right:0;
-    bottom:0;
-    left:0;
     background-color:#106ba3;
-    height:3px; }
+    bottom:0;
+    height:3px;
+    left:0;
+    position:absolute;
+    right:0; }
   .bp3-tab-indicator-wrapper.bp3-no-animation{
     -webkit-transition:none;
     transition:none; }
@@ -7656,19 +7958,19 @@ span.bp3-popover-target{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  position:relative;
+  background-color:#5c7080;
   border:none;
   border-radius:3px;
   -webkit-box-shadow:none;
           box-shadow:none;
-  background-color:#5c7080;
-  min-width:20px;
+  color:#f5f8fa;
+  font-size:12px;
+  line-height:16px;
   max-width:100%;
   min-height:20px;
+  min-width:20px;
   padding:2px 6px;
-  line-height:16px;
-  color:#f5f8fa;
-  font-size:12px; }
+  position:relative; }
   .bp3-tag.bp3-interactive{
     cursor:pointer; }
     .bp3-tag.bp3-interactive:hover{
@@ -7699,8 +8001,8 @@ span.bp3-popover-target{
     -moz-outline-radius:6px; }
   .bp3-tag.bp3-round{
     border-radius:30px;
-    padding-right:8px;
-    padding-left:8px; }
+    padding-left:8px;
+    padding-right:8px; }
   .bp3-dark .bp3-tag{
     background-color:#bfccd6;
     color:#182026; }
@@ -7716,11 +8018,11 @@ span.bp3-popover-target{
     fill:#ffffff; }
   .bp3-tag.bp3-large,
   .bp3-large .bp3-tag{
-    min-width:30px;
-    min-height:30px;
-    padding:0 10px;
+    font-size:14px;
     line-height:20px;
-    font-size:14px; }
+    min-height:30px;
+    min-width:30px;
+    padding:5px 10px; }
     .bp3-tag.bp3-large::before,
     .bp3-tag.bp3-large > *,
     .bp3-large .bp3-tag::before,
@@ -7733,8 +8035,8 @@ span.bp3-popover-target{
       margin-right:0; }
     .bp3-tag.bp3-large.bp3-round,
     .bp3-large .bp3-tag.bp3-round{
-      padding-right:12px;
-      padding-left:12px; }
+      padding-left:12px;
+      padding-right:12px; }
   .bp3-tag.bp3-intent-primary{
     background:#137cbd;
     color:#ffffff; }
@@ -7879,44 +8181,43 @@ span.bp3-popover-target{
           background-color:rgba(219, 55, 55, 0.45); }
 
 .bp3-tag-remove{
+  background:none;
+  border:none;
+  color:inherit;
+  cursor:pointer;
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
-  opacity:0.5;
-  margin-top:-2px;
-  margin-right:-6px !important;
   margin-bottom:-2px;
-  border:none;
-  background:none;
-  cursor:pointer;
+  margin-right:-6px !important;
+  margin-top:-2px;
+  opacity:0.5;
   padding:2px;
-  padding-left:0;
-  color:inherit; }
+  padding-left:0; }
   .bp3-tag-remove:hover{
-    opacity:0.8;
     background:none;
+    opacity:0.8;
     text-decoration:none; }
   .bp3-tag-remove:active{
     opacity:1; }
   .bp3-tag-remove:empty::before{
-    line-height:1;
     font-family:"Icons16", sans-serif;
     font-size:16px;
-    font-weight:400;
     font-style:normal;
+    font-weight:400;
+    line-height:1;
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased;
     content:""; }
   .bp3-large .bp3-tag-remove{
     margin-right:-10px !important;
-    padding:5px;
-    padding-left:0; }
+    padding:0 5px 0 0; }
     .bp3-large .bp3-tag-remove:empty::before{
-      line-height:1;
       font-family:"Icons20", sans-serif;
       font-size:20px;
+      font-style:normal;
       font-weight:400;
-      font-style:normal; }
+      line-height:1; }
 .bp3-tag-input{
   display:-webkit-box;
   display:-ms-flexbox;
@@ -7930,10 +8231,10 @@ span.bp3-popover-target{
           align-items:flex-start;
   cursor:text;
   height:auto;
+  line-height:inherit;
   min-height:30px;
-  padding-right:0;
   padding-left:5px;
-  line-height:inherit; }
+  padding-right:0; }
   .bp3-tag-input > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -7947,10 +8248,10 @@ span.bp3-popover-target{
     -ms-flex-negative:1;
         flex-shrink:1; }
   .bp3-tag-input .bp3-tag-input-icon{
-    margin-top:7px;
-    margin-right:7px;
+    color:#5c7080;
     margin-left:2px;
-    color:#5c7080; }
+    margin-right:7px;
+    margin-top:7px; }
   .bp3-tag-input .bp3-tag-input-values{
     display:-webkit-box;
     display:-ms-flexbox;
@@ -7959,15 +8260,15 @@ span.bp3-popover-target{
     -webkit-box-direction:normal;
         -ms-flex-direction:row;
             flex-direction:row;
-    -ms-flex-wrap:wrap;
-        flex-wrap:wrap;
     -webkit-box-align:center;
         -ms-flex-align:center;
             align-items:center;
     -ms-flex-item-align:stretch;
         align-self:stretch;
-    margin-top:5px;
+    -ms-flex-wrap:wrap;
+        flex-wrap:wrap;
     margin-right:7px;
+    margin-top:5px;
     min-width:0; }
     .bp3-tag-input .bp3-tag-input-values > *{
       -webkit-box-flex:0;
@@ -8001,8 +8302,8 @@ span.bp3-popover-target{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
             flex:1 1 auto;
-    width:80px;
-    line-height:20px; }
+    line-height:20px;
+    width:80px; }
     .bp3-tag-input .bp3-input-ghost:disabled, .bp3-tag-input .bp3-input-ghost.bp3-disabled{
       cursor:not-allowed; }
   .bp3-tag-input .bp3-button,
@@ -8010,8 +8311,8 @@ span.bp3-popover-target{
     margin:3px;
     margin-left:0; }
   .bp3-tag-input .bp3-button{
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     padding:0 7px; }
   .bp3-tag-input.bp3-large{
     height:auto;
@@ -8023,13 +8324,13 @@ span.bp3-popover-target{
     .bp3-tag-input.bp3-large > :last-child{
       margin-right:0; }
     .bp3-tag-input.bp3-large .bp3-tag-input-icon{
-      margin-top:10px;
-      margin-left:5px; }
+      margin-left:5px;
+      margin-top:10px; }
     .bp3-tag-input.bp3-large .bp3-input-ghost{
       line-height:30px; }
     .bp3-tag-input.bp3-large .bp3-button{
-      min-width:30px;
       min-height:30px;
+      min-width:30px;
       padding:5px 10px;
       margin:5px;
       margin-left:0; }
@@ -8037,9 +8338,9 @@ span.bp3-popover-target{
       margin:8px;
       margin-left:0; }
   .bp3-tag-input.bp3-active{
+    background-color:#ffffff;
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-    background-color:#ffffff; }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
     .bp3-tag-input.bp3-active.bp3-intent-primary{
       -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
               box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
@@ -8067,9 +8368,9 @@ span.bp3-popover-target{
     .bp3-dark .bp3-tag-input .bp3-input-ghost::placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::placeholder{
       color:rgba(167, 182, 194, 0.6); }
   .bp3-dark .bp3-tag-input.bp3-active, .bp3-tag-input.bp3-dark.bp3-active{
+    background-color:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background-color:rgba(16, 22, 26, 0.3); }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-primary, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-primary{
       -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
               box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
@@ -8084,76 +8385,76 @@ span.bp3-popover-target{
               box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
 
 .bp3-input-ghost{
+  background:none;
   border:none;
   -webkit-box-shadow:none;
           box-shadow:none;
-  background:none;
   padding:0; }
   .bp3-input-ghost::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost:focus{
     outline:none !important; }
 .bp3-toast{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:start;
       -ms-flex-align:start;
           align-items:flex-start;
-  position:relative !important;
-  margin:20px 0 0;
+  background-color:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  min-width:300px;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  margin:20px 0 0;
   max-width:500px;
-  pointer-events:all; }
+  min-width:300px;
+  pointer-events:all;
+  position:relative !important; }
   .bp3-toast.bp3-toast-enter, .bp3-toast.bp3-toast-appear{
     -webkit-transform:translateY(-40px);
             transform:translateY(-40px); }
   .bp3-toast.bp3-toast-enter-active, .bp3-toast.bp3-toast-appear-active{
     -webkit-transform:translateY(0);
             transform:translateY(0);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-toast.bp3-toast-enter ~ .bp3-toast, .bp3-toast.bp3-toast-appear ~ .bp3-toast{
     -webkit-transform:translateY(-40px);
             transform:translateY(-40px); }
   .bp3-toast.bp3-toast-enter-active ~ .bp3-toast, .bp3-toast.bp3-toast-appear-active ~ .bp3-toast{
     -webkit-transform:translateY(0);
             transform:translateY(0);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-toast.bp3-toast-exit{
     opacity:1;
     -webkit-filter:blur(0);
@@ -8162,32 +8463,32 @@ span.bp3-popover-target{
     opacity:0;
     -webkit-filter:blur(10px);
             filter:blur(10px);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:opacity, -webkit-filter;
     transition-property:opacity, -webkit-filter;
     transition-property:opacity, filter;
     transition-property:opacity, filter, -webkit-filter;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-toast.bp3-toast-exit ~ .bp3-toast{
     -webkit-transform:translateY(0);
             transform:translateY(0); }
   .bp3-toast.bp3-toast-exit-active ~ .bp3-toast{
     -webkit-transform:translateY(-40px);
             transform:translateY(-40px);
+    -webkit-transition-delay:50ms;
+            transition-delay:50ms;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:50ms;
-            transition-delay:50ms; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-toast .bp3-button-group{
     -webkit-box-flex:0;
         -ms-flex:0 0 auto;
@@ -8195,14 +8496,14 @@ span.bp3-popover-target{
     padding:5px;
     padding-left:0; }
   .bp3-toast > .bp3-icon{
+    color:#5c7080;
     margin:12px;
-    margin-right:0;
-    color:#5c7080; }
+    margin-right:0; }
   .bp3-toast.bp3-dark,
   .bp3-dark .bp3-toast{
+    background-color:#394b59;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-    background-color:#394b59; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
     .bp3-toast.bp3-dark > .bp3-icon,
     .bp3-dark .bp3-toast > .bp3-icon{
       color:#a7b6c2; }
@@ -8246,6 +8547,9 @@ span.bp3-popover-target{
   word-break:break-word; }
 
 .bp3-toast-container{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
   display:-webkit-box !important;
   display:-ms-flexbox !important;
   display:flex !important;
@@ -8253,26 +8557,22 @@ span.bp3-popover-target{
   -webkit-box-direction:normal;
       -ms-flex-direction:column;
           flex-direction:column;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  position:fixed;
-  right:0;
   left:0;
-  z-index:40;
   overflow:hidden;
   padding:0 20px 20px;
-  pointer-events:none; }
+  pointer-events:none;
+  position:fixed;
+  right:0;
+  z-index:40; }
   .bp3-toast-container.bp3-toast-container-top{
-    top:0;
-    bottom:auto; }
+    top:0; }
   .bp3-toast-container.bp3-toast-container-bottom{
+    bottom:0;
     -webkit-box-orient:vertical;
     -webkit-box-direction:reverse;
         -ms-flex-direction:column-reverse;
             flex-direction:column-reverse;
-    top:auto;
-    bottom:0; }
+    top:auto; }
   .bp3-toast-container.bp3-toast-container-left{
     -webkit-box-align:start;
         -ms-flex-align:start;
@@ -8285,6 +8585,7 @@ span.bp3-popover-target{
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active),
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active) ~ .bp3-toast, .bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active),
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active) ~ .bp3-toast,
+.bp3-toast-container-bottom .bp3-toast.bp3-toast-exit-active ~ .bp3-toast,
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-leave-active ~ .bp3-toast{
   -webkit-transform:translateY(60px);
           transform:translateY(60px); }
@@ -8294,16 +8595,16 @@ span.bp3-popover-target{
   -webkit-transform:scale(1);
           transform:scale(1); }
   .bp3-tooltip .bp3-popover-arrow{
+    height:22px;
     position:absolute;
-    width:22px;
-    height:22px; }
+    width:22px; }
     .bp3-tooltip .bp3-popover-arrow::before{
+      height:14px;
       margin:4px;
-      width:14px;
-      height:14px; }
+      width:14px; }
   .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip{
-    margin-top:-11px;
-    margin-bottom:11px; }
+    margin-bottom:11px;
+    margin-top:-11px; }
     .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow{
       bottom:-8px; }
       .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow svg{
@@ -8324,8 +8625,8 @@ span.bp3-popover-target{
         -webkit-transform:rotate(90deg);
                 transform:rotate(90deg); }
   .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip{
-    margin-right:11px;
-    margin-left:-11px; }
+    margin-left:-11px;
+    margin-right:11px; }
     .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow{
       right:-8px; }
       .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow svg{
@@ -8391,32 +8692,32 @@ span.bp3-popover-target{
   .bp3-popover-enter-active > .bp3-tooltip, .bp3-popover-appear-active > .bp3-tooltip{
     -webkit-transform:scale(1);
             transform:scale(1);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-popover-exit > .bp3-tooltip{
     -webkit-transform:scale(1);
             transform:scale(1); }
   .bp3-popover-exit-active > .bp3-tooltip{
     -webkit-transform:scale(0.8);
             transform:scale(0.8);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-tooltip .bp3-popover-content{
     padding:10px 12px; }
   .bp3-tooltip.bp3-dark,
@@ -8474,15 +8775,15 @@ span.bp3-popover-target{
     color:#db3737; }
 
 .bp3-tree-node-list{
+  list-style:none;
   margin:0;
-  padding-left:0;
-  list-style:none; }
+  padding-left:0; }
 
 .bp3-tree-root{
-  position:relative;
   background-color:transparent;
   cursor:default;
-  padding-left:0; }
+  padding-left:0;
+  position:relative; }
 
 .bp3-tree-node-content-0{
   padding-left:0px; }
@@ -8548,15 +8849,15 @@ span.bp3-popover-target{
   padding-left:460px; }
 
 .bp3-tree-node-content{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  width:100%;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   height:30px;
-  padding-right:5px; }
+  padding-right:5px;
+  width:100%; }
   .bp3-tree-node-content:hover{
     background-color:rgba(191, 204, 214, 0.4); }
 
@@ -8566,10 +8867,10 @@ span.bp3-popover-target{
 
 .bp3-tree-node-caret{
   color:#5c7080;
-  -webkit-transform:rotate(0deg);
-          transform:rotate(0deg);
   cursor:pointer;
   padding:7px;
+  -webkit-transform:rotate(0deg);
+          transform:rotate(0deg);
   -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
@@ -8587,8 +8888,8 @@ span.bp3-popover-target{
     content:""; }
 
 .bp3-tree-node-icon{
-  position:relative;
-  margin-right:7px; }
+  margin-right:7px;
+  position:relative; }
 
 .bp3-tree-node-label{
   overflow:hidden;
@@ -8614,22 +8915,22 @@ span.bp3-popover-target{
           user-select:none; }
   .bp3-tree-node-secondary-label .bp3-popover-wrapper,
   .bp3-tree-node-secondary-label .bp3-popover-target{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
     -webkit-box-align:center;
         -ms-flex-align:center;
-            align-items:center; }
+            align-items:center;
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex; }
 
 .bp3-tree-node.bp3-disabled .bp3-tree-node-content{
   background-color:inherit;
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-tree-node.bp3-disabled .bp3-tree-node-caret,
 .bp3-tree-node.bp3-disabled .bp3-tree-node-icon{
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
   background-color:#137cbd; }
@@ -8657,24 +8958,18 @@ span.bp3-popover-target{
 
 .bp3-dark .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
   background-color:#137cbd; }
-/*!
-
-Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
-Licensed under the Apache License, Version 2.0.
-
-*/
 .bp3-omnibar{
   -webkit-filter:blur(0);
           filter:blur(0);
   opacity:1;
-  top:20vh;
-  left:calc(50% - 250px);
-  z-index:21;
+  background-color:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  width:500px; }
+  left:calc(50% - 250px);
+  top:20vh;
+  width:500px;
+  z-index:21; }
   .bp3-omnibar.bp3-overlay-enter, .bp3-omnibar.bp3-overlay-appear{
     -webkit-filter:blur(20px);
             filter:blur(20px);
@@ -8683,16 +8978,16 @@ Licensed under the Apache License, Version 2.0.
     -webkit-filter:blur(0);
             filter:blur(0);
     opacity:1;
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
     -webkit-transition-property:opacity, -webkit-filter;
     transition-property:opacity, -webkit-filter;
     transition-property:filter, opacity;
     transition-property:filter, opacity, -webkit-filter;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-omnibar.bp3-overlay-exit{
     -webkit-filter:blur(0);
             filter:blur(0);
@@ -8701,35 +8996,35 @@ Licensed under the Apache License, Version 2.0.
     -webkit-filter:blur(20px);
             filter:blur(20px);
     opacity:0.2;
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
     -webkit-transition-property:opacity, -webkit-filter;
     transition-property:opacity, -webkit-filter;
     transition-property:filter, opacity;
     transition-property:filter, opacity, -webkit-filter;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-omnibar .bp3-input{
-    border-radius:0;
-    background-color:transparent; }
+    background-color:transparent;
+    border-radius:0; }
     .bp3-omnibar .bp3-input, .bp3-omnibar .bp3-input:focus{
       -webkit-box-shadow:none;
               box-shadow:none; }
   .bp3-omnibar .bp3-menu{
+    background-color:transparent;
     border-radius:0;
     -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
             box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-    background-color:transparent;
     max-height:calc(60vh - 40px);
     overflow:auto; }
     .bp3-omnibar .bp3-menu:empty{
       display:none; }
   .bp3-dark .bp3-omnibar, .bp3-omnibar.bp3-dark{
+    background-color:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background-color:#30404d; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4); }
 
 .bp3-omnibar-overlay .bp3-overlay-backdrop{
   background-color:rgba(16, 22, 26, 0.2); }
@@ -8741,8 +9036,8 @@ Licensed under the Apache License, Version 2.0.
   margin-bottom:0; }
 
 .bp3-select-popover .bp3-menu{
-  max-width:400px;
   max-height:300px;
+  max-width:400px;
   overflow:auto;
   padding:0; }
   .bp3-select-popover .bp3-menu:not(:first-child){
@@ -8752,8 +9047,8 @@ Licensed under the Apache License, Version 2.0.
   min-width:150px; }
 
 .bp3-multi-select-popover .bp3-menu{
-  max-width:400px;
   max-height:300px;
+  max-width:400px;
   overflow:auto; }
 
 .bp3-select-popover .bp3-popover-content{
@@ -8763,8 +9058,8 @@ Licensed under the Apache License, Version 2.0.
   margin-bottom:0; }
 
 .bp3-select-popover .bp3-menu{
-  max-width:400px;
   max-height:300px;
+  max-width:400px;
   overflow:auto;
   padding:0; }
   .bp3-select-popover .bp3-menu:not(:first-child){
@@ -8799,6 +9094,7 @@ Licensed under the Apache License, Version 2.0.
   --jp-icon-circle: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPGNpcmNsZSBjeD0iOSIgY3k9IjkiIHI9IjgiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-clear: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8bWFzayBpZD0iZG9udXRIb2xlIj4KICAgIDxyZWN0IHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0id2hpdGUiIC8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI4IiBmaWxsPSJibGFjayIvPgogIDwvbWFzaz4KCiAgPGcgY2xhc3M9ImpwLWljb24zIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxyZWN0IGhlaWdodD0iMTgiIHdpZHRoPSIyIiB4PSIxMSIgeT0iMyIgdHJhbnNmb3JtPSJyb3RhdGUoMzE1LCAxMiwgMTIpIi8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgbWFzaz0idXJsKCNkb251dEhvbGUpIi8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-close: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1ub25lIGpwLWljb24tc2VsZWN0YWJsZS1pbnZlcnNlIGpwLWljb24zLWhvdmVyIiBmaWxsPSJub25lIj4KICAgIDxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjExIi8+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIGpwLWljb24tYWNjZW50Mi1ob3ZlciIgZmlsbD0iIzYxNjE2MSI+CiAgICA8cGF0aCBkPSJNMTkgNi40MUwxNy41OSA1IDEyIDEwLjU5IDYuNDEgNSA1IDYuNDEgMTAuNTkgMTIgNSAxNy41OSA2LjQxIDE5IDEyIDEzLjQxIDE3LjU5IDE5IDE5IDE3LjU5IDEzLjQxIDEyeiIvPgogIDwvZz4KCiAgPGcgY2xhc3M9ImpwLWljb24tbm9uZSBqcC1pY29uLWJ1c3kiIGZpbGw9Im5vbmUiPgogICAgPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iNyIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-code: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyOCAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTExLjQgMTguNkw2LjggMTRMMTEuNCA5LjRMMTAgOEw0IDE0TDEwIDIwTDExLjQgMTguNlpNMTYuNiAxOC42TDIxLjIgMTRMMTYuNiA5LjRMMTggOEwyNCAxNEwxOCAyMEwxNi42IDE4LjZWMTguNloiLz4KCTwvZz4KPC9zdmc+Cg==);
   --jp-icon-console: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwMCAyMDAiPgogIDxnIGNsYXNzPSJqcC1pY29uLWJyYW5kMSBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiMwMjg4RDEiPgogICAgPHBhdGggZD0iTTIwIDE5LjhoMTYwdjE1OS45SDIweiIvPgogIDwvZz4KICA8ZyBjbGFzcz0ianAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNmZmYiPgogICAgPHBhdGggZD0iTTEwNSAxMjcuM2g0MHYxMi44aC00MHpNNTEuMSA3N0w3NCA5OS45bC0yMy4zIDIzLjMgMTAuNSAxMC41IDIzLjMtMjMuM0w5NSA5OS45IDg0LjUgODkuNCA2MS42IDY2LjV6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-copy: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTExLjksMUgzLjJDMi40LDEsMS43LDEuNywxLjcsMi41djEwLjJoMS41VjIuNWg4LjdWMXogTTE0LjEsMy45aC04Yy0wLjgsMC0xLjUsMC43LTEuNSwxLjV2MTAuMmMwLDAuOCwwLjcsMS41LDEuNSwxLjVoOCBjMC44LDAsMS41LTAuNywxLjUtMS41VjUuNEMxNS41LDQuNiwxNC45LDMuOSwxNC4xLDMuOXogTTE0LjEsMTUuNWgtOFY1LjRoOFYxNS41eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-cut: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTkuNjQgNy42NGMuMjMtLjUuMzYtMS4wNS4zNi0xLjY0IDAtMi4yMS0xLjc5LTQtNC00UzIgMy43OSAyIDZzMS43OSA0IDQgNGMuNTkgMCAxLjE0LS4xMyAxLjY0LS4zNkwxMCAxMmwtMi4zNiAyLjM2QzcuMTQgMTQuMTMgNi41OSAxNCA2IDE0Yy0yLjIxIDAtNCAxLjc5LTQgNHMxLjc5IDQgNCA0IDQtMS43OSA0LTRjMC0uNTktLjEzLTEuMTQtLjM2LTEuNjRMMTIgMTRsNyA3aDN2LTFMOS42NCA3LjY0ek02IDhjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTAgMTJjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTYtNy41Yy0uMjggMC0uNS0uMjItLjUtLjVzLjIyLS41LjUtLjUuNS4yMi41LjUtLjIyLjUtLjUuNXpNMTkgM2wtNiA2IDIgMiA3LTdWM3oiLz4KICA8L2c+Cjwvc3ZnPgo=);
@@ -8829,11 +9125,15 @@ Licensed under the Apache License, Version 2.0.
   --jp-icon-new-folder: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIwIDZoLThsLTItMkg0Yy0xLjExIDAtMS45OS44OS0xLjk5IDJMMiAxOGMwIDEuMTEuODkgMiAyIDJoMTZjMS4xMSAwIDItLjg5IDItMlY4YzAtMS4xMS0uODktMi0yLTJ6bS0xIDhoLTN2M2gtMnYtM2gtM3YtMmgzVjloMnYzaDN2MnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-not-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI1IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMTkgMTcuMTg0NCAyLjk2OTY4IDE0LjMwMzIgMS44NjA5NCAxMS40NDA5WiIvPgogICAgPHBhdGggY2xhc3M9ImpwLWljb24yIiBzdHJva2U9IiMzMzMzMzMiIHN0cm9rZS13aWR0aD0iMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOS4zMTU5MiA5LjMyMDMxKSIgZD0iTTcuMzY4NDIgMEwwIDcuMzY0NzkiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDkuMzE1OTIgMTYuNjgzNikgc2NhbGUoMSAtMSkiIGQ9Ik03LjM2ODQyIDBMMCA3LjM2NDc5Ii8+Cjwvc3ZnPgo=);
   --jp-icon-notebook: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNFRjZDMDAiPgogICAgPHBhdGggZD0iTTE4LjcgMy4zdjE1LjRIMy4zVjMuM2gxNS40bTEuNS0xLjVIMS44djE4LjNoMTguM2wuMS0xOC4zeiIvPgogICAgPHBhdGggZD0iTTE2LjUgMTYuNWwtNS40LTQuMy01LjYgNC4zdi0xMWgxMXoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-numbering: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyOCAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTQgMTlINlYxOS41SDVWMjAuNUg2VjIxSDRWMjJIN1YxOEg0VjE5Wk01IDEwSDZWNkg0VjdINVYxMFpNNCAxM0g1LjhMNCAxNS4xVjE2SDdWMTVINS4yTDcgMTIuOVYxMkg0VjEzWk05IDdWOUgyM1Y3SDlaTTkgMjFIMjNWMTlIOVYyMVpNOSAxNUgyM1YxM0g5VjE1WiIvPgoJPC9nPgo8L3N2Zz4K);
+  --jp-icon-offline-bolt: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjE2Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyIDIuMDJjLTUuNTEgMC05Ljk4IDQuNDctOS45OCA5Ljk4czQuNDcgOS45OCA5Ljk4IDkuOTggOS45OC00LjQ3IDkuOTgtOS45OFMxNy41MSAyLjAyIDEyIDIuMDJ6TTExLjQ4IDIwdi02LjI2SDhMMTMgNHY2LjI2aDMuMzVMMTEuNDggMjB6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-palette: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE4IDEzVjIwSDRWNkg5LjAyQzkuMDcgNS4yOSA5LjI0IDQuNjIgOS41IDRINEMyLjkgNCAyIDQuOSAyIDZWMjBDMiAyMS4xIDIuOSAyMiA0IDIySDE4QzE5LjEgMjIgMjAgMjEuMSAyMCAyMFYxNUwxOCAxM1pNMTkuMyA4Ljg5QzE5Ljc0IDguMTkgMjAgNy4zOCAyMCA2LjVDMjAgNC4wMSAxNy45OSAyIDE1LjUgMkMxMy4wMSAyIDExIDQuMDEgMTEgNi41QzExIDguOTkgMTMuMDEgMTEgMTUuNDkgMTFDMTYuMzcgMTEgMTcuMTkgMTAuNzQgMTcuODggMTAuM0wyMSAxMy40MkwyMi40MiAxMkwxOS4zIDguODlaTTE1LjUgOUMxNC4xMiA5IDEzIDcuODggMTMgNi41QzEzIDUuMTIgMTQuMTIgNCAxNS41IDRDMTYuODggNCAxOCA1LjEyIDE4IDYuNUMxOCA3Ljg4IDE2Ljg4IDkgMTUuNSA5WiIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDZIOS4wMTg5NEM5LjAwNjM5IDYuMTY1MDIgOSA2LjMzMTc2IDkgNi41QzkgOC44MTU3NyAxMC4yMTEgMTAuODQ4NyAxMi4wMzQzIDEySDlWMTRIMTZWMTIuOTgxMUMxNi41NzAzIDEyLjkzNzcgMTcuMTIgMTIuODIwNyAxNy42Mzk2IDEyLjYzOTZMMTggMTNWMjBINFY2Wk04IDhINlYxMEg4VjhaTTYgMTJIOFYxNEg2VjEyWk04IDE2SDZWMThIOFYxNlpNOSAxNkgxNlYxOEg5VjE2WiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-paste: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTE5IDJoLTQuMThDMTQuNC44NCAxMy4zIDAgMTIgMGMtMS4zIDAtMi40Ljg0LTIuODIgMkg1Yy0xLjEgMC0yIC45LTIgMnYxNmMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjRjMC0xLjEtLjktMi0yLTJ6bS03IDBjLjU1IDAgMSAuNDUgMSAxcy0uNDUgMS0xIDEtMS0uNDUtMS0xIC40NS0xIDEtMXptNyAxOEg1VjRoMnYzaDEwVjRoMnYxNnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-pdf: url(data:image/svg+xml;base64,PHN2ZwogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMiAyMiIgd2lkdGg9IjE2Ij4KICAgIDxwYXRoIHRyYW5zZm9ybT0icm90YXRlKDQ1KSIgY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iI0ZGMkEyQSIKICAgICAgIGQ9Im0gMjIuMzQ0MzY5LC0zLjAxNjM2NDIgaCA1LjYzODYwNCB2IDEuNTc5MjQzMyBoIC0zLjU0OTIyNyB2IDEuNTA4NjkyOTkgaCAzLjMzNzU3NiBWIDEuNjUwODE1NCBoIC0zLjMzNzU3NiB2IDMuNDM1MjYxMyBoIC0yLjA4OTM3NyB6IG0gLTcuMTM2NDQ0LDEuNTc5MjQzMyB2IDQuOTQzOTU0MyBoIDAuNzQ4OTIgcSAxLjI4MDc2MSwwIDEuOTUzNzAzLC0wLjYzNDk1MzUgMC42NzgzNjksLTAuNjM0OTUzNSAwLjY3ODM2OSwtMS44NDUxNjQxIDAsLTEuMjA0NzgzNTUgLTAuNjcyOTQyLC0xLjgzNDMxMDExIC0wLjY3Mjk0MiwtMC42Mjk1MjY1OSAtMS45NTkxMywtMC42Mjk1MjY1OSB6IG0gLTIuMDg5Mzc3LC0xLjU3OTI0MzMgaCAyLjIwMzM0MyBxIDEuODQ1MTY0LDAgMi43NDYwMzksMC4yNjU5MjA3IDAuOTA2MzAxLDAuMjYwNDkzNyAxLjU1MjEwOCwwLjg5MDAyMDMgMC41Njk4MywwLjU0ODEyMjMgMC44NDY2MDUsMS4yNjQ0ODAwNiAwLjI3Njc3NCwwLjcxNjM1NzgxIDAuMjc2Nzc0LDEuNjIyNjU4OTQgMCwwLjkxNzE1NTEgLTAuMjc2Nzc0LDEuNjM4OTM5OSAtMC4yNzY3NzUsMC43MTYzNTc4IC0wLjg0NjYwNSwxLjI2NDQ4IC0wLjY1MTIzNCwwLjYyOTUyNjYgLTEuNTYyOTYyLDAuODk1NDQ3MyAtMC45MTE3MjgsMC4yNjA0OTM3IC0yLjczNTE4NSwwLjI2MDQ5MzcgaCAtMi4yMDMzNDMgeiBtIC04LjE0NTg1NjUsMCBoIDMuNDY3ODIzIHEgMS41NDY2ODE2LDAgMi4zNzE1Nzg1LDAuNjg5MjIzIDAuODMwMzI0LDAuNjgzNzk2MSAwLjgzMDMyNCwxLjk1MzcwMzE0IDAsMS4yNzUzMzM5NyAtMC44MzAzMjQsMS45NjQ1NTcwNiBRIDkuOTg3MTk2MSwyLjI3NDkxNSA4LjQ0MDUxNDUsMi4yNzQ5MTUgSCA3LjA2MjA2ODQgViA1LjA4NjA3NjcgSCA0Ljk3MjY5MTUgWiBtIDIuMDg5Mzc2OSwxLjUxNDExOTkgdiAyLjI2MzAzOTQzIGggMS4xNTU5NDEgcSAwLjYwNzgxODgsMCAwLjkzODg2MjksLTAuMjkzMDU1NDcgMC4zMzEwNDQxLC0wLjI5ODQ4MjQxIDAuMzMxMDQ0MSwtMC44NDExNzc3MiAwLC0wLjU0MjY5NTMxIC0wLjMzMTA0NDEsLTAuODM1NzUwNzQgLTAuMzMxMDQ0MSwtMC4yOTMwNTU1IC0wLjkzODg2MjksLTAuMjkzMDU1NSB6IgovPgo8L3N2Zz4K);
   --jp-icon-python: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1icmFuZDAganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMEQ0N0ExIj4KICAgIDxwYXRoIGQ9Ik0xMS4xIDYuOVY1LjhINi45YzAtLjUgMC0xLjMuMi0xLjYuNC0uNy44LTEuMSAxLjctMS40IDEuNy0uMyAyLjUtLjMgMy45LS4xIDEgLjEgMS45LjkgMS45IDEuOXY0LjJjMCAuNS0uOSAxLjYtMiAxLjZIOC44Yy0xLjUgMC0yLjQgMS40LTIuNCAyLjh2Mi4ySDQuN0MzLjUgMTUuMSAzIDE0IDMgMTMuMVY5Yy0uMS0xIC42LTIgMS44LTIgMS41LS4xIDYuMy0uMSA2LjMtLjF6Ii8+CiAgICA8cGF0aCBkPSJNMTAuOSAxNS4xdjEuMWg0LjJjMCAuNSAwIDEuMy0uMiAxLjYtLjQuNy0uOCAxLjEtMS43IDEuNC0xLjcuMy0yLjUuMy0zLjkuMS0xLS4xLTEuOS0uOS0xLjktMS45di00LjJjMC0uNS45LTEuNiAyLTEuNmgzLjhjMS41IDAgMi40LTEuNCAyLjQtMi44VjYuNmgxLjdDMTguNSA2LjkgMTkgOCAxOSA4LjlWMTNjMCAxLS43IDIuMS0xLjkgMi4xaC02LjJ6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-r-kernel: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjE5NkYzIiBkPSJNNC40IDIuNWMxLjItLjEgMi45LS4zIDQuOS0uMyAyLjUgMCA0LjEuNCA1LjIgMS4zIDEgLjcgMS41IDEuOSAxLjUgMy41IDAgMi0xLjQgMy41LTIuOSA0LjEgMS4yLjQgMS43IDEuNiAyLjIgMyAuNiAxLjkgMSAzLjkgMS4zIDQuNmgtMy44Yy0uMy0uNC0uOC0xLjctMS4yLTMuN3MtMS4yLTIuNi0yLjYtMi42aC0uOXY2LjRINC40VjIuNXptMy43IDYuOWgxLjRjMS45IDAgMi45LS45IDIuOS0yLjNzLTEtMi4zLTIuOC0yLjNjLS43IDAtMS4zIDAtMS42LjJ2NC41aC4xdi0uMXoiLz4KPC9zdmc+Cg==);
   --jp-icon-react: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMTUwIDE1MCA1NDEuOSAyOTUuMyI+CiAgPGcgY2xhc3M9ImpwLWljb24tYnJhbmQyIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzYxREFGQiI+CiAgICA8cGF0aCBkPSJNNjY2LjMgMjk2LjVjMC0zMi41LTQwLjctNjMuMy0xMDMuMS04Mi40IDE0LjQtNjMuNiA4LTExNC4yLTIwLjItMTMwLjQtNi41LTMuOC0xNC4xLTUuNi0yMi40LTUuNnYyMi4zYzQuNiAwIDguMy45IDExLjQgMi42IDEzLjYgNy44IDE5LjUgMzcuNSAxNC45IDc1LjctMS4xIDkuNC0yLjkgMTkuMy01LjEgMjkuNC0xOS42LTQuOC00MS04LjUtNjMuNS0xMC45LTEzLjUtMTguNS0yNy41LTM1LjMtNDEuNi01MCAzMi42LTMwLjMgNjMuMi00Ni45IDg0LTQ2LjlWNzhjLTI3LjUgMC02My41IDE5LjYtOTkuOSA1My42LTM2LjQtMzMuOC03Mi40LTUzLjItOTkuOS01My4ydjIyLjNjMjAuNyAwIDUxLjQgMTYuNSA4NCA0Ni42LTE0IDE0LjctMjggMzEuNC00MS4zIDQ5LjktMjIuNiAyLjQtNDQgNi4xLTYzLjYgMTEtMi4zLTEwLTQtMTkuNy01LjItMjktNC43LTM4LjIgMS4xLTY3LjkgMTQuNi03NS44IDMtMS44IDYuOS0yLjYgMTEuNS0yLjZWNzguNWMtOC40IDAtMTYgMS44LTIyLjYgNS42LTI4LjEgMTYuMi0zNC40IDY2LjctMTkuOSAxMzAuMS02Mi4yIDE5LjItMTAyLjcgNDkuOS0xMDIuNyA4Mi4zIDAgMzIuNSA0MC43IDYzLjMgMTAzLjEgODIuNC0xNC40IDYzLjYtOCAxMTQuMiAyMC4yIDEzMC40IDYuNSAzLjggMTQuMSA1LjYgMjIuNSA1LjYgMjcuNSAwIDYzLjUtMTkuNiA5OS45LTUzLjYgMzYuNCAzMy44IDcyLjQgNTMuMiA5OS45IDUzLjIgOC40IDAgMTYtMS44IDIyLjYtNS42IDI4LjEtMTYuMiAzNC40LTY2LjcgMTkuOS0xMzAuMSA2Mi0xOS4xIDEwMi41LTQ5LjkgMTAyLjUtODIuM3ptLTEzMC4yLTY2LjdjLTMuNyAxMi45LTguMyAyNi4yLTEzLjUgMzkuNS00LjEtOC04LjQtMTYtMTMuMS0yNC00LjYtOC05LjUtMTUuOC0xNC40LTIzLjQgMTQuMiAyLjEgMjcuOSA0LjcgNDEgNy45em0tNDUuOCAxMDYuNWMtNy44IDEzLjUtMTUuOCAyNi4zLTI0LjEgMzguMi0xNC45IDEuMy0zMCAyLTQ1LjIgMi0xNS4xIDAtMzAuMi0uNy00NS0xLjktOC4zLTExLjktMTYuNC0yNC42LTI0LjItMzgtNy42LTEzLjEtMTQuNS0yNi40LTIwLjgtMzkuOCA2LjItMTMuNCAxMy4yLTI2LjggMjAuNy0zOS45IDcuOC0xMy41IDE1LjgtMjYuMyAyNC4xLTM4LjIgMTQuOS0xLjMgMzAtMiA0NS4yLTIgMTUuMSAwIDMwLjIuNyA0NSAxLjkgOC4zIDExLjkgMTYuNCAyNC42IDI0LjIgMzggNy42IDEzLjEgMTQuNSAyNi40IDIwLjggMzkuOC02LjMgMTMuNC0xMy4yIDI2LjgtMjAuNyAzOS45em0zMi4zLTEzYzUuNCAxMy40IDEwIDI2LjggMTMuOCAzOS44LTEzLjEgMy4yLTI2LjkgNS45LTQxLjIgOCA0LjktNy43IDkuOC0xNS42IDE0LjQtMjMuNyA0LjYtOCA4LjktMTYuMSAxMy0yNC4xek00MjEuMiA0MzBjLTkuMy05LjYtMTguNi0yMC4zLTI3LjgtMzIgOSAuNCAxOC4yLjcgMjcuNS43IDkuNCAwIDE4LjctLjIgMjcuOC0uNy05IDExLjctMTguMyAyMi40LTI3LjUgMzJ6bS03NC40LTU4LjljLTE0LjItMi4xLTI3LjktNC43LTQxLTcuOSAzLjctMTIuOSA4LjMtMjYuMiAxMy41LTM5LjUgNC4xIDggOC40IDE2IDEzLjEgMjQgNC43IDggOS41IDE1LjggMTQuNCAyMy40ek00MjAuNyAxNjNjOS4zIDkuNiAxOC42IDIwLjMgMjcuOCAzMi05LS40LTE4LjItLjctMjcuNS0uNy05LjQgMC0xOC43LjItMjcuOC43IDktMTEuNyAxOC4zLTIyLjQgMjcuNS0zMnptLTc0IDU4LjljLTQuOSA3LjctOS44IDE1LjYtMTQuNCAyMy43LTQuNiA4LTguOSAxNi0xMyAyNC01LjQtMTMuNC0xMC0yNi44LTEzLjgtMzkuOCAxMy4xLTMuMSAyNi45LTUuOCA0MS4yLTcuOXptLTkwLjUgMTI1LjJjLTM1LjQtMTUuMS01OC4zLTM0LjktNTguMy01MC42IDAtMTUuNyAyMi45LTM1LjYgNTguMy01MC42IDguNi0zLjcgMTgtNyAyNy43LTEwLjEgNS43IDE5LjYgMTMuMiA0MCAyMi41IDYwLjktOS4yIDIwLjgtMTYuNiA0MS4xLTIyLjIgNjAuNi05LjktMy4xLTE5LjMtNi41LTI4LTEwLjJ6TTMxMCA0OTBjLTEzLjYtNy44LTE5LjUtMzcuNS0xNC45LTc1LjcgMS4xLTkuNCAyLjktMTkuMyA1LjEtMjkuNCAxOS42IDQuOCA0MSA4LjUgNjMuNSAxMC45IDEzLjUgMTguNSAyNy41IDM1LjMgNDEuNiA1MC0zMi42IDMwLjMtNjMuMiA0Ni45LTg0IDQ2LjktNC41LS4xLTguMy0xLTExLjMtMi43em0yMzcuMi03Ni4yYzQuNyAzOC4yLTEuMSA2Ny45LTE0LjYgNzUuOC0zIDEuOC02LjkgMi42LTExLjUgMi42LTIwLjcgMC01MS40LTE2LjUtODQtNDYuNiAxNC0xNC43IDI4LTMxLjQgNDEuMy00OS45IDIyLjYtMi40IDQ0LTYuMSA2My42LTExIDIuMyAxMC4xIDQuMSAxOS44IDUuMiAyOS4xem0zOC41LTY2LjdjLTguNiAzLjctMTggNy0yNy43IDEwLjEtNS43LTE5LjYtMTMuMi00MC0yMi41LTYwLjkgOS4yLTIwLjggMTYuNi00MS4xIDIyLjItNjAuNiA5LjkgMy4xIDE5LjMgNi41IDI4LjEgMTAuMiAzNS40IDE1LjEgNTguMyAzNC45IDU4LjMgNTAuNi0uMSAxNS43LTIzIDM1LjYtNTguNCA1MC42ek0zMjAuOCA3OC40eiIvPgogICAgPGNpcmNsZSBjeD0iNDIwLjkiIGN5PSIyOTYuNSIgcj0iNDUuNyIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-redo: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjE2Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgICA8cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTE4LjQgMTAuNkMxNi41NSA4Ljk5IDE0LjE1IDggMTEuNSA4Yy00LjY1IDAtOC41OCAzLjAzLTkuOTYgNy4yMkwzLjkgMTZjMS4wNS0zLjE5IDQuMDUtNS41IDcuNi01LjUgMS45NSAwIDMuNzMuNzIgNS4xMiAxLjg4TDEzIDE2aDlWN2wtMy42IDMuNnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-refresh: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTkgMTMuNWMtMi40OSAwLTQuNS0yLjAxLTQuNS00LjVTNi41MSA0LjUgOSA0LjVjMS4yNCAwIDIuMzYuNTIgMy4xNyAxLjMzTDEwIDhoNVYzbC0xLjc2IDEuNzZDMTIuMTUgMy42OCAxMC42NiAzIDkgMyA1LjY5IDMgMy4wMSA1LjY5IDMuMDEgOVM1LjY5IDE1IDkgMTVjMi45NyAwIDUuNDMtMi4xNiA1LjktNWgtMS41MmMtLjQ2IDItMi4yNCAzLjUtNC4zOCAzLjV6Ii8+CiAgICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-regex: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwIDIwIj4KICA8ZyBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiM0MTQxNDEiPgogICAgPHJlY3QgeD0iMiIgeT0iMiIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbi1hY2NlbnQyIiBmaWxsPSIjRkZGIj4KICAgIDxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjUuNSIgY3k9IjE0LjUiIHI9IjEuNSIvPgogICAgPHJlY3QgeD0iMTIiIHk9IjQiIGNsYXNzPSJzdDIiIHdpZHRoPSIxIiBoZWlnaHQ9IjgiLz4KICAgIDxyZWN0IHg9IjguNSIgeT0iNy41IiB0cmFuc2Zvcm09Im1hdHJpeCgwLjg2NiAtMC41IDAuNSAwLjg2NiAtMi4zMjU1IDcuMzIxOSkiIGNsYXNzPSJzdDIiIHdpZHRoPSI4IiBoZWlnaHQ9IjEiLz4KICAgIDxyZWN0IHg9IjEyIiB5PSI0IiB0cmFuc2Zvcm09Im1hdHJpeCgwLjUgLTAuODY2IDAuODY2IDAuNSAtMC42Nzc5IDE0LjgyNTIpIiBjbGFzcz0ic3QyIiB3aWR0aD0iMSIgaGVpZ2h0PSI4Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-run: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTggNXYxNGwxMS03eiIvPgogICAgPC9nPgo8L3N2Zz4K);
@@ -8844,8 +9144,12 @@ Licensed under the Apache License, Version 2.0.
   --jp-icon-spreadsheet: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNENBRjUwIiBkPSJNMi4yIDIuMnYxNy42aDE3LjZWMi4ySDIuMnptMTUuNCA3LjdoLTUuNVY0LjRoNS41djUuNXpNOS45IDQuNHY1LjVINC40VjQuNGg1LjV6bS01LjUgNy43aDUuNXY1LjVINC40di01LjV6bTcuNyA1LjV2LTUuNWg1LjV2NS41aC01LjV6Ii8+Cjwvc3ZnPgo=);
   --jp-icon-stop: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik02IDZoMTJ2MTJINnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-tab: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIxIDNIM2MtMS4xIDAtMiAuOS0yIDJ2MTRjMCAxLjEuOSAyIDIgMmgxOGMxLjEgMCAyLS45IDItMlY1YzAtMS4xLS45LTItMi0yem0wIDE2SDNWNWgxMHY0aDh2MTB6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-table-rows: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik0yMSw4SDNWNGgxOFY4eiBNMjEsMTBIM3Y0aDE4VjEweiBNMjEsMTZIM3Y0aDE4VjE2eiIvPgogICAgPC9nPgo8L3N2Zz4=);
+  --jp-icon-tag: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjgiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCA0MyAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTI4LjgzMzIgMTIuMzM0TDMyLjk5OTggMTYuNTAwN0wzNy4xNjY1IDEyLjMzNEgyOC44MzMyWiIvPgoJCTxwYXRoIGQ9Ik0xNi4yMDk1IDIxLjYxMDRDMTUuNjg3MyAyMi4xMjk5IDE0Ljg0NDMgMjIuMTI5OSAxNC4zMjQ4IDIxLjYxMDRMNi45ODI5IDE0LjcyNDVDNi41NzI0IDE0LjMzOTQgNi4wODMxMyAxMy42MDk4IDYuMDQ3ODYgMTMuMDQ4MkM1Ljk1MzQ3IDExLjUyODggNi4wMjAwMiA4LjYxOTQ0IDYuMDY2MjEgNy4wNzY5NUM2LjA4MjgxIDYuNTE0NzcgNi41NTU0OCA2LjA0MzQ3IDcuMTE4MDQgNi4wMzA1NUM5LjA4ODYzIDUuOTg0NzMgMTMuMjYzOCA1LjkzNTc5IDEzLjY1MTggNi4zMjQyNUwyMS43MzY5IDEzLjYzOUMyMi4yNTYgMTQuMTU4NSAyMS43ODUxIDE1LjQ3MjQgMjEuMjYyIDE1Ljk5NDZMMTYuMjA5NSAyMS42MTA0Wk05Ljc3NTg1IDguMjY1QzkuMzM1NTEgNy44MjU2NiA4LjYyMzUxIDcuODI1NjYgOC4xODI4IDguMjY1QzcuNzQzNDYgOC43MDU3MSA3Ljc0MzQ2IDkuNDE3MzMgOC4xODI4IDkuODU2NjdDOC42MjM4MiAxMC4yOTY0IDkuMzM1ODIgMTAuMjk2NCA5Ljc3NTg1IDkuODU2NjdDMTAuMjE1NiA5LjQxNzMzIDEwLjIxNTYgOC43MDUzMyA5Ljc3NTg1IDguMjY1WiIvPgoJPC9nPgo8L3N2Zz4K);
   --jp-icon-terminal: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiA+CiAgICA8cmVjdCBjbGFzcz0ianAtaWNvbjIganAtaWNvbi1zZWxlY3RhYmxlIiB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMikiIGZpbGw9IiMzMzMzMzMiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uLWFjY2VudDIganAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGQ9Ik01LjA1NjY0IDguNzYxNzJDNS4wNTY2NCA4LjU5NzY2IDUuMDMxMjUgOC40NTMxMiA0Ljk4MDQ3IDguMzI4MTJDNC45MzM1OSA4LjE5OTIyIDQuODU1NDcgOC4wODIwMyA0Ljc0NjA5IDcuOTc2NTZDNC42NDA2MiA3Ljg3MTA5IDQuNSA3Ljc3NTM5IDQuMzI0MjIgNy42ODk0NUM0LjE1MjM0IDcuNTk5NjEgMy45NDMzNiA3LjUxMTcyIDMuNjk3MjcgNy40MjU3OEMzLjMwMjczIDcuMjg1MTYgMi45NDMzNiA3LjEzNjcyIDIuNjE5MTQgNi45ODA0N0MyLjI5NDkyIDYuODI0MjIgMi4wMTc1OCA2LjY0MjU4IDEuNzg3MTEgNi40MzU1NUMxLjU2MDU1IDYuMjI4NTIgMS4zODQ3NyA1Ljk4ODI4IDEuMjU5NzcgNS43MTQ4NEMxLjEzNDc3IDUuNDM3NSAxLjA3MjI3IDUuMTA5MzggMS4wNzIyNyA0LjczMDQ3QzEuMDcyMjcgNC4zOTg0NCAxLjEyODkxIDQuMDk1NyAxLjI0MjE5IDMuODIyMjdDMS4zNTU0NyAzLjU0NDkyIDEuNTE1NjIgMy4zMDQ2OSAxLjcyMjY2IDMuMTAxNTZDMS45Mjk2OSAyLjg5ODQ0IDIuMTc5NjkgMi43MzQzNyAyLjQ3MjY2IDIuNjA5MzhDMi43NjU2MiAyLjQ4NDM4IDMuMDkxOCAyLjQwNDMgMy40NTExNyAyLjM2OTE0VjEuMTA5MzhINC4zODg2N1YyLjM4MDg2QzQuNzQwMjMgMi40Mjc3MyA1LjA1NjY0IDIuNTIzNDQgNS4zMzc4OSAyLjY2Nzk3QzUuNjE5MTQgMi44MTI1IDUuODU3NDIgMy4wMDE5NSA2LjA1MjczIDMuMjM2MzNDNi4yNTE5NSAzLjQ2NjggNi40MDQzIDMuNzQwMjMgNi41MDk3NyA0LjA1NjY0QzYuNjE5MTQgNC4zNjkxNCA2LjY3MzgzIDQuNzIwNyA2LjY3MzgzIDUuMTExMzNINS4wNDQ5MkM1LjA0NDkyIDQuNjM4NjcgNC45Mzc1IDQuMjgxMjUgNC43MjI2NiA0LjAzOTA2QzQuNTA3ODEgMy43OTI5NyA0LjIxNjggMy42Njk5MiAzLjg0OTYxIDMuNjY5OTJDMy42NTAzOSAzLjY2OTkyIDMuNDc2NTYgMy42OTcyNyAzLjMyODEyIDMuNzUxOTVDMy4xODM1OSAzLjgwMjczIDMuMDY0NDUgMy44NzY5NSAyLjk3MDcgMy45NzQ2MUMyLjg3Njk1IDQuMDY4MzYgMi44MDY2NCA0LjE3OTY5IDIuNzU5NzcgNC4zMDg1OUMyLjcxNjggNC40Mzc1IDIuNjk1MzEgNC41NzgxMiAyLjY5NTMxIDQuNzMwNDdDMi42OTUzMSA0Ljg4MjgxIDIuNzE2OCA1LjAxOTUzIDIuNzU5NzcgNS4xNDA2MkMyLjgwNjY0IDUuMjU3ODEgMi44ODI4MSA1LjM2NzE5IDIuOTg4MjggNS40Njg3NUMzLjA5NzY2IDUuNTcwMzEgMy4yNDAyMyA1LjY2Nzk3IDMuNDE2MDIgNS43NjE3MkMzLjU5MTggNS44NTE1NiAzLjgxMDU1IDUuOTQzMzYgNC4wNzIyNyA2LjAzNzExQzQuNDY2OCA2LjE4NTU1IDQuODI0MjIgNi4zMzk4NCA1LjE0NDUzIDYuNUM1LjQ2NDg0IDYuNjU2MjUgNS43MzgyOCA2LjgzOTg0IDUuOTY0ODQgNy4wNTA3OEM2LjE5NTMxIDcuMjU3ODEgNi4zNzEwOSA3LjUgNi40OTIxOSA3Ljc3NzM0QzYuNjE3MTkgOC4wNTA3OCA2LjY3OTY5IDguMzc1IDYuNjc5NjkgOC43NUM2LjY3OTY5IDkuMDkzNzUgNi42MjMwNSA5LjQwNDMgNi41MDk3NyA5LjY4MTY0QzYuMzk2NDggOS45NTUwOCA2LjIzNDM4IDEwLjE5MTQgNi4wMjM0NCAxMC4zOTA2QzUuODEyNSAxMC41ODk4IDUuNTU4NTkgMTAuNzUgNS4yNjE3MiAxMC44NzExQzQuOTY0ODQgMTAuOTg4MyA0LjYzMjgxIDExLjA2NDUgNC4yNjU2MiAxMS4wOTk2VjEyLjI0OEgzLjMzMzk4VjExLjA5OTZDMy4wMDE5NSAxMS4wNjg0IDIuNjc5NjkgMTAuOTk2MSAyLjM2NzE5IDEwLjg4MjhDMi4wNTQ2OSAxMC43NjU2IDEuNzc3MzQgMTAuNTk3NyAxLjUzNTE2IDEwLjM3ODlDMS4yOTY4OCAxMC4xNjAyIDEuMTA1NDcgOS44ODQ3NyAwLjk2MDkzOCA5LjU1MjczQzAuODE2NDA2IDkuMjE2OCAwLjc0NDE0MSA4LjgxNDQ1IDAuNzQ0MTQxIDguMzQ1N0gyLjM3ODkxQzIuMzc4OTEgOC42MjY5NSAyLjQxOTkyIDguODYzMjggMi41MDE5NSA5LjA1NDY5QzIuNTgzOTggOS4yNDIxOSAyLjY4OTQ1IDkuMzkyNTggMi44MTgzNiA5LjUwNTg2QzIuOTUxMTcgOS42MTUyMyAzLjEwMTU2IDkuNjkzMzYgMy4yNjk1MyA5Ljc0MDIzQzMuNDM3NSA5Ljc4NzExIDMuNjA5MzggOS44MTA1NSAzLjc4NTE2IDkuODEwNTVDNC4yMDMxMiA5LjgxMDU1IDQuNTE5NTMgOS43MTI4OSA0LjczNDM4IDkuNTE3NThDNC45NDkyMiA5LjMyMjI3IDUuMDU2NjQgOS4wNzAzMSA1LjA1NjY0IDguNzYxNzJaTTEzLjQxOCAxMi4yNzE1SDguMDc0MjJWMTFIMTMuNDE4VjEyLjI3MTVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzLjk1MjY0IDYpIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K);
   --jp-icon-text-editor: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-toc: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgoJPHBhdGggZD0iTTcsNUgyMVY3SDdWNU03LDEzVjExSDIxVjEzSDdNNCw0LjVBMS41LDEuNSAwIDAsMSA1LjUsNkExLjUsMS41IDAgMCwxIDQsNy41QTEuNSwxLjUgMCAwLDEgMi41LDZBMS41LDEuNSAwIDAsMSA0LDQuNU00LDEwLjVBMS41LDEuNSAwIDAsMSA1LjUsMTJBMS41LDEuNSAwIDAsMSA0LDEzLjVBMS41LDEuNSAwIDAsMSAyLjUsMTJBMS41LDEuNSAwIDAsMSA0LDEwLjVNNywxOVYxN0gyMVYxOUg3TTQsMTYuNUExLjUsMS41IDAgMCwxIDUuNSwxOEExLjUsMS41IDAgMCwxIDQsMTkuNUExLjUsMS41IDAgMCwxIDIuNSwxOEExLjUsMS41IDAgMCwxIDQsMTYuNVoiIC8+Cjwvc3ZnPgo=);
+  --jp-icon-tree-view: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik0yMiAxMVYzaC03djNIOVYzSDJ2OGg3VjhoMnYxMGg0djNoN3YtOGgtN3YzaC0yVjhoMnYzeiIvPgogICAgPC9nPgo8L3N2Zz4=);
   --jp-icon-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMiAxNy4xODQ0IDIuOTY5NjggMTQuMzAzMiAxLjg2MDk0IDExLjQ0MDlaIi8+CiAgICA8cGF0aCBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiMzMzMzMzMiIHN0cm9rZT0iIzMzMzMzMyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOCA5Ljg2NzE5KSIgZD0iTTIuODYwMTUgNC44NjUzNUwwLjcyNjU0OSAyLjk5OTU5TDAgMy42MzA0NUwyLjg2MDE1IDYuMTMxNTdMOCAwLjYzMDg3Mkw3LjI3ODU3IDBMMi44NjAxNSA0Ljg2NTM1WiIvPgo8L3N2Zz4K);
   --jp-icon-undo: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyLjUgOGMtMi42NSAwLTUuMDUuOTktNi45IDIuNkwyIDd2OWg5bC0zLjYyLTMuNjJjMS4zOS0xLjE2IDMuMTYtMS44OCA1LjEyLTEuODggMy41NCAwIDYuNTUgMi4zMSA3LjYgNS41bDIuMzctLjc4QzIxLjA4IDExLjAzIDE3LjE1IDggMTIuNSA4eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-vega: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbjEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjEyMTIxIj4KICAgIDxwYXRoIGQ9Ik0xMC42IDUuNGwyLjItMy4ySDIuMnY3LjNsNC02LjZ6Ii8+CiAgICA8cGF0aCBkPSJNMTUuOCAyLjJsLTQuNCA2LjZMNyA2LjNsLTQuOCA4djUuNWgxNy42VjIuMmgtNHptLTcgMTUuNEg1LjV2LTQuNGgzLjN2NC40em00LjQgMEg5LjhWOS44aDMuNHY3Ljh6bTQuNCAwaC0zLjRWNi41aDMuNHYxMS4xeiIvPgogIDwvZz4KPC9zdmc+Cg==);
@@ -8901,6 +9205,9 @@ Licensed under the Apache License, Version 2.0.
 }
 .jp-CloseIcon {
   background-image: var(--jp-icon-close);
+}
+.jp-CodeIcon {
+  background-image: var(--jp-icon-code);
 }
 .jp-ConsoleIcon {
   background-image: var(--jp-icon-console);
@@ -8992,11 +9299,20 @@ Licensed under the Apache License, Version 2.0.
 .jp-NotebookIcon {
   background-image: var(--jp-icon-notebook);
 }
+.jp-NumberingIcon {
+  background-image: var(--jp-icon-numbering);
+}
+.jp-OfflineBoltIcon {
+  background-image: var(--jp-icon-offline-bolt);
+}
 .jp-PaletteIcon {
   background-image: var(--jp-icon-palette);
 }
 .jp-PasteIcon {
   background-image: var(--jp-icon-paste);
+}
+.jp-PdfIcon {
+  background-image: var(--jp-icon-pdf);
 }
 .jp-PythonIcon {
   background-image: var(--jp-icon-python);
@@ -9006,6 +9322,9 @@ Licensed under the Apache License, Version 2.0.
 }
 .jp-ReactIcon {
   background-image: var(--jp-icon-react);
+}
+.jp-RedoIcon {
+  background-image: var(--jp-icon-redo);
 }
 .jp-RefreshIcon {
   background-image: var(--jp-icon-refresh);
@@ -9037,11 +9356,23 @@ Licensed under the Apache License, Version 2.0.
 .jp-TabIcon {
   background-image: var(--jp-icon-tab);
 }
+.jp-TableRowsIcon {
+  background-image: var(--jp-icon-table-rows);
+}
+.jp-TagIcon {
+  background-image: var(--jp-icon-tag);
+}
 .jp-TerminalIcon {
   background-image: var(--jp-icon-terminal);
 }
 .jp-TextEditorIcon {
   background-image: var(--jp-icon-text-editor);
+}
+.jp-TocIcon {
+  background-image: var(--jp-icon-toc);
+}
+.jp-TreeViewIcon {
+  background-image: var(--jp-icon-tree-view);
 }
 .jp-TrustedIcon {
   background-image: var(--jp-icon-trusted);
@@ -9625,6 +9956,64 @@ Licensed under the Apache License, Version 2.0.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-switch {
+  display: flex;
+  align-items: center;
+  padding-left: 4px;
+  padding-right: 4px;
+  font-size: var(--jp-ui-font-size1);
+  background-color: transparent;
+  color: var(--jp-ui-font-color1);
+  border: none;
+  height: 20px;
+}
+
+.jp-switch:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.jp-switch-label {
+  margin-right: 5px;
+}
+
+.jp-switch-track {
+  cursor: pointer;
+  background-color: var(--jp-border-color1);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 34px;
+  height: 16px;
+  width: 35px;
+  position: relative;
+}
+
+.jp-switch-track::before {
+  content: '';
+  position: absolute;
+  height: 10px;
+  width: 10px;
+  margin: 3px;
+  left: 0px;
+  background-color: var(--jp-ui-inverse-font-color1);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+.jp-switch[aria-checked='true'] .jp-switch-track {
+  background-color: var(--jp-warn-color0);
+}
+
+.jp-switch[aria-checked='true'] .jp-switch-track::before {
+  /* track width (35) - margins (3 + 3) - thumb width (10) */
+  left: 19px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
 /* Sibling imports */
 
 /* Override Blueprint's _reset.scss styles */
@@ -9757,13 +10146,6 @@ select {
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
 .jp-Collapse {
   display: flex;
   flex-direction: column;
@@ -9814,6 +10196,46 @@ select {
   /* This is needed so that all font sizing of children done in ems is
    * relative to this base size */
   font-size: var(--jp-ui-font-size1);
+}
+
+/*-----------------------------------------------------------------------------
+| Modal variant
+|----------------------------------------------------------------------------*/
+
+.jp-ModalCommandPalette {
+  position: absolute;
+  z-index: 10000;
+  top: 38px;
+  left: 30%;
+  margin: 0;
+  padding: 4px;
+  width: 40%;
+  box-shadow: var(--jp-elevation-z4);
+  border-radius: 4px;
+  background: var(--jp-layout-color0);
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette {
+  max-height: 40vh;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-close-icon::after {
+  display: none;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-header {
+  display: none;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-item {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+
+.jp-ModalCommandPalette
+  .lm-CommandPalette
+  .lm-CommandPalette-item.lm-mod-disabled {
+  display: none;
 }
 
 /*-----------------------------------------------------------------------------
@@ -10027,6 +10449,7 @@ select {
    * relative to this base size */
   font-size: var(--jp-ui-font-size1);
   color: var(--jp-ui-font-color1);
+  resize: both;
 }
 
 .jp-Dialog-button {
@@ -10043,7 +10466,16 @@ button.jp-Dialog-button:focus::-moz-focus-inner {
   border: 0;
 }
 
+button.jp-Dialog-close-button {
+  padding: 0;
+  height: 100%;
+  min-width: unset;
+  min-height: unset;
+}
+
 .jp-Dialog-header {
+  display: flex;
+  justify-content: space-between;
   flex: 0 0 auto;
   padding-bottom: 12px;
   font-size: var(--jp-ui-font-size3);
@@ -10616,6 +11048,11 @@ select.jp-mod-styled {
   min-height: var(--jp-toolbar-micro-height);
   padding: 2px;
   z-index: 1;
+  overflow-x: hidden;
+}
+
+.jp-Toolbar:hover {
+  overflow-x: auto;
 }
 
 /* Toolbar items */
@@ -10694,18 +11131,25 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   color: var(--jp-ui-font-color1);
 }
 
+#jp-main-dock-panel[data-mode='single-document']
+  .jp-MainAreaWidget
+  > .jp-Toolbar.jp-Toolbar-micro {
+  padding: 0;
+  min-height: 0;
+}
+
+#jp-main-dock-panel[data-mode='single-document']
+  .jp-MainAreaWidget
+  > .jp-Toolbar {
+  border: none;
+  box-shadow: none;
+}
+
 /*-----------------------------------------------------------------------------
 | Copyright (c) 2014-2017, Jupyter Development Team.
 |
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -10776,18 +11220,6 @@ body.lm-mod-override-cursor * {
   border: var(--jp-border-width) solid var(--jp-input-active-border-color);
   box-shadow: var(--jp-input-box-shadow);
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
 
 /* BASICS */
 
@@ -10955,17 +11387,17 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
 
 .CodeMirror-scroll {
   overflow: scroll !important; /* Things will break if this is overridden */
-  /* 30px is the magic margin used to hide the element's real scrollbars */
+  /* 50px is the magic margin used to hide the element's real scrollbars */
   /* See overflow: hidden in .CodeMirror */
-  margin-bottom: -30px; margin-right: -30px;
-  padding-bottom: 30px;
+  margin-bottom: -50px; margin-right: -50px;
+  padding-bottom: 50px;
   height: 100%;
   outline: none; /* Prevent dragging from highlighting the element */
   position: relative;
 }
 .CodeMirror-sizer {
   position: relative;
-  border-right: 30px solid transparent;
+  border-right: 50px solid transparent;
 }
 
 /* The fake, visible scrollbars. Used to force redraw during scrolling
@@ -11003,7 +11435,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   height: 100%;
   display: inline-block;
   vertical-align: top;
-  margin-bottom: -30px;
+  margin-bottom: -50px;
 }
 .CodeMirror-gutter-wrapper {
   position: absolute;
@@ -11193,740 +11625,6 @@ span.CodeMirror-selectedtext { background: none; }
   content: "\25B8";
 }
 
-/*
-  Name:       material
-  Author:     Mattia Astorino (http://github.com/equinusocio)
-  Website:    https://material-theme.site/
-*/
-
-.cm-s-material.CodeMirror {
-  background-color: #263238;
-  color: #EEFFFF;
-}
-
-.cm-s-material .CodeMirror-gutters {
-  background: #263238;
-  color: #546E7A;
-  border: none;
-}
-
-.cm-s-material .CodeMirror-guttermarker,
-.cm-s-material .CodeMirror-guttermarker-subtle,
-.cm-s-material .CodeMirror-linenumber {
-  color: #546E7A;
-}
-
-.cm-s-material .CodeMirror-cursor {
-  border-left: 1px solid #FFCC00;
-}
-
-.cm-s-material div.CodeMirror-selected {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material.CodeMirror-focused div.CodeMirror-selected {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material .CodeMirror-line::selection,
-.cm-s-material .CodeMirror-line>span::selection,
-.cm-s-material .CodeMirror-line>span>span::selection {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material .CodeMirror-line::-moz-selection,
-.cm-s-material .CodeMirror-line>span::-moz-selection,
-.cm-s-material .CodeMirror-line>span>span::-moz-selection {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material .CodeMirror-activeline-background {
-  background: rgba(0, 0, 0, 0.5);
-}
-
-.cm-s-material .cm-keyword {
-  color: #C792EA;
-}
-
-.cm-s-material .cm-operator {
-  color: #89DDFF;
-}
-
-.cm-s-material .cm-variable-2 {
-  color: #EEFFFF;
-}
-
-.cm-s-material .cm-variable-3,
-.cm-s-material .cm-type {
-  color: #f07178;
-}
-
-.cm-s-material .cm-builtin {
-  color: #FFCB6B;
-}
-
-.cm-s-material .cm-atom {
-  color: #F78C6C;
-}
-
-.cm-s-material .cm-number {
-  color: #FF5370;
-}
-
-.cm-s-material .cm-def {
-  color: #82AAFF;
-}
-
-.cm-s-material .cm-string {
-  color: #C3E88D;
-}
-
-.cm-s-material .cm-string-2 {
-  color: #f07178;
-}
-
-.cm-s-material .cm-comment {
-  color: #546E7A;
-}
-
-.cm-s-material .cm-variable {
-  color: #f07178;
-}
-
-.cm-s-material .cm-tag {
-  color: #FF5370;
-}
-
-.cm-s-material .cm-meta {
-  color: #FFCB6B;
-}
-
-.cm-s-material .cm-attribute {
-  color: #C792EA;
-}
-
-.cm-s-material .cm-property {
-  color: #C792EA;
-}
-
-.cm-s-material .cm-qualifier {
-  color: #DECB6B;
-}
-
-.cm-s-material .cm-variable-3,
-.cm-s-material .cm-type {
-  color: #DECB6B;
-}
-
-
-.cm-s-material .cm-error {
-  color: rgba(255, 255, 255, 1.0);
-  background-color: #FF5370;
-}
-
-.cm-s-material .CodeMirror-matchingbracket {
-  text-decoration: underline;
-  color: white !important;
-}
-/**
- * "
- *  Using Zenburn color palette from the Emacs Zenburn Theme
- *  https://github.com/bbatsov/zenburn-emacs/blob/master/zenburn-theme.el
- *
- *  Also using parts of https://github.com/xavi/coderay-lighttable-theme
- * "
- * From: https://github.com/wisenomad/zenburn-lighttable-theme/blob/master/zenburn.css
- */
-
-.cm-s-zenburn .CodeMirror-gutters { background: #3f3f3f !important; }
-.cm-s-zenburn .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: #999; }
-.cm-s-zenburn .CodeMirror-cursor { border-left: 1px solid white; }
-.cm-s-zenburn { background-color: #3f3f3f; color: #dcdccc; }
-.cm-s-zenburn span.cm-builtin { color: #dcdccc; font-weight: bold; }
-.cm-s-zenburn span.cm-comment { color: #7f9f7f; }
-.cm-s-zenburn span.cm-keyword { color: #f0dfaf; font-weight: bold; }
-.cm-s-zenburn span.cm-atom { color: #bfebbf; }
-.cm-s-zenburn span.cm-def { color: #dcdccc; }
-.cm-s-zenburn span.cm-variable { color: #dfaf8f; }
-.cm-s-zenburn span.cm-variable-2 { color: #dcdccc; }
-.cm-s-zenburn span.cm-string { color: #cc9393; }
-.cm-s-zenburn span.cm-string-2 { color: #cc9393; }
-.cm-s-zenburn span.cm-number { color: #dcdccc; }
-.cm-s-zenburn span.cm-tag { color: #93e0e3; }
-.cm-s-zenburn span.cm-property { color: #dfaf8f; }
-.cm-s-zenburn span.cm-attribute { color: #dfaf8f; }
-.cm-s-zenburn span.cm-qualifier { color: #7cb8bb; }
-.cm-s-zenburn span.cm-meta { color: #f0dfaf; }
-.cm-s-zenburn span.cm-header { color: #f0efd0; }
-.cm-s-zenburn span.cm-operator { color: #f0efd0; }
-.cm-s-zenburn span.CodeMirror-matchingbracket { box-sizing: border-box; background: transparent; border-bottom: 1px solid; }
-.cm-s-zenburn span.CodeMirror-nonmatchingbracket { border-bottom: 1px solid; background: none; }
-.cm-s-zenburn .CodeMirror-activeline { background: #000000; }
-.cm-s-zenburn .CodeMirror-activeline-background { background: #000000; }
-.cm-s-zenburn div.CodeMirror-selected { background: #545454; }
-.cm-s-zenburn .CodeMirror-focused div.CodeMirror-selected { background: #4f4f4f; }
-
-.cm-s-abcdef.CodeMirror { background: #0f0f0f; color: #defdef; }
-.cm-s-abcdef div.CodeMirror-selected { background: #515151; }
-.cm-s-abcdef .CodeMirror-line::selection, .cm-s-abcdef .CodeMirror-line > span::selection, .cm-s-abcdef .CodeMirror-line > span > span::selection { background: rgba(56, 56, 56, 0.99); }
-.cm-s-abcdef .CodeMirror-line::-moz-selection, .cm-s-abcdef .CodeMirror-line > span::-moz-selection, .cm-s-abcdef .CodeMirror-line > span > span::-moz-selection { background: rgba(56, 56, 56, 0.99); }
-.cm-s-abcdef .CodeMirror-gutters { background: #555; border-right: 2px solid #314151; }
-.cm-s-abcdef .CodeMirror-guttermarker { color: #222; }
-.cm-s-abcdef .CodeMirror-guttermarker-subtle { color: azure; }
-.cm-s-abcdef .CodeMirror-linenumber { color: #FFFFFF; }
-.cm-s-abcdef .CodeMirror-cursor { border-left: 1px solid #00FF00; }
-
-.cm-s-abcdef span.cm-keyword { color: darkgoldenrod; font-weight: bold; }
-.cm-s-abcdef span.cm-atom { color: #77F; }
-.cm-s-abcdef span.cm-number { color: violet; }
-.cm-s-abcdef span.cm-def { color: #fffabc; }
-.cm-s-abcdef span.cm-variable { color: #abcdef; }
-.cm-s-abcdef span.cm-variable-2 { color: #cacbcc; }
-.cm-s-abcdef span.cm-variable-3, .cm-s-abcdef span.cm-type { color: #def; }
-.cm-s-abcdef span.cm-property { color: #fedcba; }
-.cm-s-abcdef span.cm-operator { color: #ff0; }
-.cm-s-abcdef span.cm-comment { color: #7a7b7c; font-style: italic;}
-.cm-s-abcdef span.cm-string { color: #2b4; }
-.cm-s-abcdef span.cm-meta { color: #C9F; }
-.cm-s-abcdef span.cm-qualifier { color: #FFF700; }
-.cm-s-abcdef span.cm-builtin { color: #30aabc; }
-.cm-s-abcdef span.cm-bracket { color: #8a8a8a; }
-.cm-s-abcdef span.cm-tag { color: #FFDD44; }
-.cm-s-abcdef span.cm-attribute { color: #DDFF00; }
-.cm-s-abcdef span.cm-error { color: #FF0000; }
-.cm-s-abcdef span.cm-header { color: aquamarine; font-weight: bold; }
-.cm-s-abcdef span.cm-link { color: blueviolet; }
-
-.cm-s-abcdef .CodeMirror-activeline-background { background: #314151; }
-
-/*
-
-    Name:       Base16 Default Light
-    Author:     Chris Kempson (http://chriskempson.com)
-
-    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-*/
-
-.cm-s-base16-light.CodeMirror { background: #f5f5f5; color: #202020; }
-.cm-s-base16-light div.CodeMirror-selected { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-line::selection, .cm-s-base16-light .CodeMirror-line > span::selection, .cm-s-base16-light .CodeMirror-line > span > span::selection { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-line::-moz-selection, .cm-s-base16-light .CodeMirror-line > span::-moz-selection, .cm-s-base16-light .CodeMirror-line > span > span::-moz-selection { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-gutters { background: #f5f5f5; border-right: 0px; }
-.cm-s-base16-light .CodeMirror-guttermarker { color: #ac4142; }
-.cm-s-base16-light .CodeMirror-guttermarker-subtle { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-linenumber { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-cursor { border-left: 1px solid #505050; }
-
-.cm-s-base16-light span.cm-comment { color: #8f5536; }
-.cm-s-base16-light span.cm-atom { color: #aa759f; }
-.cm-s-base16-light span.cm-number { color: #aa759f; }
-
-.cm-s-base16-light span.cm-property, .cm-s-base16-light span.cm-attribute { color: #90a959; }
-.cm-s-base16-light span.cm-keyword { color: #ac4142; }
-.cm-s-base16-light span.cm-string { color: #f4bf75; }
-
-.cm-s-base16-light span.cm-variable { color: #90a959; }
-.cm-s-base16-light span.cm-variable-2 { color: #6a9fb5; }
-.cm-s-base16-light span.cm-def { color: #d28445; }
-.cm-s-base16-light span.cm-bracket { color: #202020; }
-.cm-s-base16-light span.cm-tag { color: #ac4142; }
-.cm-s-base16-light span.cm-link { color: #aa759f; }
-.cm-s-base16-light span.cm-error { background: #ac4142; color: #505050; }
-
-.cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC; }
-.cm-s-base16-light .CodeMirror-matchingbracket { color: #f5f5f5 !important; background-color: #6A9FB5 !important}
-
-/*
-
-    Name:       Base16 Default Dark
-    Author:     Chris Kempson (http://chriskempson.com)
-
-    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-*/
-
-.cm-s-base16-dark.CodeMirror { background: #151515; color: #e0e0e0; }
-.cm-s-base16-dark div.CodeMirror-selected { background: #303030; }
-.cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-gutters { background: #151515; border-right: 0px; }
-.cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
-.cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
-.cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
-.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0; }
-
-.cm-s-base16-dark span.cm-comment { color: #8f5536; }
-.cm-s-base16-dark span.cm-atom { color: #aa759f; }
-.cm-s-base16-dark span.cm-number { color: #aa759f; }
-
-.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute { color: #90a959; }
-.cm-s-base16-dark span.cm-keyword { color: #ac4142; }
-.cm-s-base16-dark span.cm-string { color: #f4bf75; }
-
-.cm-s-base16-dark span.cm-variable { color: #90a959; }
-.cm-s-base16-dark span.cm-variable-2 { color: #6a9fb5; }
-.cm-s-base16-dark span.cm-def { color: #d28445; }
-.cm-s-base16-dark span.cm-bracket { color: #e0e0e0; }
-.cm-s-base16-dark span.cm-tag { color: #ac4142; }
-.cm-s-base16-dark span.cm-link { color: #aa759f; }
-.cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
-
-.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
-.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
-
-/*
-
-    Name:       dracula
-    Author:     Michael Kaminsky (http://github.com/mkaminsky11)
-
-    Original dracula color scheme by Zeno Rocha (https://github.com/zenorocha/dracula-theme)
-
-*/
-
-
-.cm-s-dracula.CodeMirror, .cm-s-dracula .CodeMirror-gutters {
-  background-color: #282a36 !important;
-  color: #f8f8f2 !important;
-  border: none;
-}
-.cm-s-dracula .CodeMirror-gutters { color: #282a36; }
-.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
-.cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-dracula .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula span.cm-comment { color: #6272a4; }
-.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 { color: #f1fa8c; }
-.cm-s-dracula span.cm-number { color: #bd93f9; }
-.cm-s-dracula span.cm-variable { color: #50fa7b; }
-.cm-s-dracula span.cm-variable-2 { color: white; }
-.cm-s-dracula span.cm-def { color: #50fa7b; }
-.cm-s-dracula span.cm-operator { color: #ff79c6; }
-.cm-s-dracula span.cm-keyword { color: #ff79c6; }
-.cm-s-dracula span.cm-atom { color: #bd93f9; }
-.cm-s-dracula span.cm-meta { color: #f8f8f2; }
-.cm-s-dracula span.cm-tag { color: #ff79c6; }
-.cm-s-dracula span.cm-attribute { color: #50fa7b; }
-.cm-s-dracula span.cm-qualifier { color: #50fa7b; }
-.cm-s-dracula span.cm-property { color: #66d9ef; }
-.cm-s-dracula span.cm-builtin { color: #50fa7b; }
-.cm-s-dracula span.cm-variable-3, .cm-s-dracula span.cm-type { color: #ffb86c; }
-
-.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
-.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
-
-/*
-
-    Name:       Hopscotch
-    Author:     Jan T. Sott
-
-    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-*/
-
-.cm-s-hopscotch.CodeMirror {background: #322931; color: #d5d3d5;}
-.cm-s-hopscotch div.CodeMirror-selected {background: #433b42 !important;}
-.cm-s-hopscotch .CodeMirror-gutters {background: #322931; border-right: 0px;}
-.cm-s-hopscotch .CodeMirror-linenumber {color: #797379;}
-.cm-s-hopscotch .CodeMirror-cursor {border-left: 1px solid #989498 !important;}
-
-.cm-s-hopscotch span.cm-comment {color: #b33508;}
-.cm-s-hopscotch span.cm-atom {color: #c85e7c;}
-.cm-s-hopscotch span.cm-number {color: #c85e7c;}
-
-.cm-s-hopscotch span.cm-property, .cm-s-hopscotch span.cm-attribute {color: #8fc13e;}
-.cm-s-hopscotch span.cm-keyword {color: #dd464c;}
-.cm-s-hopscotch span.cm-string {color: #fdcc59;}
-
-.cm-s-hopscotch span.cm-variable {color: #8fc13e;}
-.cm-s-hopscotch span.cm-variable-2 {color: #1290bf;}
-.cm-s-hopscotch span.cm-def {color: #fd8b19;}
-.cm-s-hopscotch span.cm-error {background: #dd464c; color: #989498;}
-.cm-s-hopscotch span.cm-bracket {color: #d5d3d5;}
-.cm-s-hopscotch span.cm-tag {color: #dd464c;}
-.cm-s-hopscotch span.cm-link {color: #c85e7c;}
-
-.cm-s-hopscotch .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
-.cm-s-hopscotch .CodeMirror-activeline-background { background: #302020; }
-
-/****************************************************************/
-/*   Based on mbonaci's Brackets mbo theme                      */
-/*   https://github.com/mbonaci/global/blob/master/Mbo.tmTheme  */
-/*   Create your own: http://tmtheme-editor.herokuapp.com       */
-/****************************************************************/
-
-.cm-s-mbo.CodeMirror { background: #2c2c2c; color: #ffffec; }
-.cm-s-mbo div.CodeMirror-selected { background: #716C62; }
-.cm-s-mbo .CodeMirror-line::selection, .cm-s-mbo .CodeMirror-line > span::selection, .cm-s-mbo .CodeMirror-line > span > span::selection { background: rgba(113, 108, 98, .99); }
-.cm-s-mbo .CodeMirror-line::-moz-selection, .cm-s-mbo .CodeMirror-line > span::-moz-selection, .cm-s-mbo .CodeMirror-line > span > span::-moz-selection { background: rgba(113, 108, 98, .99); }
-.cm-s-mbo .CodeMirror-gutters { background: #4e4e4e; border-right: 0px; }
-.cm-s-mbo .CodeMirror-guttermarker { color: white; }
-.cm-s-mbo .CodeMirror-guttermarker-subtle { color: grey; }
-.cm-s-mbo .CodeMirror-linenumber { color: #dadada; }
-.cm-s-mbo .CodeMirror-cursor { border-left: 1px solid #ffffec; }
-
-.cm-s-mbo span.cm-comment { color: #95958a; }
-.cm-s-mbo span.cm-atom { color: #00a8c6; }
-.cm-s-mbo span.cm-number { color: #00a8c6; }
-
-.cm-s-mbo span.cm-property, .cm-s-mbo span.cm-attribute { color: #9ddfe9; }
-.cm-s-mbo span.cm-keyword { color: #ffb928; }
-.cm-s-mbo span.cm-string { color: #ffcf6c; }
-.cm-s-mbo span.cm-string.cm-property { color: #ffffec; }
-
-.cm-s-mbo span.cm-variable { color: #ffffec; }
-.cm-s-mbo span.cm-variable-2 { color: #00a8c6; }
-.cm-s-mbo span.cm-def { color: #ffffec; }
-.cm-s-mbo span.cm-bracket { color: #fffffc; font-weight: bold; }
-.cm-s-mbo span.cm-tag { color: #9ddfe9; }
-.cm-s-mbo span.cm-link { color: #f54b07; }
-.cm-s-mbo span.cm-error { border-bottom: #636363; color: #ffffec; }
-.cm-s-mbo span.cm-qualifier { color: #ffffec; }
-
-.cm-s-mbo .CodeMirror-activeline-background { background: #494b41; }
-.cm-s-mbo .CodeMirror-matchingbracket { color: #ffb928 !important; }
-.cm-s-mbo .CodeMirror-matchingtag { background: rgba(255, 255, 255, .37); }
-
-/*
-  MDN-LIKE Theme - Mozilla
-  Ported to CodeMirror by Peter Kroon <plakroon@gmail.com>
-  Report bugs/issues here: https://github.com/codemirror/CodeMirror/issues
-  GitHub: @peterkroon
-
-  The mdn-like theme is inspired on the displayed code examples at: https://developer.mozilla.org/en-US/docs/Web/CSS/animation
-
-*/
-.cm-s-mdn-like.CodeMirror { color: #999; background-color: #fff; }
-.cm-s-mdn-like div.CodeMirror-selected { background: #cfc; }
-.cm-s-mdn-like .CodeMirror-line::selection, .cm-s-mdn-like .CodeMirror-line > span::selection, .cm-s-mdn-like .CodeMirror-line > span > span::selection { background: #cfc; }
-.cm-s-mdn-like .CodeMirror-line::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span > span::-moz-selection { background: #cfc; }
-
-.cm-s-mdn-like .CodeMirror-gutters { background: #f8f8f8; border-left: 6px solid rgba(0,83,159,0.65); color: #333; }
-.cm-s-mdn-like .CodeMirror-linenumber { color: #aaa; padding-left: 8px; }
-.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
-
-.cm-s-mdn-like .cm-keyword { color: #6262FF; }
-.cm-s-mdn-like .cm-atom { color: #F90; }
-.cm-s-mdn-like .cm-number { color:  #ca7841; }
-.cm-s-mdn-like .cm-def { color: #8DA6CE; }
-.cm-s-mdn-like span.cm-variable-2, .cm-s-mdn-like span.cm-tag { color: #690; }
-.cm-s-mdn-like span.cm-variable-3, .cm-s-mdn-like span.cm-def, .cm-s-mdn-like span.cm-type { color: #07a; }
-
-.cm-s-mdn-like .cm-variable { color: #07a; }
-.cm-s-mdn-like .cm-property { color: #905; }
-.cm-s-mdn-like .cm-qualifier { color: #690; }
-
-.cm-s-mdn-like .cm-operator { color: #cda869; }
-.cm-s-mdn-like .cm-comment { color:#777; font-weight:normal; }
-.cm-s-mdn-like .cm-string { color:#07a; font-style:italic; }
-.cm-s-mdn-like .cm-string-2 { color:#bd6b18; } /*?*/
-.cm-s-mdn-like .cm-meta { color: #000; } /*?*/
-.cm-s-mdn-like .cm-builtin { color: #9B7536; } /*?*/
-.cm-s-mdn-like .cm-tag { color: #997643; }
-.cm-s-mdn-like .cm-attribute { color: #d6bb6d; } /*?*/
-.cm-s-mdn-like .cm-header { color: #FF6400; }
-.cm-s-mdn-like .cm-hr { color: #AEAEAE; }
-.cm-s-mdn-like .cm-link { color:#ad9361; font-style:italic; text-decoration:none; }
-.cm-s-mdn-like .cm-error { border-bottom: 1px solid red; }
-
-div.cm-s-mdn-like .CodeMirror-activeline-background { background: #efefff; }
-div.cm-s-mdn-like span.CodeMirror-matchingbracket { outline:1px solid grey; color: inherit; }
-
-.cm-s-mdn-like.CodeMirror { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFcAAAAyCAYAAAAp8UeFAAAHvklEQVR42s2b63bcNgyEQZCSHCdt2vd/0tWF7I+Q6XgMXiTtuvU5Pl57ZQKkKHzEAOtF5KeIJBGJ8uvL599FRFREZhFx8DeXv8trn68RuGaC8TRfo3SNp9dlDDHedyLyTUTeRWStXKPZrjtpZxaRw5hPqozRs1N8/enzIiQRWcCgy4MUA0f+XWliDhyL8Lfyvx7ei/Ae3iQFHyw7U/59pQVIMEEPEz0G7XiwdRjzSfC3UTtz9vchIntxvry5iMgfIhJoEflOz2CQr3F5h/HfeFe+GTdLaKcu9L8LTeQb/R/7GgbsfKedyNdoHsN31uRPWrfZ5wsj/NzzRQHuToIdU3ahwnsKPxXCjJITuOsi7XLc7SG/v5GdALs7wf8JjTFiB5+QvTEfRyGOfX3Lrx8wxyQi3sNq46O7QahQiCsRFgqddjBouVEHOKDgXAQHD9gJCr5sMKkEdjwsarG/ww3BMHBU7OBjXnzdyY7SfCxf5/z6ATccrwlKuwC/jhznnPF4CgVzhhVf4xp2EixcBActO75iZ8/fM9zAs2OMzKdslgXWJ9XG8PQoOAMA5fGcsvORgv0doBXyHrCwfLJAOwo71QLNkb8n2Pl6EWiR7OCibtkPaz4Kc/0NNAze2gju3zOwekALDaCFPI5vjPFmgGY5AZqyGEvH1x7QfIb8YtxMnA/b+QQ0aQDAwc6JMFg8CbQZ4qoYEEHbRwNojuK3EHwd7VALSgq+MNDKzfT58T8qdpADrgW0GmgcAS1lhzztJmkAzcPNOQbsWEALBDSlMKUG0Eq4CLAQWvEVQ9WU57gZJwZtgPO3r9oBTQ9WO8TjqXINx8R0EYpiZEUWOF3FxkbJkgU9B2f41YBrIj5ZfsQa0M5kTgiAAqM3ShXLgu8XMqcrQBvJ0CL5pnTsfMB13oB8athpAq2XOQmcGmoACCLydx7nToa23ATaSIY2ichfOdPTGxlasXMLaL0MLZAOwAKIM+y8CmicobGdCcbbK9DzN+yYGVoNNI5iUKTMyYOjPse4A8SM1MmcXgU0toOq1yO/v8FOxlASyc7TgeYaAMBJHcY1CcCwGI/TK4AmDbDyKYBBtFUkRwto8gygiQEaByFgJ00BH2M8JWwQS1nafDXQCidWyOI8AcjDCSjCLk8ngObuAm3JAHAdubAmOaK06V8MNEsKPJOhobSprwQa6gD7DclRQdqcwL4zxqgBrQcabUiBLclRDKAlWp+etPkBaNMA0AKlrHwTdEByZAA4GM+SNluSY6wAzcMNewxmgig5Ks0nkrSpBvSaQHMdKTBAnLojOdYyGpQ254602ZILPdTD1hdlggdIm74jbTp8vDwF5ZYUeLWGJpWsh6XNyXgcYwVoJQTEhhTYkxzZjiU5npU2TaB979TQehlaAVq4kaGpiPwwwLkYUuBbQwocyQTv1tA0+1UFWoJF3iv1oq+qoSk8EQdJmwHkziIF7oOZk14EGitibAdjLYYK78H5vZOhtWpoI0ATGHs0Q8OMb4Ey+2bU2UYztCtA0wFAs7TplGLRVQCcqaFdGSPCeTI1QNIC52iWNzof6Uib7xjEp07mNNoUYmVosVItHrHzRlLgBn9LFyRHaQCtVUMbtTNhoXWiTOO9k/V8BdAc1Oq0ArSQs6/5SU0hckNy9NnXqQY0PGYo5dWJ7nINaN6o958FWin27aBaWRka1r5myvLOAm0j30eBJqCxHLReVclxhxOEN2JfDWjxBtAC7MIH1fVaGdoOp4qJYDgKtKPSFNID2gSnGldrCqkFZ+5UeQXQBIRrSwocbdZYQT/2LwRahBPBXoHrB8nxaGROST62DKUbQOMMzZIC9abkuELfQzQALWTnDNAm8KHWFOJgJ5+SHIvTPcmx1xQyZRhNL5Qci689aXMEaN/uNIWkEwDAvFpOZmgsBaaGnbs1NPa1Jm32gBZAIh1pCtG7TSH4aE0y1uVY4uqoFPisGlpP2rSA5qTecWn5agK6BzSpgAyD+wFaqhnYoSZ1Vwr8CmlTQbrcO3ZaX0NAEyMbYaAlyquFoLKK3SPby9CeVUPThrSJmkCAE0CrKUQadi4DrdSlWhmah0YL9z9vClH59YGbHx1J8VZTyAjQepJjmXwAKTDQI3omc3p1U4gDUf6RfcdYfrUp5ClAi2J3Ba6UOXGo+K+bQrjjssitG2SJzshaLwMtXgRagUNpYYoVkMSBLM+9GGiJZMvduG6DRZ4qc04DMPtQQxOjEtACmhO7K1AbNbQDEggZyJwscFpAGwENhoBeUwh3bWolhe8BTYVKxQEWrSUn/uhcM5KhvUu/+eQu0Lzhi+VrK0PrZZNDQKs9cpYUuFYgMVpD4/NxenJTiMCNqdUEUf1qZWjppLT5qSkkUZbCwkbZMSuVnu80hfSkzRbQeqCZSAh6huR4VtoM2gHAlLf72smuWgE+VV7XpE25Ab2WFDgyhnSuKbs4GuGzCjR+tIoUuMFg3kgcWKLTwRqanJQ2W00hAsenfaApRC42hbCvK1SlE0HtE9BGgneJO+ELamitD1YjjOYnNYVcraGhtKkW0EqVVeDx733I2NH581k1NNxNLG0i0IJ8/NjVaOZ0tYZ2Vtr0Xv7tPV3hkWp9EFkgS/J0vosngTaSoaG06WHi+xObQkaAdlbanP8B2+2l0f90LmUAAAAASUVORK5CYII=); }
-
-/*
-
-    Name:       seti
-    Author:     Michael Kaminsky (http://github.com/mkaminsky11)
-
-    Original seti color scheme by Jesse Weed (https://github.com/jesseweed/seti-syntax)
-
-*/
-
-
-.cm-s-seti.CodeMirror {
-  background-color: #151718 !important;
-  color: #CFD2D1 !important;
-  border: none;
-}
-.cm-s-seti .CodeMirror-gutters {
-  color: #404b53;
-  background-color: #0E1112;
-  border: none;
-}
-.cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
-.cm-s-seti .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-seti.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti .CodeMirror-line::-moz-selection, .cm-s-seti .CodeMirror-line > span::-moz-selection, .cm-s-seti .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti span.cm-comment { color: #41535b; }
-.cm-s-seti span.cm-string, .cm-s-seti span.cm-string-2 { color: #55b5db; }
-.cm-s-seti span.cm-number { color: #cd3f45; }
-.cm-s-seti span.cm-variable { color: #55b5db; }
-.cm-s-seti span.cm-variable-2 { color: #a074c4; }
-.cm-s-seti span.cm-def { color: #55b5db; }
-.cm-s-seti span.cm-keyword { color: #ff79c6; }
-.cm-s-seti span.cm-operator { color: #9fca56; }
-.cm-s-seti span.cm-keyword { color: #e6cd69; }
-.cm-s-seti span.cm-atom { color: #cd3f45; }
-.cm-s-seti span.cm-meta { color: #55b5db; }
-.cm-s-seti span.cm-tag { color: #55b5db; }
-.cm-s-seti span.cm-attribute { color: #9fca56; }
-.cm-s-seti span.cm-qualifier { color: #9fca56; }
-.cm-s-seti span.cm-property { color: #a074c4; }
-.cm-s-seti span.cm-variable-3, .cm-s-seti span.cm-type { color: #9fca56; }
-.cm-s-seti span.cm-builtin { color: #9fca56; }
-.cm-s-seti .CodeMirror-activeline-background { background: #101213; }
-.cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
-
-/*
-Solarized theme for code-mirror
-http://ethanschoonover.com/solarized
-*/
-
-/*
-Solarized color palette
-http://ethanschoonover.com/solarized/img/solarized-palette.png
-*/
-
-.solarized.base03 { color: #002b36; }
-.solarized.base02 { color: #073642; }
-.solarized.base01 { color: #586e75; }
-.solarized.base00 { color: #657b83; }
-.solarized.base0 { color: #839496; }
-.solarized.base1 { color: #93a1a1; }
-.solarized.base2 { color: #eee8d5; }
-.solarized.base3  { color: #fdf6e3; }
-.solarized.solar-yellow  { color: #b58900; }
-.solarized.solar-orange  { color: #cb4b16; }
-.solarized.solar-red { color: #dc322f; }
-.solarized.solar-magenta { color: #d33682; }
-.solarized.solar-violet  { color: #6c71c4; }
-.solarized.solar-blue { color: #268bd2; }
-.solarized.solar-cyan { color: #2aa198; }
-.solarized.solar-green { color: #859900; }
-
-/* Color scheme for code-mirror */
-
-.cm-s-solarized {
-  line-height: 1.45em;
-  color-profile: sRGB;
-  rendering-intent: auto;
-}
-.cm-s-solarized.cm-s-dark {
-  color: #839496;
-  background-color: #002b36;
-  text-shadow: #002b36 0 1px;
-}
-.cm-s-solarized.cm-s-light {
-  background-color: #fdf6e3;
-  color: #657b83;
-  text-shadow: #eee8d5 0 1px;
-}
-
-.cm-s-solarized .CodeMirror-widget {
-  text-shadow: none;
-}
-
-.cm-s-solarized .cm-header { color: #586e75; }
-.cm-s-solarized .cm-quote { color: #93a1a1; }
-
-.cm-s-solarized .cm-keyword { color: #cb4b16; }
-.cm-s-solarized .cm-atom { color: #d33682; }
-.cm-s-solarized .cm-number { color: #d33682; }
-.cm-s-solarized .cm-def { color: #2aa198; }
-
-.cm-s-solarized .cm-variable { color: #839496; }
-.cm-s-solarized .cm-variable-2 { color: #b58900; }
-.cm-s-solarized .cm-variable-3, .cm-s-solarized .cm-type { color: #6c71c4; }
-
-.cm-s-solarized .cm-property { color: #2aa198; }
-.cm-s-solarized .cm-operator { color: #6c71c4; }
-
-.cm-s-solarized .cm-comment { color: #586e75; font-style:italic; }
-
-.cm-s-solarized .cm-string { color: #859900; }
-.cm-s-solarized .cm-string-2 { color: #b58900; }
-
-.cm-s-solarized .cm-meta { color: #859900; }
-.cm-s-solarized .cm-qualifier { color: #b58900; }
-.cm-s-solarized .cm-builtin { color: #d33682; }
-.cm-s-solarized .cm-bracket { color: #cb4b16; }
-.cm-s-solarized .CodeMirror-matchingbracket { color: #859900; }
-.cm-s-solarized .CodeMirror-nonmatchingbracket { color: #dc322f; }
-.cm-s-solarized .cm-tag { color: #93a1a1; }
-.cm-s-solarized .cm-attribute { color: #2aa198; }
-.cm-s-solarized .cm-hr {
-  color: transparent;
-  border-top: 1px solid #586e75;
-  display: block;
-}
-.cm-s-solarized .cm-link { color: #93a1a1; cursor: pointer; }
-.cm-s-solarized .cm-special { color: #6c71c4; }
-.cm-s-solarized .cm-em {
-  color: #999;
-  text-decoration: underline;
-  text-decoration-style: dotted;
-}
-.cm-s-solarized .cm-error,
-.cm-s-solarized .cm-invalidchar {
-  color: #586e75;
-  border-bottom: 1px dotted #dc322f;
-}
-
-.cm-s-solarized.cm-s-dark div.CodeMirror-selected { background: #073642; }
-.cm-s-solarized.cm-s-dark.CodeMirror ::selection { background: rgba(7, 54, 66, 0.99); }
-.cm-s-solarized.cm-s-dark .CodeMirror-line::-moz-selection, .cm-s-dark .CodeMirror-line > span::-moz-selection, .cm-s-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(7, 54, 66, 0.99); }
-
-.cm-s-solarized.cm-s-light div.CodeMirror-selected { background: #eee8d5; }
-.cm-s-solarized.cm-s-light .CodeMirror-line::selection, .cm-s-light .CodeMirror-line > span::selection, .cm-s-light .CodeMirror-line > span > span::selection { background: #eee8d5; }
-.cm-s-solarized.cm-s-light .CodeMirror-line::-moz-selection, .cm-s-ligh .CodeMirror-line > span::-moz-selection, .cm-s-ligh .CodeMirror-line > span > span::-moz-selection { background: #eee8d5; }
-
-/* Editor styling */
-
-
-
-/* Little shadow on the view-port of the buffer view */
-.cm-s-solarized.CodeMirror {
-  -moz-box-shadow: inset 7px 0 12px -6px #000;
-  -webkit-box-shadow: inset 7px 0 12px -6px #000;
-  box-shadow: inset 7px 0 12px -6px #000;
-}
-
-/* Remove gutter border */
-.cm-s-solarized .CodeMirror-gutters {
-  border-right: 0;
-}
-
-/* Gutter colors and line number styling based of color scheme (dark / light) */
-
-/* Dark */
-.cm-s-solarized.cm-s-dark .CodeMirror-gutters {
-  background-color: #073642;
-}
-
-.cm-s-solarized.cm-s-dark .CodeMirror-linenumber {
-  color: #586e75;
-  text-shadow: #021014 0 -1px;
-}
-
-/* Light */
-.cm-s-solarized.cm-s-light .CodeMirror-gutters {
-  background-color: #eee8d5;
-}
-
-.cm-s-solarized.cm-s-light .CodeMirror-linenumber {
-  color: #839496;
-}
-
-/* Common */
-.cm-s-solarized .CodeMirror-linenumber {
-  padding: 0 5px;
-}
-.cm-s-solarized .CodeMirror-guttermarker-subtle { color: #586e75; }
-.cm-s-solarized.cm-s-dark .CodeMirror-guttermarker { color: #ddd; }
-.cm-s-solarized.cm-s-light .CodeMirror-guttermarker { color: #cb4b16; }
-
-.cm-s-solarized .CodeMirror-gutter .CodeMirror-gutter-text {
-  color: #586e75;
-}
-
-/* Cursor */
-.cm-s-solarized .CodeMirror-cursor { border-left: 1px solid #819090; }
-
-/* Fat cursor */
-.cm-s-solarized.cm-s-light.cm-fat-cursor .CodeMirror-cursor { background: #77ee77; }
-.cm-s-solarized.cm-s-light .cm-animate-fat-cursor { background-color: #77ee77; }
-.cm-s-solarized.cm-s-dark.cm-fat-cursor .CodeMirror-cursor { background: #586e75; }
-.cm-s-solarized.cm-s-dark .cm-animate-fat-cursor { background-color: #586e75; }
-
-/* Active line */
-.cm-s-solarized.cm-s-dark .CodeMirror-activeline-background {
-  background: rgba(255, 255, 255, 0.06);
-}
-.cm-s-solarized.cm-s-light .CodeMirror-activeline-background {
-  background: rgba(0, 0, 0, 0.06);
-}
-
-.cm-s-the-matrix.CodeMirror { background: #000000; color: #00FF00; }
-.cm-s-the-matrix div.CodeMirror-selected { background: #2D2D2D; }
-.cm-s-the-matrix .CodeMirror-line::selection, .cm-s-the-matrix .CodeMirror-line > span::selection, .cm-s-the-matrix .CodeMirror-line > span > span::selection { background: rgba(45, 45, 45, 0.99); }
-.cm-s-the-matrix .CodeMirror-line::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span > span::-moz-selection { background: rgba(45, 45, 45, 0.99); }
-.cm-s-the-matrix .CodeMirror-gutters { background: #060; border-right: 2px solid #00FF00; }
-.cm-s-the-matrix .CodeMirror-guttermarker { color: #0f0; }
-.cm-s-the-matrix .CodeMirror-guttermarker-subtle { color: white; }
-.cm-s-the-matrix .CodeMirror-linenumber { color: #FFFFFF; }
-.cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00; }
-
-.cm-s-the-matrix span.cm-keyword { color: #008803; font-weight: bold; }
-.cm-s-the-matrix span.cm-atom { color: #3FF; }
-.cm-s-the-matrix span.cm-number { color: #FFB94F; }
-.cm-s-the-matrix span.cm-def { color: #99C; }
-.cm-s-the-matrix span.cm-variable { color: #F6C; }
-.cm-s-the-matrix span.cm-variable-2 { color: #C6F; }
-.cm-s-the-matrix span.cm-variable-3, .cm-s-the-matrix span.cm-type { color: #96F; }
-.cm-s-the-matrix span.cm-property { color: #62FFA0; }
-.cm-s-the-matrix span.cm-operator { color: #999; }
-.cm-s-the-matrix span.cm-comment { color: #CCCCCC; }
-.cm-s-the-matrix span.cm-string { color: #39C; }
-.cm-s-the-matrix span.cm-meta { color: #C9F; }
-.cm-s-the-matrix span.cm-qualifier { color: #FFF700; }
-.cm-s-the-matrix span.cm-builtin { color: #30a; }
-.cm-s-the-matrix span.cm-bracket { color: #cc7; }
-.cm-s-the-matrix span.cm-tag { color: #FFBD40; }
-.cm-s-the-matrix span.cm-attribute { color: #FFF700; }
-.cm-s-the-matrix span.cm-error { color: #FF0000; }
-
-.cm-s-the-matrix .CodeMirror-activeline-background { background: #040; }
-
-/*
-Copyright (C) 2011 by MarkLogic Corporation
-Author: Mike Brevoort <mike@brevoort.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
-.cm-s-xq-light span.cm-keyword { line-height: 1em; font-weight: bold; color: #5A5CAD; }
-.cm-s-xq-light span.cm-atom { color: #6C8CD5; }
-.cm-s-xq-light span.cm-number { color: #164; }
-.cm-s-xq-light span.cm-def { text-decoration:underline; }
-.cm-s-xq-light span.cm-variable { color: black; }
-.cm-s-xq-light span.cm-variable-2 { color:black; }
-.cm-s-xq-light span.cm-variable-3, .cm-s-xq-light span.cm-type { color: black; }
-.cm-s-xq-light span.cm-property {}
-.cm-s-xq-light span.cm-operator {}
-.cm-s-xq-light span.cm-comment { color: #0080FF; font-style: italic; }
-.cm-s-xq-light span.cm-string { color: red; }
-.cm-s-xq-light span.cm-meta { color: yellow; }
-.cm-s-xq-light span.cm-qualifier { color: grey; }
-.cm-s-xq-light span.cm-builtin { color: #7EA656; }
-.cm-s-xq-light span.cm-bracket { color: #cc7; }
-.cm-s-xq-light span.cm-tag { color: #3F7F7F; }
-.cm-s-xq-light span.cm-attribute { color: #7F007F; }
-.cm-s-xq-light span.cm-error { color: #f00; }
-
-.cm-s-xq-light .CodeMirror-activeline-background { background: #e8f2ff; }
-.cm-s-xq-light .CodeMirror-matchingbracket { outline:1px solid grey;color:black !important;background:yellow; }
-
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
@@ -11961,12 +11659,7 @@ THE SOFTWARE.
   padding: 0 8px;
 }
 
-.jp-CodeMirrorEditor-static {
-  margin: var(--jp-code-padding);
-}
-
-.jp-CodeMirrorEditor,
-.jp-CodeMirrorEditor-static {
+.jp-CodeMirrorEditor {
   cursor: text;
 }
 
@@ -12166,16 +11859,16 @@ THE SOFTWARE.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
 /*-----------------------------------------------------------------------------
 | RenderedText
 |----------------------------------------------------------------------------*/
+
+:root {
+  /* This is the padding value to fill the gaps between lines containing spans with background color. */
+  --jp-private-code-span-padding: calc(
+    (var(--jp-code-line-height) - 1) * var(--jp-code-font-size) / 2
+  );
+}
 
 .jp-RenderedText {
   text-align: left;
@@ -12192,7 +11885,6 @@ THE SOFTWARE.
   border: none;
   margin: 0px;
   padding: 0px;
-  line-height: normal;
 }
 
 .jp-RenderedText pre a:link {
@@ -12236,27 +11928,35 @@ THE SOFTWARE.
 
 .jp-RenderedText pre .ansi-black-bg {
   background-color: #3e424d;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-red-bg {
   background-color: #e75c58;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-green-bg {
   background-color: #00a250;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-yellow-bg {
   background-color: #ddb62b;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-blue-bg {
   background-color: #208ffb;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-magenta-bg {
   background-color: #d160c4;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-cyan-bg {
   background-color: #60c6c8;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-white-bg {
   background-color: #c5c1b4;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-black-intense-fg {
@@ -12286,27 +11986,35 @@ THE SOFTWARE.
 
 .jp-RenderedText pre .ansi-black-intense-bg {
   background-color: #282c36;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-red-intense-bg {
   background-color: #b22b31;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-green-intense-bg {
   background-color: #007427;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-yellow-intense-bg {
   background-color: #b27d12;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-blue-intense-bg {
   background-color: #0065ca;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-magenta-intense-bg {
   background-color: #a03196;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-cyan-intense-bg {
   background-color: #258f8f;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-white-intense-bg {
   background-color: #a1a6b2;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-default-inverse-fg {
@@ -12314,6 +12022,7 @@ THE SOFTWARE.
 }
 .jp-RenderedText pre .ansi-default-inverse-bg {
   background-color: var(--jp-inverse-layout-color0);
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-bold {
@@ -12735,33 +12444,9 @@ h6:hover .jp-InternalAnchorLink {
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
 .jp-MimeDocument {
   outline: none;
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -12801,7 +12486,7 @@ h6:hover .jp-InternalAnchorLink {
 
 .jp-BreadCrumbs {
   flex: 0 0 auto;
-  margin: 4px 12px;
+  margin: 8px 12px 8px 12px;
 }
 
 .jp-BreadCrumbs-item {
@@ -12830,18 +12515,57 @@ h6:hover .jp-InternalAnchorLink {
 
 .jp-FileBrowser-toolbar.jp-Toolbar {
   padding: 0px;
+  margin: 8px 12px 0px 12px;
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar {
-  justify-content: space-evenly;
+  justify-content: flex-start;
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item {
-  flex: 1;
+  flex: 0 0 auto;
+  padding-left: 0px;
+  padding-right: 2px;
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar .jp-ToolbarButtonComponent {
-  width: 100%;
+  width: 40px;
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar
+  .jp-Toolbar-item:first-child
+  .jp-ToolbarButtonComponent {
+  width: 72px;
+  background: var(--jp-brand-color1);
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar
+  .jp-Toolbar-item:first-child
+  .jp-ToolbarButtonComponent
+  .jp-icon3 {
+  fill: white;
+}
+
+/*-----------------------------------------------------------------------------
+| Other styles
+|----------------------------------------------------------------------------*/
+
+.jp-FileDialog.jp-mod-conflict input {
+  color: red;
+}
+
+.jp-FileDialog .jp-new-name-title {
+  margin-top: 12px;
+}
+
+.jp-LastModified-hidden {
+  display: none;
+}
+
+.jp-FileBrowser-filterBox {
+  padding: 0px;
+  flex: 0 0 auto;
+  margin: 8px 12px 0px 12px;
 }
 
 /*-----------------------------------------------------------------------------
@@ -12885,6 +12609,19 @@ h6:hover .jp-InternalAnchorLink {
   text-align: right;
 }
 
+.jp-id-narrow {
+  display: none;
+  flex: 0 0 5px;
+  padding: 4px 4px;
+  border-left: var(--jp-border-width) solid var(--jp-border-color2);
+  text-align: right;
+  color: var(--jp-border-color2);
+}
+
+.jp-DirListing-narrow .jp-id-narrow {
+  display: block;
+}
+
 .jp-DirListing-narrow .jp-id-modified,
 .jp-DirListing-narrow .jp-DirListing-itemModified {
   display: none;
@@ -12904,6 +12641,12 @@ h6:hover .jp-InternalAnchorLink {
   background-color: var(--jp-layout-color1);
 }
 
+.jp-DirListing-content mark {
+  color: var(--jp-ui-font-color0);
+  background-color: transparent;
+  font-weight: bold;
+}
+
 /* Style the directory listing content when a user drops a file to upload */
 .jp-DirListing.jp-mod-native-drop .jp-DirListing-content {
   outline: 5px dashed rgba(128, 128, 128, 0.5);
@@ -12919,6 +12662,10 @@ h6:hover .jp-InternalAnchorLink {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+.jp-DirListing-item[data-is-dot] {
+  opacity: 75%;
 }
 
 .jp-DirListing-item.jp-mod-selected {
@@ -12993,21 +12740,6 @@ h6:hover .jp-InternalAnchorLink {
   min-height: 120px;
   outline: none;
 }
-
-.jp-FileDialog.jp-mod-conflict input {
-  color: red;
-}
-
-.jp-FileDialog .jp-new-name-title {
-  margin-top: 12px;
-}
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -13167,8 +12899,12 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   flex: 1 1 auto;
 }
 
-.jp-OutputArea-executeResult.jp-RenderedText {
+/* Text output with the Out[] prompt needs a top padding to match the
+ * alignment of the Out[] prompt itself.
+ */
+.jp-OutputArea-executeResult .jp-RenderedText.jp-OutputArea-output {
   padding-top: var(--jp-code-padding);
+  border-top: var(--jp-border-width) solid transparent;
 }
 
 /*-----------------------------------------------------------------------------
@@ -13219,13 +12955,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-LinkedOutputView .jp-OutputArea-output:only-child {
   height: 100%;
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -13287,10 +13016,12 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-InputArea {
   display: flex;
   flex-direction: row;
+  overflow: hidden;
 }
 
 .jp-InputArea-editor {
   flex: 1 1 auto;
+  overflow: hidden;
 }
 
 .jp-InputArea-editor {
@@ -13433,13 +13164,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   margin-top: 5px;
 }
 
-/* Text output with the Out[] prompt needs a top padding to match the
- * alignment of the Out[] prompt itself.
- */
-.jp-OutputArea-executeResult .jp-RenderedText.jp-OutputArea-output {
-  padding-top: var(--jp-code-padding);
-}
-
 .jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
   overflow-y: auto;
   max-height: 200px;
@@ -13478,13 +13202,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -13771,6 +13488,15 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   line-height: 1.4;
 }
 
+.jp-NotebookTools .jp-select-wrapper {
+  margin-top: 4px;
+  margin-bottom: 0px;
+}
+
+.jp-NotebookTools .jp-Collapse {
+  margin-top: 16px;
+}
+
 /*-----------------------------------------------------------------------------
 | Presentation Mode (.jp-mod-presentationMode)
 |----------------------------------------------------------------------------*/
@@ -13784,18 +13510,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-mod-presentationMode .jp-Notebook .jp-Cell .jp-OutputPrompt {
   flex: 0 0 110px;
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
 
 </style>
 
@@ -14067,7 +13781,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
   --jp-cell-prompt-width: 64px;
-  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
+  --jp-cell-prompt-font-family: var(--jp-code-font-family-default);
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1;
   --jp-cell-prompt-not-active-opacity: 0.5;
@@ -14168,7 +13882,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 180px;
+  --jp-sidebar-min-width: 250px;
 
   /* Search-related styles */
 
@@ -14213,8 +13927,6 @@ a.anchor-link {
   }
 }
 </style>
-
-
 
 <!-- Load mathjax -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML-full,Safe"> </script>
@@ -14436,9 +14148,9 @@ You make an object of a particular sub-type, and then 'freeze' it by passing it 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
 <pre>This is the generic normal distribution class:  &lt;class &#39;scipy.stats._continuous_distns.norm_gen&#39;&gt;
-This is an instance of the generic normal distribution class &lt;scipy.stats._continuous_distns.norm_gen object at 0x7fe582967310&gt;
-This is a frozen normal distribution, with specific paramters &lt;scipy.stats._distn_infrastructure.rv_frozen object at 0x7fe582973970&gt; {&#39;loc&#39;: 0, &#39;scale&#39;: 1}
-The frozen object know what generic distribution it comes from &lt;scipy.stats._continuous_distns.norm_gen object at 0x7fe582973c40&gt;
+This is an instance of the generic normal distribution class &lt;scipy.stats._continuous_distns.norm_gen object at 0x7f60c5e59fa0&gt;
+This is a frozen normal distribution, with specific paramters &lt;scipy.stats._distn_infrastructure.rv_frozen object at 0x7f607083f130&gt; {&#39;loc&#39;: 0, &#39;scale&#39;: 1}
+The frozen object know what generic distribution it comes from &lt;scipy.stats._continuous_distns.norm_gen object at 0x7f607083f610&gt;
 </pre>
 </div>
 </div>
@@ -14592,6 +14304,9 @@ M2  =  1.0
 class lognorm(qp.pdf_gen.Pdf_gen_wrap, scipy.stats._continuous_distns.lognorm_gen)
  |  lognorm(*args, **kwargs)
  |  
+ |  Mixin class to extend `scipy.stats.rv_continuous` with
+ |  information needed for `qp` for analytic distributions.
+ |  
  |  Method resolution order:
  |      lognorm
  |      qp.pdf_gen.Pdf_gen_wrap
@@ -14626,6 +14341,10 @@ class lognorm(qp.pdf_gen.Pdf_gen_wrap, scipy.stats._continuous_distns.lognorm_ge
  |  add_mappings() from builtins.type
  |      Add this classes mappings to the conversion dictionary
  |  
+ |  get_allocation_kwds(npdf, **kwargs) from builtins.type
+ |      Return kwds necessary to create &#39;empty&#39; hdf5 file with npdf entries
+ |      for iterative writeout
+ |  
  |  ----------------------------------------------------------------------
  |  Class methods inherited from qp.pdf_gen.Pdf_gen:
  |  
@@ -14654,7 +14373,7 @@ class lognorm(qp.pdf_gen.Pdf_gen_wrap, scipy.stats._continuous_distns.lognorm_ge
  |      
  |      This defaults to plotting it as a curve, but this can be overwritten
  |  
- |  print_method_maps(stream=&lt;ipykernel.iostream.OutStream object at 0x7fe57dbc0190&gt;) from builtins.type
+ |  print_method_maps(stream=&lt;ipykernel.iostream.OutStream object at 0x7f617093ab80&gt;) from builtins.type
  |      Print the maps showing the methods
  |  
  |  reader_method(version=None) from builtins.type
@@ -15267,7 +14986,7 @@ create(**kwds) method of builtins.type instance
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAYkAAAEJCAYAAABhbdtlAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAApWElEQVR4nO3deXhb5Z0v8O9PkvdNXmQ7uyMndhInJHGcAIEsJHYIUGgLhpbSzp0WJkw797YzvVPaztZ5pn+0gZkuM3OHEtrSlilcIEDpA7cQJyEbIYudhJDNTiIncRbb8r7Fi6T3/qEjLBwrlrdztHw/z+PHks458i+Kra/O+77nfUUpBSIiouGYjC6AiIhCF0OCiIgCYkgQEVFADAkiIgqIIUFERAFZjC5gomVlZam8vDyjyyAiCitVVVVNSinb0McjLiTy8vJQWVlpdBlERGFFRC4O9zibm4iIKCCGBBERBcSQICKigBgSREQUEEOCiIgC0j0kRKRcREpFZNMI+20e7TFERDSxdA0JESkHAKXUdu1+aYD9SgHYR3MMERFNPL3PJJYDcGi3HQCKh+4gIna/fYI6hiiUtfcM4I8fXcUvdp/Hx5fb4fFwen4KH3pfTGcdcj9zmH3sSqntIhL0MVoz1CYAmDlz5vgqJJoASilsrbqM1yovo+pSK9x+wWBLicP6edn45vq5mGpNMLBKopHpHRJtADICbRSRUl+zUrDHAIBSaguALQBQUlLCj2lkKLdH4Ydvn8Jv9l9AQU4yvr4mH+vmZ2N6egL21jRh55lGvHXsKt6vbsQLf74CC6amGl0yUUB6h8RhDJ4Z2AFUDNneovU5WAHYRaQ4iGOIQsb1fje+9X+PYtupBjxx52z83b3zYTJ9claMh5ZNx0PLpuNMfQe++sJhPPLch/ivx4qxuuCGKXOIQoKufRJKqa3wvvmXArD6dUZXaNuPaI9lQAuGQMcQhZquPhceff4AKk434Af3L8A/fGbBpwLC37zcVLz5jTswIyMRX/3NYbx17IrO1RIFRyJtjeuSkhLFCf7ICH/72kd448hl/Ndjy7BxYW5Qx3T2DuCJ31biWF0b3vnmnZiTnTLJVRINT0SqlFIlQx/nxXREE+DdE9ewteoy/uquOUEHBACkxMfgP760FElxFvz1K8fQ7/JMYpVEo8eQIBqnxo5efP+Nj3HL9DR8c/3cUR+fnRKPHz24CCeudODnO2omoUKisWNIEI2DUgrf2Xoc1wfc+OkXliDGPLY/qbuLcvFIyXQ8u+s8Ki+0THCVRGPHkCAah5cP1WF3jRN/f+985NuSx/Vc/3R/EaanJ+JvXj2G3gH3BFVIND4MCaIxut7vxk8qarAiLwNfvm3WuJ8vOc6CHz+4CHUt1/H7g5cmoEKi8WNIEI3RiwcuoKmrD397dyH8ZggYl5VzsnDHnEw8u+scevpdE/KcROPBkCAag64+F57ddR6rC2xYMfumEwKM2rfLCtHU1Y/f7h92yWEiXTEkiMbghX21aO0ZwP8uK5jw5142Kx3r5mXjF7vPo6N3YMKfn2g0GBJEo9TeM4Atex0oW5CDxTOsk/Izvl1WgPbrA/j1vtpJeX6iYDEkiEbpl/sc6Ox14duTcBbhs3BaGu5ZmItf7a1Fa3f/pP0copEwJIhGobvPhd98cAH3LZqC+VMmd/bWvykrQGefCy8eYN8EGYchQTQKbx69gs4+Fx5fNXvSf1ZBTgpWF9jw0sFLcLk5XQcZgyFBFCSlFF788CIWTkvF0knqixjqz26bhfqOXlScatDl5xENxZAgCtKh2hZUN3TiK7fNmrDrIkZy17xsTLMm4HcfssmJjMGQIArSiwcuIi0hBg8snqbbzzSbBI/dNhMfOppxrrFTt59L5MOQIApCY0cv3j1Rj4eXTUdCrFnXn/2FkhmINZvwIs8myAAMCaIgvHyoDi6PwmMTMEfTaGUmx+G+W6bg9SNX0NXHqTpIX7qHhIiUi0ipiGwKsL1U+9rs91iriFSIyFP6VUrkNeD24KVDF7G6wIbZWUmG1PCV22ehq8+FN49ymVPSl64hISLlAOC3tnXpkO3FAIq17cUiYtc2PayUKlNKPa1nvUQAsKvaiYaOPnzFgLMIn6UzrCiamoqXOTss6UzvM4nlABzabQeAYv+NSqkjSqmnRcQKwKGU8u1r9QuMG4jIJhGpFJFKp9M5GXVTFPvD0SvITIrF2kKbYTWICMqXTcepax2oaWAHNulH75CwDrmfGWC/EgDn/e5nAGgRkeeG21kptUUpVaKUKrHZjPtDpsjT0TuAitMNuH/x1DGvOjdRPnPLVJhNgj+wyYl0pPdvfRu8b/g3pTU35fs1T21RSrUBaPM9RqSHdz+uR7/Lg88t1W/YayC2lDismpuFt45dhcejjC6HooTeIXEYg2cTdgAV/htFZLNfh3YbgAytKelTzVJEennz6BXkZSZi8fQ0o0sBAHxuyTRcabuOw1wHm3Sia0gopbYCsGsd1la/DmxfWDwHwOG3fQuAV7V9yv2eg2jSXWu/jgO1zfjc0mm6XWE9kg1FOUiMNeMPx9jkRPqw6P0D/UYobfd7rEz77sBgx/Z27bE2AEe0LwYE6eaPx65CKe+n91CRGGvB3UW5eOf4NfzzA0WIs+h7YR9FH15MRxTAm0evYOlMK/IMujYikM8tnYaOXhfeP8ORfDT5GBJEwzh9rQNn6jvx+RDosB7qjvxMZCXHcZQT6YIhQTSMt45dhdkkuG/RFKNLuYHFbML9i6dg55lGtF/nGtg0uRgSREMopfCnE9ewMj8TmclxRpczrPsXT0W/24OdZ7jOBE0uhgTREKevdeJicw/uWRh6ZxE+S6ZbkZMah3dP1BtdCkU4hgTREO+erIeId7hpqDKZBBuLcrG7xomefs4MS5OHIUE0xLsnrmF5XgayQrSpyefuhbnoHfBgdzVHOdHkYUgQ+Tnv7EJNQxfuWZhrdCkjWpGXgYykWPyJTU40iRgSRH58bfx3F4V+SFjMJpTNz8HOM43oc7mNLociFEOCyM97J+uxeIYVU60JRpcSlI2LctHV58L+c81Gl0IRiiFBpLnc2oPjl9uxMQzOInxW5mciJc6CP524ZnQpFKEYEkSa9056rznYGAb9ET5xFjPWz89GxakGuNweo8uhCMSQINK8e+Ia5uWmGLaO9VhtXJiL1p4BHKrl9OE08RgSRACau/pQebEVG8KoqclnTUE24mNM2HaKV1/TxGNIEAF4v9oJpYCy+aF7AV0gCbFm3JGfhR1nGqAUV6yjicWQIAKw80wDclLjsHBaqtGljMn6+Tmoa7mOc41dRpdCEYYhQVGv3+XBnpomrJuXHTIr0I3WunnZAIDtpxsNroQije4hISLlIlLqt5b10O2l2tfmYI8hGo+Dtc3o6nNh/bzwa2ryyU2Lx8Jpqdhxmv0SNLF0DQm/dap9a1uXDtleDKBY214sIvaRjiEarx2nGxFnMeGOOVlGlzIu6+bl4MilVrR09xtdCkUQvc8klmNwDWsHgGL/jUqpI0qpp0XECsChrXl902MAQEQ2iUiliFQ6nZzsjIKnlMKOMw24Y04WEmLDe73o0vnZ8ChgVzWbnGji6B0S1iH3MwPsVwLgfLDHKKW2KKVKlFIlNpttXAVSdDnb2IW6lutYPz/b6FLGbeHUNGSnxGEH+yVoAukdEm0AMkbaSWtayteamoI6hmgsfG+ovo7fcGYyCdbNy8aeGif6Xbz6miaG3iFxGINnBnYAFf4bRWSzX+d0G7zhcNNjiMZjx+kGFE1NxZS08JjQbyTr5+egs8+Fwxd49TVNDF1DQim1FYBd63y2+nVG+974nwPg8Nu+JdAxROPV0t2PI5dasT4ML6AL5M45WYizmLCdo5xoglj0/oFKqae1m9v9HivTvjsw2Em9/WbHEI3X7ppGeBSwPgKamnwSYs1YmZ+JnWca8YP7i4wuhyIAL6ajqLWr2oms5FgsmpZmdCkT6q552bjY3IPapm6jS6EIwJCgqOT2KOyucWL1XBtMpvC8yjqQtQXeMyMOhaWJwJCgqPTR5Ta09QxgTWHkDZmemZkIe1YSdlXzmiEaP4YERaVd1U6YBFg9N/JCAgDWFNpwwNGM6/1c+5rGhyFBUWl3dSOWzLAiPSnW6FImxV2F2ehzeXDAwbWvaXwYEhR1mrr68NHldqwtjJxRTUOtmJ2BhBgz+yVo3BgSFHX21Hjb6u+K4JCIjzHj9vxMbTElLkREY8eQoKjjG/paNDU8FxgK1tpCGy61cCgsjQ9DgqKK26Ow56wTqwsib+jrUINDYTnKicaOIUFRxTf0NZKbmnxmZibCbkvCrhqGBI0dQ4Kiyq4zjTAJsGpueC8wFKy1Bdk44GhGT7/L6FIoTDEkKKrsrnFiyQwrrImROfR1qLWFNvS7PDjo4KywNDYMCYoaLd39OH4lsoe+DrVidgbiY0zYzSYnGiOGBEWNvWedUApYUxCZV1kPJz7GjNvsmZ8M+yUaLYYERY3dNU6kJ8ZgYYTN+jqS1XNtcDR1o66lx+hSKAwxJCgqeDwKe2qasGquDeYIH/o6lG8SQzY50VjoHhIiUi4ipX7LlPpvs4pIsbbPZr/HW0WkQkSe0rdaihSn6zvQ1NUXVU1NPvasJExPT2BI0JjoGhIiUg4AfsuWlg7Z5REAJdqSpfALkoeVUmV+K9QRjYrvDXJVQXQMffUnIlhdYMP+c03od3mMLofCjN5nEssxuDypA0Cx/0ZtTest2l27375WEbHrUyJFot3VTiyYkorslHijSzHEmgIbuvvdqLrYanQpFGb0DgnrkPuZw+2kBUKL74wDQAaAFhF5LsD+m0SkUkQqnU6eUtOndfW5UHWxNSIXGArWyvxMWEyCPWf590Gjo3dItMH7hj+ScqXUk7472hlGG4A2X5OVP217iVKqxGaL3jcCGt7+c01weVRU9kf4pMTHYNmsdOzmPE40SnqHxGEMnk3YAVQM3UFEyn19D1on9iYRKR66H1Gwdtc4kRRrRvHMdKNLMdTqAhtOXetAY2ev0aVQGNE1JLQOabvWYW3168Cu0L6XAtgsIlUiUgXvWcer2rZyv+cgCopS3llfV87JQqwlukd8+86k9tQ0GVwJhROL3j/Qb4TSdr/HyrTv2wHkD3PYEe2LAUGjUtvUjbqW69i0erhfq+iyYEoqspLjsKfGifJl040uh8JEdH+0oojnG/q6Nor7I3xMJsHqgizsPeuE28PV6ig4DAmKaLtrnLBnJWFGRqLRpYSENQU2tPYM4OMr7UaXQmGCIUERq3fAjQOOZqzmWcQnVs21QQSc8I+CxpCgiHX4Qgt6BzxRfX3EUBlJsbhlWhqn6KCgMSQoYu2udiLWYsJts4e9ZjNqrSmw4eilVrT3DBhdCoUBhgRFrN01Ttw6OwMJsWajSwkpawpt8Chg3zkOhaWRMSQoIl1tu46zjV1RfZV1IIunW5ESb2G/BAVl1NdJiMgSeK+WtsM7zUYLAIdS6thEFkY0Hr43QHZa38hiNmHV3CzsrnFCKQWR6Fpfg0YnqDMJEckTkV+IyHsAnoT3grd2AKLd/ksR2SYiz4pI3qRVSxSk3TVOTEmLx9zsZKNLCUlrCmyo7+hFTUOX0aVQiBvxTEJEvgPv9BjfVUrddHC1iKQB2CQirUqpX05QjUSj4nJ7sO9cE+5bNIWfkgPwnWHtrmlEYW6KwdVQKLvpmYQWEFuVUt8fKSAAQCnVrpR6BsAOEfnbiSqSaDSO1bWhs9fF/oibmJKWgMKcFA6FpRHdNCSUUs8opWpH+6RKqVql1L+OvSyisdtV7YTZJFg5J/pWoRuNNYU2HK5tRXefy+hSKISNenQT+xwo1O2qaUTxTCvSEmKMLiWkrSmwod/twYfnm40uhULYWIbApovIE747IvKQiKybwJqIxqyxsxcnrnRgbWG20aWEvJK8dCTFmvF+daPRpVAIG3VIKKWOApjjCwal1OsANojI4xNdHNFo+VZeW8upOEYUZzFj5Zws7Kr2DoUlGs5YmpveA6AAVGnXTADAjwA8HfAgIp3sqnEiOyUOC6akGl1KWFhbaMOVtus47+RQWBreWJqb8gE8p412Em3Y6/PaF5FhXG4P9tY4sabAxqGvQfI1y+3i2tcUwFhCYgOA74pIqtb0VArgkFLqe8EcLCLlIlIqIpuG2WbV1rUuF5HNwRxD5HOsrg0dvS72R4zCNGsC5mYnMyQooLH0STiUUl9XSnVo918H0B5M57XfOtW+ta1Lh+zyCIAS3zrWIrIpiGOIAAwOfb1zLoe+jsbaQhsO1bZwKCwNa0Im+FNKPQ8gmOsplgNwaLcdAIqHPM8WpdQW7a5d2+emxxD5cOjr2KwtzOZQWApowmaBDfKiO+uQ+8NO9C8idgAt2tnDiMdoZxyVIlLpdPK0ORpx6OvYleSlIzHWjF01HApLNxpxWo6xXDwnIrMDTMvRBu88UCMpV0o9Gewx2hlIiVKqxGbj0MdotKfGuzYCp+IYvTiLGSvzORSWhjfitBwAykTkR8GEhYikisiPATwUYFqOwxg8M7ADqBjmOcqVUk9rt4uDOYbo/epG2FLiUDSVQ1/HYm2hDZdbORSWbjTiLLBKqedFZDa804EvhbdfoA3AeXjfvDO17/naY08HanpSSm0Vkae0zmerX2d0hVKqTHt8s4h8Xzvku4GOIfIZcHuwp8aJexbmcujrGN01z9tMt/NMI+Zkc1ZYGhTUokPam/73AG9TEgYXHWqHt8PaoQ2HDea5fBfdbfd7rEz7vh3esBnxGCKfygut6Ox1Yd28HKNLCVvTrAmYl5uCHacbsWn1DX+CFMVGvTKdFhi1AHZMfDlEo7fzTANizSYOfR2n9fOz8YvdDrT3DCAtkSPEyGtMo5tE5Amtn+IJEWEjMBlq55lG3GrPQHLcqD/zkJ9183Lg9ijsOcsRgjRoLHM3/QLAHHiXLn0EQC0n9yOjXGjqxnlnN9bN49DX8Voyw4qMpFjsPMOhsDRoLB+9KrSrrAF4p9IA8D0ReVAp9caEVUYUBN8bGkNi/MwmwdoCG3ZWN8LtUTCbOAiAJuBiOqVUmzZv07AXxhFNJu9onGTMykwyupSIsG5+Ntp6BnD0UqvRpVCIGEtIOETksIh8fkh/BK/pJ1119blwsLYZ63kWMWFWzbXBYhI2OdEnxhISXwDwKoBHAVzQAuMVeIfEAgC4Uh3pYd9ZJwbcik1NEygtIQbL8zIYEvSJsYTEeQCvKaUeUUplANgEoBLe1emaReQwgM03fQaiCbDjdCNS4y1YNivd6FIiyvr52ThT34nLrT1Gl0IhYCxThT8P7zrXedr9o0qpZ5RSG5RSmQCeBMAGTZpUHo/C+9VOrCnMhsU8YfNUEj599TXRmP66tGC4EGDbEQDfHU9RRCM5WteGpq4+lM5nU9NEs2clwZ6VhIpTDUaXQiFgUj6CBTtFB9FYbTtVD4tJODX4JBARlC3IwQFHMzp6B4wuhwzG83QKO0opbDvZgNvzM7nA0CTZUJSDAbfisqbEkKDwc97ZhdqmbmxYwAn9JsuSGenISo7DtpP1RpdCBmNIUNh576S3rbyUITFpzCZB2YJs7Kp2os/lNrocMhBDgsLOtlMNWDw9DVPSEowuJaJtWJCLrj4X176OcgwJCiv17b34qK4NG4pyjS4l4t2en4mkWDO2cZRTVGNIUFipOO19w2J/xOSLjzFjbWE2Kk41wOPh2tfRSveQEJFyESkVkU032V4x5LFWEakQkaf0qZJC1baT9ZidlYQ52clGlxIVNhTlwNnZh2OX24wuhQyia0iISDnwyTKl0Nat/hSl1NZhDn1YKVXmt4wpRaH26wP48HwzNizI4VrWOllbmA2LSbDtJJucopXeZxLLATi02w4AxUEeZxUR+8i7USTbVd0Il0ehjE1NuklLiMHt+ZnYdrIeSrHJKRrpHRLWIfeDXYMiA0CLiDw33EYR2SQilSJS6XTy4p9I9c7xa8hOiUPxTE7op6eNC3PhaOrGmfpOo0shA+gdEm3wvuGPilJqi1KqDUCbr8lqmO0lSqkSm802/iop5HT1ubCrxol7F02BiSum6eruolyYBPh/H18zuhQygN4hcRiDZxN2ABWBd/XSzhKCbZaiCLXjdAP6XR7cd8sUo0uJOlnJcbg9PxPvHL/GJqcopGtIaJ3Sdq3D2urXgf1JWGjbSvzOGF7VHi/3ew6KMu8cv4ac1DgsY1OTIe5dNAWOpm6cvsYmp2ij+xBYpdTTSqnt/iOVlFJlfre3K6XSfWGgraF9RCm1VSnFKcijUGfvAHbVOHHPQjY1GWUjm5yiFi+mo5C380wj+l0efIZNTYbJ9DU5fcwmp2jDkKCQ9/bxa8hNjeeoJoPdt2gqatnkFHUYEhTSOnsHsLvGiXsW5bKpyWB3F+XAbBK88/FVo0shHTEkKKTtOM2mplCRmRyH2+0c5RRtGBIU0nxNTUtnsKkpFNx3yxRcaO7ByasdRpdCOmFIUMhq6e7HrupGPLBkKpuaQsTGolzEmAVvHr1idCmkE4YEhay3j1+Fy6Pw+aXTjC6FNOlJsbirMBtvHbsKl9tjdDmkA4YEhaw3jlzBvNwUzJ+SanQp5OfB4mlo6urDvnNNRpdCOmBIUEhyOLtwrK4NDxbzLCLU3DUvG2kJMWxyihIMCQpJfzh6BSYBPruEIRFq4ixm3HfLFLx3sh5dfS6jy6FJxpCgkKOUwpvHruCOOVnISY03uhwaxoNLp6F3wIN3T9QbXQpNMoYEhZzKi62oa7nODusQtmxWOmZmJOLNo5eNLoUmGUOCQs4bR64gIcaMu4tyjS6FAhARfG7pNOw/34xr7deNLocmEUOCQkrvgBvvHL+KjQtzkRRnMbocuonPL50GpYA/HOU0HZGMIUEh5d0T9ejodaF82XSjS6ERzM5KQsmsdLxaWcdpOiIYQ4JCykuHLiEvMxG324Nd/pyM9KVbZ6K2qRsfOpqNLoUmCUOCQsa5xk4cqm3BF1fM5DQcYeLeRVOQlhCDlw5eMroUmiS6h4SIlItIqYhsusn2itEcQ5Hh5UN1iDELm5rCSHyMGQ8WT8N7J+vR3NVndDk0CXQNCb91qn1rW5cO3WfoGtbBHEPhr3fAjdePXMaGolxkJccZXQ6NwpdWzMSAW2FrFYfDRiK9zySWA3Botx0AiifiGBHZJCKVIlLpdDonpFDS17sn6tHWM4AvrZhpdCk0SnNzUrA8Lx0vH7rEDuwIpHdIWIfcD6Z3csRjlFJblFIlSqkSm802xtLISC8dZId1OHt0xUxcaO7Bh+fZgR1p9A6JNgAZOhxDYeRcYycOXWCHdTjzdWD//hA7sCON3iFxGINnBnYAFYF3HdcxFEZ+u/8iYs0mdliHsfgYMx4qno73TtSjvr3X6HJoAukaElqntF3rfLb6dUZ/8savbSvx67Ae9hiKDK3d/Xitqg6fXTKVHdZh7qt35MGjFH6z/4LRpdAE0n3eA6XU09rN7X6Plfnd3g4gfaRjKDK8dOgSegc8eGKV3ehSaJxmZCRi48JcvHTwIv7XujmcViVC8GI6Mkyfy43f7L+AVXOzUJibYnQ5NAEev9OOjl4XXqusM7oUmiAMCTLMH49dhbOzD3/Bs4iIsWxWOopnWvHrDy7A7eFw2EjAkCBDKKXwq321KMxJwaq5WUaXQxPoiVV2XGrpQcUpLkgUCRgSZIh955pwpr4Tj6+aDREOe40kdxflYkZGAn65t9boUmgCMCTIEFv2OJCVHIfPLplqdCk0wcwmwdfumI3Ki62outhqdDk0TgwJ0l3VxRbsPduEJ1bNRpzFbHQ5NAkeKZmBjKRY/Gx7jdGl0DgxJEh3P604i8ykWPzZ7bOMLoUmSVKcBX+5xo69Z5tQeaHF6HJoHBgSpKuDjmbsO9eEr6/NR2Isx9FHsq/cloes5Dj8lGcTYY0hQbr66fYaZCXH4bFbeRYR6RJizfjLNXZ8cK4ZB7hyXdhiSJBu9p9vwgFHC76xNh8JseyLiAZfvm0WbClx+ElFDacRD1MMCdKFUgo/qziLnNQ4fOlWrhkRLeJjzPirtfk4VNvCacTDFEOCdLHjdCMOXWjBX901B/ExPIuIJl9cMRNT0uLxoz+dgYdXYYcdhgRNuj6XGz985xTybUl4lCvPRZ34GDOe2liIj6+0c4nTMMSQoEn3wgcXcLG5B/90fxFizPyVi0afWzINxTOtePq9M+jsHTC6HBoF/sXSpGrs6MV/7DiL0vnZWFPApWWjlYjgnx8oQnN3P/5j5zmjy6FRYEjQpNr8bjUG3Ar/cN8Co0shg90y3YqHl03HCx/UwuHsMrocCpLuISEi5SJSKiKbgt0uIq0iUiEiT+lXKY3X0UuteP3IZXztztnIy0oyuhwKAd+5ex7iLGb8y9unOCQ2TOgaEn5LkvqWLS0NcvvDSqkyvxXqKMT1Drjx1NbjyE2Nx/9cN8focihE2FLi8Nelc7Gr2ok/HLtidDkUBL3PJJYDcGi3HQCKg9xuFRGuTBNGfrq9Bmcbu/DjhxYhmctYkp+v3jEby2al4wdvnUR9e6/R5dAI9A4J65D7mUFuzwDQIiLPDfekIrJJRCpFpNLpdI67SBqfqouteH6PA4+umIG1hdlGl0MhxmwS/OvDi9Hv9uD7bxxns1OI0zsk2uB9wx/VdqXUFqVUG4A2X5PUMNtLlFIlNhtH0Bjper8b33ntI0xJS8Df3Tvf6HIoRM3OSsJ3N87D+9VOvFbJaydCmd4hcRiDZwt2ABUjbdfOEoY2S1GIevq9M3A0deOZ8luQEh9jdDkUwv7H7Xm4zZ6Bf3n7FOpaeowuhwLQNSSUUlsB2LUOaatfB3XFTba/qu1T7rcPhaC3j1/FCx9cwJ+vzMPKOVy3mm7OZBI8U74YAuDrv69C74Db6JJoGBJp7YElJSWqsrLS6DKizpn6Dnz+/+zHgqmpePkvbkOshZfgUHB2nG7A47+txIPF0/BvDy/mmucGEZEqpVTJ0Mf5l0zj1t4zgCdfrEJKvAXPPlbMgKBRWT8/B39dOhdvHLmC33140ehyaAj+NdO4uD0K33rlKK62XcezXy5Gdmq80SVRGPrmurkonZ+NH759Cge5QFFIYUjQmHk8Ct9/4zh2VTvxg/uLsGzWzQauEQVmMgl+8oUlmJmRiL/4XSVOXe0wuiTSMCRoTJRS+OE7p/Bq5WV8c90cfPk2LkdK45MaH4Pffm0FkuIs+LNfH8R5zu8UEhgSNCY/3X4WL3xwAV+9Iw9/U1ZgdDkUIWZkJOK/n7gVSgFf/uVBXG7l0FijMSRoVJRS+Nn2Gvz7jrN4pGQ6/vG+BRyNQhMq35aMFx+/Fd19Lnzp+YO42NxtdElRjSFBQRtwe/C91z/Gz7afxYPF0/CjB2+BycSAoIm3YGoqfvf4rejoHcCD/7Ufx+rajC4pajEkKChdfS488dtKvFJZh2+um4N/e3gxzAwImkRLZljxxtdXIinOgi9u+RAVpxqMLikqMSRoRGcbOlH+7H7sO9eEHz+4CN/eUMgmJtKF3ZaMN76xEoU5KXjyxUr8+46zcHsi6wLgUMeQoICUUvj9wYu4/z/3obGzDy/8+XJ8ccVMo8uiKJOVHIeXN92Gz9wyFT+pqMGjzx/A1bbrRpcVNRgSNKyGjl48+WIV/v7NE1iel4F3v7UKq7lGNRkkMdaCn39xCf7t4cU4eaUd9/x8L946doXTjOuAczfRp/S53PjVvlr8585zcLkVntpYiK/dMZsd1BQyLjR141uvHMNHdW1YkZeBHzywAEVT04wuK+wFmruJIUEAAJfbgz+dqMe/bqvGxeYelC3IwT/cNx+zMrk2NYUet0fh1co6PPNeNdp6+vGF5TPwjbVzMCMj0ejSwhZDgobVO+DG1qrLeH6vAxebezA3Oxn/+JkFbFqisNDeM4Cf7ajBfx+4CI8CHlg8FU+usWNebqrRpYUdhgR9QimFj6+04/Wqy/jjR1fR2jOAxTOs+PqafGxYkMOmJQo719qv41d7a/HSoUvo6XdjRV4GHlo2DfcumsLFr4LEkIhyLrcHx+ra8H51I7adbMDZxi7EWkwoW5CDx26didvtmRzWSmGvracfLx26hK1Vl+FwdiM+xoR187JxV2E21hTakJ3CWYoDYUhEmd4BN05caUfVxVYcudSKA44WtF8fgNkkKJmVjgeWTMVnFk1FWiI/ZVHkUUrhWF0bXj9yGRWnGtDQ0QcAKJqaiuV5GSielY5ls9IxNS2eH440IRMS2jKkbQDsSqktwWwf6Rh/0RQSHo9CU1cfLrX0oK61BxeaenC2sRPV9Z240NzzyUVHszITsTwvA3cVZuPOuVlIS2AwUPRQSuHUtQ7sqnZi71knPqprx3VtqVRrYgwKclJQmJOCfFsSZmQkYmZGIqanJyIh1mxw5foKiZDwX6daRDYBcPjWuQ60HYD1ZscMFcohoZSC26Pg8igMuD1wuRX63R70uzzoc3nQO+BG74Ab1wfc6O5zo7vPhS7tq7W7H23XB9DW0w9nZx8aO/vg7OyDy+/qUxFgVkYiCnJSUJCTglump6F4VjqykuMM/FcThRaX24Mz9Z04cqkVp691oqahEzX1nejsc31qv5R4C7JT4pCdEo+M5FikJ8bAmhCLtIQYJMdbkBRnQXKcGQkxFiTEmhEfY0KcxYxYiwmxZhNiLSbEmAVmkyDGZAr5vr5AIWHRuY7lAF7RbjsAFAPYPsL2zBGO+ZTq+k6seeb9mxYxNBcV1LDbhstPpbx7K+U9zvtde1wBHqXgUd5P+b7bbo+CWwuIsUqMNcOaEANrYiyyUuIwNycF2SlxyE2Lx4yMRMxIT8T09ATEx0TXpx+i0bKYTVg4LQ0Lpw1eW6GUQlNXP+pae1DX0oPLrdfR2NGLRu0D2elrHWjr8X5IG+ufsQhgMQlM4g0OkwhM4l1wyXcbEIgAAsAkg7e9x8sNzzfcbe1ZAm4bLb1DwjrkfmYQ20c6BtoZxiYASJ1qx9IZQw+50Q0veIA7ghv/Y+ST79p/onifzyTafyw+/R9vNpm8vxwmgcUksJi9nywsZvnUp46EGLP2icSMhBgzUuItSI6zIDnegjgL3/yJJouIwJYSB1tKHIpnpgfcz+NR6Op3obvP+9XZ60LvgLcVoKffjX63+5OWgX6XBy6P98PhgNsDj9aK4NY+QLo9vg+Vn/6ACQze931Q9X0w9fH/YIsbPvT63R5FS9GeAI/rHRJtAG62xuVw20c6Blo/xRbA29z0sy8uHXOBRESBmEyC1PgYpEbgsNqfPzr843qHxGEMnhnYAVQEsd06wjFERDRJdJ3gTym1FYBdREoBWH0d0CJSEWh7oGOIiGjy8ToJIiIKOLqJU4UTEVFADAkiIgqIIUFERAExJIiIKCCGBBERBRRxo5tExAngosFlZAFoMriGUMHXYhBfi0F8LQaFymsxSyl1w2pjERcSoUBEKocbShaN+FoM4msxiK/FoFB/LdjcREREATEkiIgoIIbE5LjpwkhRhq/FIL4Wg/haDArp14J9EkREFBDPJIiIKCCGBBERBcSQ0ImIbDa6BiOJiFVEikWkPBpfC+3fXaqtohi1ov33IJBQfi0YEjrQ1sKwG12HwR4BUKKtD4JoerMUkXIA8Fs/pdTYigwVtb8HgYT6+4PeK9NFHRGxA3AYXYfRtCVmfaJthcHlAF7RbjsAFAOIysWzovz34Abh8P7AM4nJZ1dKhfQvgZ60P4qWKFth0DrkfqYRRYSSKP09GE7Ivz/wTGKctKaEjCEPO5RS20WkNJr+CG72WvjdL1dKPaljWaGgDTe+LtEuGn8PPiVc3h8YEuPka1sNoMW3Nje863QXK6WO6FOZ/kZ4LSAi5Uqpp7XbEf1aDHEYg2cTbGKJ3t+DocLi/YHNTZNIKXVE+6SQgRubHKKK9sewWUSqRKQKUfTJWgtPu+8NIRw+PU6WaP49GCpc3h94xTUREQXEMwkiIgqIIUFERAExJIiIKCCGBBERBcSQICKigBgSREQUEEOCiIgCYkgQEVFADAkiIgqIIUGkAxGxi8h5EanQ7hdrM6EShTSGBJE+vgugDMARbRWyklCfIpoI4NxNRLoQEatSqk1ErPAGRNRO8kfhhSFBpBMRKQa8s38aXQtRsNjcRKQDbUEmhy8gfOteE4U6hgTRJBORTfAuNvS8iFi1Pok2Y6siCg5DgmgS+Ra611ZicwCoBXCefRIULtgnQUREAfFMgoiIAmJIEBFRQAwJIiIKiCFBREQBMSSIiCgghgQREQXEkCAiooAYEkREFND/B7dbEAGXZJ1HAAAAAElFTkSuQmCC
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAYkAAAEJCAYAAABhbdtlAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqK0lEQVR4nO3deXhU530v8O9vRvs6WkYSYhMSSIDAgCTjLSwGgbEdO4mDTRInvU3syE1zn6TNvSHpcps+zR+JnTZL21u3OKmTuLFLjJfksW9skDBgGwMWSzCbBEiAWCSNltGKlpl57x9zxhqEhhlJM+fM8v08jx6d7ZV+COn8zruc9xWlFIiIiCZiMjoAIiIKX0wSRETkE5MEERH5xCRBREQ+MUkQEZFPcUYHEGy5ubmqqKjI6DCIiCLK4cOHO5RS1vHHoy5JFBUVob6+3ugwiIgiiohcnOg4m5uIiMgnJgkiIvKJSYKIiHzSPUmIyGYRqRaRrX6u2zrZMkREFFy6JgkRqQAApVQtALtnf4LrqgHcPpkyREQUfHrXJLYAsGvbTQCqQ1SGiIiCQO8kYQHQ5bWfM/4CEanQag0BlyEiotAIx/ckso0OgCiYegZHsfesDVft13FPSS7KCzNgMonRYREFRO8kYcdYErAA6PQ+OUEtwm8ZrVwNgBoAmDNnTrBiJZoypRR2HL6Ml+sv4/ClbjhdY+u2WNMTsX5hHr6xfgEKLckGRknkn95JYjuAKm27GEAtAIiIRSllB1AsIsWe81on9YRlvCmltgHYBgBVVVVcRYkM5XQpfP+NU/jl/gsozU/D19aUYN2iPMzKSsa7jR3YfaYdvzt2Fe80tOP5P12JxYUZRodM5JOuSUIpdUREqrTRS3al1BHtVB2ASqXUDuDjmoHFTxmisHN9xIlv/vdR7DzVhic/MQ9//cCiG5qWPls5C5+tnIUzrb348vMf4rH/+AD/9ngFVpfeNGUOUViQaFu+tKqqSnHuJjJC/7ADX/z5Qfzxsh1/98nF+PI98255fWvPEL78yw/R2NaHHz+2DJ9aPlOnSIluJiKHlVJV44/zjWuiIPn735/E8ct2PPt4pd8EAQAFmUn47VN3ompuFrbuOI5z7X06REk0OUwSREHw1olr2HH4Mr5+73xsWlIQcLn0pHj8yxdWIDUxDn+x/RhGHK4QRkk0eUwSRNPU3juEv3r1I9w2KxPfWL9g0uXz0pPwg0eW4sSVXvysrjEEERJNHZME0TQopfDtHcdxfdSJn2xZjnjz1P6k7isvwGNVs/DsnvOov9DlvwCRTpgkiKbhpUMt2Ntow988sAgl1rRpfa2/e6gcs7JS8Je/PYahUWeQIiSaHiYJoim6PuLEj3c1YmVRNr5459xpf720xDj88JGlaOm6jt8cvBSECImmj0mCaIpeOHABHf3D+N/3lUEkONNs3D0/F/fMz8Gze85hcMQRlK9JNB1MEkRT0D/swLN7zmN1qRUr5wV3urFvbShDR/8IfrV/wiWHiXTFJEE0Bc+/14zuwVH8rw2lQf/alXOzsG5hHv5973n0Do0G/esTTQaTBNEk9QyOYtu7TdiwOB/LZltC8j2+taEUPddH8Z/vNYfk6xMFikmCaJJ+/l4T+oYc+FYIahEeS2Zm4v4lBfjFu83oHhgJ2fch8odJgmgSBoYd+OX7F/Dg0hlYNCO0s7f+5YZS9A078MIB9k2QcZgkiCbhtaNX0DfswBOr/M/NNF2l+elYXWrFiwcvweHkdB1kDCYJogAppfDCBxexZGYGVoSoL2K8P7lzLlp7h7DrVJsu349oPCYJogAdau5CQ1sfvnTn3KC9F+HPvQvzMNOSjF9/wCYnMgaTBFGAXjhwEZnJ8Xh4mX7rPphNgsfvnIMPmjo5lTgZgkmCKADtvUN460QrHq2cheQEs67fe0vVbCSYTXiBtQkygO5JQkQ2i0i1iGz1cb5a+3ja69jT2ucaveIk8vbSoRY4XAqPB2GOpsnKSUvEg7fNwCtHrqB/mFN1kL50TRIiUgEASqlaAHbP/rjzG7TzFV7na0TkPIAmPeMlAoBRpwsvHrqI1aVWzMtNNSSGL901F/3DDrx29Ioh359il941iS0A7Np2E4Bq75NKqSNKqe9ou8VKqSPa9qNKqRIteRDpak+DDW29w/iSAbUIjxWzLSgvzMBLnB2WdKZ3krAA8F5RJWeii7SmqKe8DlX4aaKqEZF6Eam32WxBC5YIAF4/egU5qQlYW2Y1LAYRwebKWTh1rReNbezAJv2EZce1UuoZAE+JiMWzr9UickSkeoLrtymlqpRSVVarcX/IFH16h0ax63QbHlpWOOVV54Llk7cVwmwSvM4mJ9KR3r/1dgCeeZUtADq9T4qIdz9EE9x9EZtFZLN2rBNAsQ5xEgEA3vqoFSMOFz69Qr9hr75Y0xOxakEufnfsKlwuZXQ4FCP0ThLbMXaTLwZQCwCeGgPcfRTeSaRJ+/D0RZQAqNchTiIA7mk4inJSsGxWptGhAAA+vXwmrtiv40Oug0060TVJeDqitSYju1fHdJ32eRuAYk/NQSm1Q7vmMe3Yea8yRCF1rec6DjR34tMrZur2hrU/G8vzkZJgxuvH2ORE+ojT+xsqpbZNcKxS+2yHO1EAwI5blSEKtd8fuwql3E/v4SIlIQ73lRfgzePX8PcPlyMxTt8X+yj2hGXHNVE4eO3oFayYY0GRQe9G+PLpFTPRO+TAO2c4ko9Cj0mCaAKnr/XiTGsfPhMGHdbj3VOSg9y0RI5yIl0wSRBN4HfHrsJsEjy4dIbRodwkzmzCQ8tmYPeZdvRc5xrYFFpMEkTjKKXwhxPXcHdJDnLSEo0OZ0IPLSvEiNOF3We4zgSFFpME0Tinr/XhYucg7l8SfrUIj+WzLMjPSMRbJ1qNDoWiHJME0ThvnWyFiHu4abgymQSbyguwt9GGwRHODEuhwyRBNM5bJ67h9qJs5IZpU5PHfUsKMDTqwt4GjnKi0GGSIPJy3taPxrZ+3L+kwOhQ/FpZlI3s1AT8gU1OFEJMEkRePG3895WHf5KIM5uwYVE+dp9px7DDaXQ4FKWYJIi8vH2yFctmW1BoSTY6lIBsWlqA/mEH9p/r9H8x0RQwSRBpLncP4vjlHmyKgFqEx90lOUhPjMMfTlwzOhSKUkwSRJq3T7rfOdgUAf0RHolxZqxflIddp9rgcLqMDoeiEJMEkeatE9ewsCDdsHWsp2rTkgJ0D47iUDOnD6fgY5IgAtDZP4z6i93YGEFNTR5rSvOQFG/CzlN8+5qCj0mCCMA7DTYoBWxYFL4v0PmSnGDGPSW5qDvTBqW4Yh0FF5MEEYDdZ9qQn5GIJTMzjA5lStYvykdL13Wca+83OhSKMronCW3N6moR2erjfLX28XSgZYimY8Thwr7GDqxbmBc2K9BN1rqFeQCA2tPtBkdC0UbXJCEiFQCglKoFYPfsjzu/QTtfISIV/soQTdfB5k70DzuwfmHkNTV5FGQmYcnMDNSdZr8EBZfeNYktAOzadhOAau+TSqkjSqnvaLvF2nrWtyxDNF11p9uRGGfCPfNzjQ5lWtYtzMeRS93oGhgxOhSKInonCQsA73F6ORNdpDUrPRVoGRGpEZF6Eam32TjZGQVOKYW6M224Z34ukhMie73o6kV5cClgTwObnCh4wrLjWin1DICnRMQS4PXblFJVSqkqq9Ua2uAoqpxt70dL13WsX5RndCjTtqQwE3npiahjvwQFkd5Jwg4gW9u2ALhhwhnvPgi4m5Zq/JUhmg7PDdXT8RvJTCbBuoV52Ndow4iDb19TcOidJLYDKNa2iwHUAoBXjaEaNyaEJl9liIKh7nQbygszMCMzMib082f9onz0DTvw4QW+fU3BoWuS0DqiISLVAOyefQB12udtAIpFZLN2/Y5blCGalq6BERy51I31EfgCnS+fmJ+LxDgTajnKiYIkTu9vqJTaNsGxSu2zHe5EAQA7blWGaLr2NrbDpYD1UdDU5JGcYMbdJTnYfaYd33uo3OhwKAqEZcc1kR72NNiQm5aApTMzjQ4lqO5dmIeLnYNo7hgwOhSKAkwSFJOcLoW9jTasXmCFyRSZb1n7srbUXTPiUFgKBiYJikl/vGyHfXAUa8qib8j0nJwUFOemYk8D3xmi6WOSoJi0p8EGkwCrF0RfkgCANWVWHGjqxPURrn1N08MkQTFpb0M7ls+2ICs1wehQQuLesjwMO1w40MTXimh6mCQo5nT0D+OPl3uwtix6RjWNt3JeNpLjzeyXoGljkqCYs6/R3VZ/bxQniaR4M+4qydEWU+JCRDR1TBIUczxDX8sLI3OBoUCtLbPiUheHwtL0MElQTHG6FPadtWF1afQNfR1vbCgsRznR1DFJUEzxDH2N5qYmjzk5KSi2pmJPI5METR2TBMWUPWfaYRJg1YLIXmAoUGtL83CgqRODIw6jQ6EIxSRBMWVvow3LZ1tgSYnOoa/jrS2zYsThwsEmzgpLU8MkQTGja2AEx69E99DX8VbOy0ZSvAl72eREU8QkQTHj3bM2KAWsKY3Ot6wnkhRvxp3FOR8P+yWaLCYJihl7G23ISonHkiib9dWf1QusaOoYQEvXoNGhUATSPUmIyGYRqRaRrT7O12gfT3sde9pzTq84Kbq4XAr7GjuwaoEV5igf+jqeZxJDNjnRVOiaJDzrVyulagHYvdaz9pyvBlCrLTJUrO0DQI2InId7OVOiSTvd2ouO/uGYamryKM5NxaysZCYJmhK9axJbANi17Sa417T2Vux1rAlja1s/qpQq0ZIL0aR5bpCrSmNj6Ks3EcHqUiv2n+vAiMNldDgUYfROEhYA3mPxcrxPKqW2eS1VWgGg3rN9qyYqIn/2NtiweEYG8tKTjA7FEGtKrRgYceLwxW6jQ6EIE5Yd11oz1C6l1BEAUEo9o9UicryaoLyvrxGRehGpt9lYpaYb9Q87cPhid1QuMBSou0tyEGcS7DvLvw+aHL2ThB1AtrZtAeBrsvtqpdQzwMcd3Zu1450Ya4L6mFYDqVJKVVmtsXsjoIntP9cBh0vFZH+ER3pSPCrnZmEv53GiSdI7SWzH2E2+GEAtAIiIxXOBiNR4JYhquPsmPH0RJRhrgiIKyN5GG1ITzKiYk2V0KIZaXWrFqWu9aO8bMjoUiiC6JglP85F287d79gHUeR1/WkTOi0i3V5nHtNrEea8yRH4p5Z719e75uUiIC8vWVd14alL7GjsMjoQiSZze39CrY9r7WKX2uRbATY97E5UhCkRzxwBauq6jZnWJ0aEYbvGMDOSmJWJfow2bK2cZHQ5FiNh+tKKo5xn6ujaG+yM8TCbB6tJcvHvWBqeLq9VRYJgkKKrtbbShODcVs7NTjA4lLKwptaJ7cBQfXekxOhSKEEwSFLWGRp040NSJ1axFfGzVAitEwAn/KGBMEhS1PrzQhaFRV0y/HzFedmoCbpuZySk6KGBMEhS19jbYkBBnwp3zcvxfHEPWlFpx9FI3egZHjQ6FIgCTBEWtvY023DEvG8kJZqNDCStryqxwKeC9cxwKS/4xSVBUumq/jrPt/TH9lrUvy2ZZkJ4Ux34JCsik35MQkSK4J9/LhntqjSa4X4zbHdTIiKbBcwNkp/XN4swmrFqQi72NNiilIBJb62vQ5ARckxCRb4vITgBPwz09hgDo0bY3ishOEXlWRJaHJFKiSdjbaMOMzCQsyEszOpSwtKbUitbeITS29RsdCoU5vzUJEZkH4CkA/62U+pGfazPhXiCoSin18yDFSDQpDqcL753rwINLZ/Ap2QdPDWtvYzvKCtINjobC2S1rElqCWK+U+q5S6pi/L6aU6tESSZ2IPBmkGIkm5ViLHX1DDvZH3MKMzGSU5adzKCz5dcskoZRqnkqNYKrliIJhT4MNZpPg7vmxtwrdZKwps+LD5m4MDDuMDoXC2KRHN4lIRigCIQqWPY3tqJhjQWZyvNGhhLU1pVaMOF344LyvZV2IpjYEtsS7c1pE5onIuuCFRDR17X1DOHGlF2vL8owOJexVFWUhNcGMdxrajQ6Fwtikk4RS6iiA27WhsFBKNQPIEpEfBDk2oknzrLy2llNx+JUYZ8bd83Oxp8E9FJZoIlNpbtoO4DyAbq+mp1oANcEMjGgq9jTakJeeiMUz2CoaiLVlVlyxX8d5G4fC0sSm0txUCaBeKdUDQLRhr9UAfhhIYW3N6moR2erjfI328XSgZYgA99DXdxttWFNq5dDXAHma5fZw7WvyYSpJ4lFotQYtUWQDyPL3DgUAiEiFVq4WgN2z73W+GkCtthJdsZYYblmGyONYix29Qw72R0zCTEsyFuSlMUmQT1Pqk1BK/aPXfjOAwwG+ab0FgF3bboK7BuKt2OtYk7bvrwwRgLGhr59YwKGvk7G2zIpDzV0cCksTCsoEf1pndnMAl1oAdHnt3zCHs1Jqm9d61hUA6v2VIfLg0NepWVuWx6Gw5FPQZoHVmp6CQmtS2qWUOhLg9TUiUi8i9TYbq82xiENfp66qKAspCWbsaeRQWLqZ32k5pjK9xi3K2eHuwwDcNQRfjy7VSqlnAi2j1UCqlFJVViuHPsaifY3utRE4FcfkJcaZcXcJh8LSxPxOywH3PEz/HsgLcyKSISLfhnu+p4mm5dgOdz8DtM+1WjmL19eo8SQIrSN7wjJE3t5paIc1PRHlhRz6OhVry6y43M2hsHQzv7PAaoniz0TkqyLyXQAKwBGMPdHnwP2EXwL3+xPPaGUm+lpHRKRKu/nbvZqT6gBUasefFpHvwF17ePQWZYgAAKNOF/Y12nD/kgIOfZ2iexe6m+l2n2nH/DzOCktjAl50SCn1HIDntPciquBODNlwd1g3aZ3XgXydbRMcq9Q+1wLICqQMkUf9hW70DTmwbmG+0aFErJmWZCwsSEfd6XbUrC4xOhwKI5NemU7roK4LQSxEU7L7TBsSzCYOfZ2m9Yvy8O97m9AzOIrMFI4QI7cpjW4SkSe1Veie5KywZLTdZ9pxR3E20hIn/cxDXtYtzIfTpbDvLEcI0pipzN30QwDz4V669DEAzSLyRLADIwrEhY4BnLcNYN1CDn2druWzLchOTcDuMxwKS2Om8uj1oVLqFc+ONjLpuyLyiFLq1aBFRhQAzw2NSWL6zCbB2lIrdje0w+lSMJs4CICC8DKdUsqulPou+CY0GcA9GicNc3NSjQ4lKqxblAf74CiOXuo2OhQKE1NJEk0i8qGI3DuuP4Lv9JOu+ocdONjcifWsRQTNqgVWxJmETU70sakkiS0AfgvgawAuaAnjbbhnbU0HABF5JIgxEk3ovbM2jDoVm5qCKDM5HrcXZTNJ0MemkiTOA3hZKfWYUiob7mnDawFsBHBRRM4CePpWX4AoGOpOtyMjKQ6Vc296tYamYf2iPJxp7cPl7kGjQ6EwMJWpwp+De7nSIm3/qFLqR0qpjVrS2ILAZoQlmjKXS+GdBhvWlOUhzhy0eSoJN759TTSlvy4tMVzwce4IgO9MJygif4622NHRP4zqRWxqCrbi3FQU56Zi16k2o0OhMBCSR7BAp+ggmqqdp1oRZxJODR4CIoINi/NxoKkTvUOjRodDBmM9nSKOUgo7T7bhrpIcLjAUIhvL8zHqVFzWlJgkKPKct/WjuWMAGxdzQr9QWT47C7lpidh5stXoUMhgTBIUcd4+6W4rr2aSCBmzSbBhcR72NNgw7HAaHQ4ZiEmCIs7OU21YNisTMzKTjQ4lqm1cXID+YQfXvo5xuicJEdksItUisvUW11SM239a+1wT6vgovLX2DOGPLXZsLC8wOpSod1dJDlITzNjJUU4xTdck4bn5a4sL2ccnA+2aagDPjTtcIyLnATSFPkoKZ7tOu29Y7I8IvaR4M9aW5WHXqTa4XFz7OlbpXZPYAsCubTcBqB5/gZZAusYdflQpVaKdoxi282Qr5uWmYn5emtGhxISN5fmw9Q3j2GW70aGQQfROEhbcmAACnTm2wl8TFUW/nuuj+OB8JzYuzuda1jpZW5aHOJNg50k2OcWqiOi4Vko9o9UicrTmKIpBexra4XApbGBTk24yk+NxV0kOdp5shVJscopFeicJO4BsbduCAKYX1zq6N2u7nQCKJ7imRkTqRaTeZuPLP9HqzePXkJeeiIo5nNBPT5uWFKCpYwBnWvuMDoUMoHeS2I6xm3wx3LPHela386XJcx2AEgD14y9QSm1TSlUppaqsVmvwoqWw0T/swJ5GGx5YOgMmrpimq/vKC2AS4P99dM3oUMgAuiYJbfI/zwgmu2cfQJ3nGq3WUOWpPWjXPKbtn/cqQzGk7nQbRhwuPHjbDKNDiTm5aYm4qyQHbx6/xianGDSVNa6nRSm1bYJjlV7bOwDs8FeGYsubx68hPyMRlWxqMsQDS2fgb147gdPX+rC4MMN/AYoaEdFxTbGtb2gUexptuH8Jm5qMsolNTjGLSYLC3u4z7RhxuPBJNjUZJsfT5PQRm5xiDZMEhb03jl9DQUYSRzUZ7MGlhWjuGMDpaxzlFEuYJCis9Q2NYm+jDfcvLWBTk8HuK8+H2SR486OrRodCOmKSoLBWd5pNTeEiJy0RdxVzlFOsYZKgsOZpaloxm01N4eDB22bgQucgTl7tNToU0gmTBIWtroER7Glox8PLC9nUFCY2lRcg3ix47egVo0MhnTBJUNh64/hVOFwKn1kx0+hQSJOVmoB7y/Lwu2NX4XC6jA6HdMAkQWHr1SNXsLAgHYtm8OWtcPJIxUx09A/jvXMdRodCOmCSoLDUZOvHsRY7HqlgLSLc3LswD5nJ8WxyihFMEhSWXj96BSYBPrWcSSLcJMaZ8eBtM/D2yVb0DzuMDodCjEmCwo5SCq8du4J75uciPyPJ6HBoAo+smImhURfeOtFqdCgUYkwSFHbqL3ajpes6O6zDWOXcLMzJTsFrRy8bHQqFGJMEhZ1Xj1xBcrwZ95UXGB0K+SAi+PSKmdh/vhPXeq4bHQ6FEJMEhZWhUSfePH4Vm5YUIDVR95nsaRI+s2ImlAJeP8ppOqIZkwSFlbdOtKJ3yIHNlbOMDoX8mJebiqq5WfhtfQun6YhiuicJbc3qahHZeotrKiZbhqLDi4cuoSgnBXcV5xgdCgXgC3fMQXPHAD5o8rtcPUUoXZOE5+avlKoFYB+fDLRrqgE8N5kyFB3OtffhUHMXPrdyDqfhiBAPLJ2BzOR4vHjwktGhUIjoXZPYAsCubTcBqB5/gZYMuiZThqLDS4daEG8WNjVFkKR4Mx6pmIm3T7ais3/Y6HAoBPROEhbcmAACaVOYShmKMEOjTrxy5DI2lhcgNy3R6HBoEr6wcg5GnQo7DnM4bDSKio5rEakRkXoRqbfZbEaHQ1Pw1olW2AdH8YWVc4wOhSZpQX46bi/KwkuHLrEDOwrpnSTsALK1bQuAQHq7/JZRSm1TSlUppaqsVuu0gyT9vXiQHdaR7PMr5+BC5yA+OM8O7Gijd5LYDqBY2y4GUAsAImKZbBmKHufa+3DoAjusI5mnA/s3h9iBHW10TRJKqSPAxyOY7J59AHWea0RkM4Aq7fOtylCU+NX+i0gwm9hhHcGS4s34bMUsvH2iFa09Q0aHQ0Gke5+E1jRUq5Ta5nWs0mt7h1IqSym141ZlKDp0D4zg5cMt+NTyQnZYR7gv31MEl1L45f4LRodCQRQVHdcUuV48dAlDoy48uarY/8UU1mZnp2DTkgK8ePAiBjiFeNRgkiDDDDuc+OX+C1i1IBdlBelGh0NB8MQnitE75MDL9S1Gh0JBwiRBhvn9sauw9Q3jq6xFRI3KuVmomGPBf75/AU4Xh8NGAyYJMoRSCr94rxll+elYtSDX6HAoiJ5cVYxLXYPYdYoLEkUDJgkyxHvnOnCmtQ9PrJoHEQ57jSb3lRdgdnYyfv5us9GhUBAwSZAhtu1rQm5aIj61vNDoUCjIzCbBV+6Zh/qL3Th8sdvocGiamCRId4cvduHdsx14ctU8JMaZjQ6HQuCxqtnITk3AT2sbjQ6FpolJgnT3k11nkZOagD+5a67RoVCIpCbG4c/WFOPdsx2ov9DlvwCFLSYJ0tXBpk68d64DX1tbgpQELk8azb50ZxFy0xLxE9YmIhqTBOnqJ7WNyE1LxON3sBYR7ZITzPizNcV4/1wnDnDluojFJEG62X++AweauvDna0uQnMC+iFjwxTvnwpqeiB/vauQ04hGKSYJ0oZTCT3edRX5GIr5wB9eMiBVJ8WZ8fW0JDjV3cRrxCMUkQbqoO92OQxe68PV75yMpnrWIWPK5lXMwIzMJP/jDGbj4FnbEYZKgkBt2OPH9N0+hxJqKz3PluZiTFG/G1k1l+OhKD5c4jUBMEhRyz79/ARc7B/F3D5Uj3sxfuVj06eUzUTHHgmfePoO+oVGjw6FJ4F8shVR77xD+pe4sqhflYU0pl5aNVSKCv3+4HJ0DI/iX3eeMDocmQfckISKbRaRaRLYGel5EntY+1+gVJwXH0281YNSp8LcPLjY6FDLYbbMseLRyFp5/vxlNtn6jw6EA6ZokRKQCAJRStQDsnv0AzteIyHkATXrGS9Nz9FI3XjlyGV/5xDwU5aYaHQ6FgW/ftxCJcWb8wxunOCQ2Quhdk9gCwK5tNwGoDvD8o0qpEi15UAQYGnVi647jKMhIwv9cN9/ocChMWNMT8RfVC7CnwYbXj10xOhwKgN5JwgLAeyKXnADPV9yqiYrCz09qG3G2vR8//OxSpCVy+g0a8+V75qFybha+97uTaO0ZMjoc8iMiOq6VUs9otYgcERlf+4CI1IhIvYjU22w2AyIkb4cvduO5fU34/MrZWFuWZ3Q4FGbMJsE/ProMI04X/urV42x2CnN6Jwk7gGxt2wJg/CuYN53XOrI3a8c6Ady01qVSaptSqkopVWW1cgSNka6POPHtl/+IGZnJ+OsHFhkdDoWpebmp+M6mhXinwYaX6/nuRDjTO0lsx9hNvhhALQCIiOUW55s81wEoAVCvR6A0Nc+8fQZNHQP40ebbkJ4Ub3Q4FMb+x11FuLM4G//wxim0dA0aHQ75oGuSUEodAQCtycju2QdQ5+u8duwxrTZx3qsMhZk3jl/F8+9fwJ/eXYS753Pdaro1k0nwo83LIAC+9pvDGBp1Gh0STUCirT2wqqpK1dezsqG3M629+Mz/3Y/FhRl46at3IiEuIrq7KAzUnW7DE7+qxyMVM/FPjy7jmucGEZHDSqmq8cf5l0zT1jM4iqdeOIz0pDg8+3gFEwRNyvpF+fiL6gV49cgV/PqDi0aHQ+Pwr5mmxelS+Ob2o7hqv45nv1iBvIwko0OiCPSNdQtQvSgP33/jFA5ygaKwwiRBU+ZyKfzVq8exp8GG7z1Ujsq52f4LEU3AZBL8eMtyzMlOwVd/XY9TV3uNDok0TBI0JUopfP/NU/ht/WV8Y918fPFOLkdK05ORFI9ffWUlUhPj8Cf/eRDnOb9TWGCSoCn5Se1ZPP/+BXz5niL85YZSo8OhKDE7OwX/9eQdUAr44s8P4nI3h8YajUmCJkUphZ/WNuKf687isapZ+D8PLuZoFAqqEmsaXnjiDgwMO/CF5w7iYueA0SHFNCYJCtio04XvvvIRflp7Fo9UzMQPHrkNJhMTBAXf4sIM/PqJO9A7NIpH/m0/jrXYjQ4pZjFJUED6hx148lf12F7fgm+sm49/enQZzEwQFELLZ1vw6tfuRmpiHD637QPsOtVmdEgxiUmC/Drb1ofNz+7He+c68MNHluJbG8vYxES6KLam4dU/vxtl+el46oV6/HPdWThd0fUCcLhjkiCflFL4zcGLeOhf30N73zCe/9Pb8bmVc4wOi2JMbloiXqq5E5+8rRA/3tWIzz93AFft140OK2YwSdCE2nqH8NQLh/E3r53A7UXZeOubq7Caa1STQVIS4vCzzy3HPz26DCev9OD+n72L3x27wmnGdcC5m+gGww4nfvFeM/519zk4nApbN5XhK/fMYwc1hY0LHQP45vZj+GOLHSuLsvG9hxejvDDT6LAinq+5m5gkCADgcLrwhxOt+MedDbjYOYgNi/Pxtw8uwtwcrk1N4cfpUvhtfQt+9HYD7IMj2HL7bPz52vmYnZ1idGgRi0mCJjQ06sSOw5fx3LtNuNg5iAV5afg/n1zMpiWKCD2Do/hpXSP+68BFuBTw8LJCPLWmGAsLMowOLeIwSdDHlFL46EoPXjl8Gb//41V0D45i2WwLvramBBsX57NpiSLOtZ7r+MW7zXjx0CUMjjixsigbn62ciQeWzuDiVwFikohxDqcLx1rseKehHTtPtuFsez8S4kzYsDgfj98xB3cV53BYK0U8++AIXjx0CTsOX0aTbQBJ8SasW5iHe8vysKbMirx0zlLsS9gkCW2FOTuACqXUM4Gc91fGG5OE29CoEyeu9ODwxW4cudSNA01d6Lk+CrNJUDU3Cw8vL8QnlxYiM4VPWRR9lFI41mLHK0cuY9epNrT1DgMAygszcHtRNirmZqFybhYKM5P4cKTxlSTidA6iAgCUUrUiUiwiFd7LkU503nPOV5lY5nIpdPQP41LXIFq6B3GhYxBn2/vQ0NqHC52DH790NDcnBRsW5+Pesjx8YkEuMpOZGCi6iQhWzMnCijlZ+P6nluDUtV7sabDh3bM2bP+wBb/cfwEAYEmJR2l+Osry01FiTcXs7BTMyU7BrKwUJCeYjf1HhAldkwSALQB2adtNAKoBHPFzPsdPmYihlILTpeBwKYw6XXA4FUacLow4XBh2uDA06sTQqBPXR50YGHZiYNiBfu2je2AE9uujsA+OwNY3jPa+Ydj6huHwevtUBJibnYLS/HTcv2QGbpuViYq5WchNSzTwX01kLBFBeWEmygsz8fV758PhdOFMax+OXOrG6Wt9aGzrw+tHr6Bv2HFDufSkOOSlJyIvPQnZaQnISomHJTkBmcnxSEuKQ2piHNISzUiOj0NyghlJ8SYkxpmREGdCgtmEhDgT4s0Cs0kQbzJFbF+f3knCAqDLaz8ngPP+ytygobUPa370zi2DGN/CpqAmPDdRS5xS7quVcpdzf9aOK8ClFFzK/ZTv2Xa6FJxagpiqlAQzLMnxsKQkIDc9EQvy05GXnoiCzCTMzk7B7KwUzMpKRlI8n36IbiXObMKSmZlYMnPs3QqlFDr6R9DSPYiWrkFc7r6O9t4htGsPZKev9cI+6H5Im+qfsQgQZxKYxJ04TCIwiXvBJc82IBABBIBJxrbd5eWmrzfRtvZVfJ6bLL2TREiISA2AGgDIKCzGitmWQMrcuO9jR3Dzf4x8/Fn7TxT31zOJ9h+LG//jzSaT+5fDJIgzCeLM7ieLOLPc8NSRHG/WnkjMSI43Iz0pDmmJcUhLikNiHG/+RKEiIrCmJ8KanoiKOVk+r3O5FPpHHBgYdn/0DTkwNOpuBRgccWLE6fy4ZWDE4YLD5X44HHW64NJaEZzaA6TT5XmovPEBExjb9zyoeh5MPbwfbHHTQ6/X9iT6nPf5OK53krAD8KxxaQEwfjFbX+dvVQZKqW0AtgHujuuffm5FcKIlIvJiMgkykuKREYXDan/2+YmP650ktgPw9J4XA6gFABGxKKXsvs77OEZERCGm6wR/nlFJIlINwO41SqnO1/lblCEiohDTvU9Caxoaf6zSz/mbjhERUehxqnAiIvKJSYKIiHxikiAiIp+YJIiIyCcmCSIi8inqpgoXERuAiwaHkQugw+AYwgV/FmP4sxjDn8WYcPlZzFVK3bTaWNQliXAgIvUTTbkbi/izGMOfxRj+LMaE+8+CzU1EROQTkwQREfnEJBEafEN8DH8WY/izGMOfxZiw/lmwT4KIiHxiTUInIrLV6BiIKDyF8/0hKhYdCnfaDLa3Gx2H0bTFoQCgRCn1HUOD0ZmIbIZ7vZQKpdQzBodjqFj+PZhIuN8fWJMgXWh/CLXajL7F2n5MEJEKAFBK1QKwe/ZjUSz/HkQqJokQE5EK7eYQ64oBeG4ITdp+rNgCdy0CcP/bY/nGGMu/BzeJhPsDm5tCL9v/JdFv3JogFXCvQhgrLAC6vPZzDIrDcDH+ezCRsL8/MElMk1f7qrcmpVRtJDwl6E1ratnFFQZjG38PIqMWATBJTJufVfOKRaTYa7simv8obpUwvfarY7Dj1o6xJ0YLgE7DIgkfsfh7MF5E3B+YJEJIKbUD+PjmaTE2mtDzt8ysiNR4bgwiUh0JT1FBsh2AZ26eYgCx8u+eUAz/HtwgUu4PfJmOdKGNYnkZ7rb5bACPxtLNQbsRNAEojuU122P99yASMUkQEZFPHAJLREQ+MUkQEZFPTBJEROQTkwQREfnEJEFERD4xSRARkU9MEkRE5BOTBBER+cQkQUREPjFJEOlARCpE5LyIvOy1bzE4LCK/mCSI9FENoBLAf3hmy1VK2Q2NiCgAnLuJSEda7SFbKdVkdCxEgWCSINKJp3mJNQiKJGxuItKBZ3EZT4LwWmyGKKxx0SGiENOW6qwC0CUitXD3T9jhXl+CKKyxJkEUQl5NTNvgXpWuGcDtXGiHIgX7JIiIyCfWJIiIyCcmCSIi8olJgoiIfGKSICIin5gkiIjIJyYJIiLyiUmCiIh8YpIgIiKf/j9mV0b83Qb2HgAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -15338,7 +15057,7 @@ To construct this you need to give the bin edges (shape=(N)) and the bin values 
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAZZElEQVR4nO3dX2xU993n8c83RqDHjwD/GW8iJSbU/BF1kNiaoUWVm4vWNJCL1XTX6eqBG/xs4iyVEJXih3QXehWqFY4rNc0FC4mW3OSilKeyVKlJZZO9GUU0GPKwQl4UwGlLKpF6whisWIIFvnvhM/EwmT/+x7F/nvdLsjxnfud3zm8Ow3z8O/M7v2PuLgAAQvPYQjcAAIDZIMAAAEEiwAAAQSLAAABBWrbQDQCwuJ0/f/7fLVu27G1Jm8UfvYjfA0mX7t279+LWrVv/nl9AgAEoa9myZW8/8cQT32xqaso+9thjDFtGrB48eGCjo6OtN27ceFvSf8gv468pAJVsbmpquk14YSE89thj3tTUdEuTZwAeLluA9gAIy2OEFxZS9P77Wl5xChHAzPzSts7r9l7x8+WK0+l07csvv/z0s88+e/u11167kU6na/fv3//0gQMHbjz//PO3X3nllafee++9kWJ1T548Wd/V1ZWd1/bOUGH7E4nE/WLrPaq29vf3r+zt7X3iww8/vFJqnenue9++fU82NjbeO3LkyOf5z+de449+9KOb69atu3vt2rXl69atu9vV1ZUtLPviiy9qJKmnpyeTX/fZZ5+9/e1vf3viiy++qPnd735XX669OfTAACxq7e3tE2vWrLmzZ8+ebCKRuJ9KpcZXrVp1f+/evdnW1ta7pcIrk8nUDAwMrIq7vYUK219snUfZ1lQqNb569eqi+53pvvfs2VM05HKvcefOneNdXV3ZI0eOfH7gwIGnM5lMTWFZLrj6+voS+XX37NmTzZW/9NJLmem0hx4YgGCl0+nagwcPPvnhhx9eSafTtZlMpiabzS6rr6+/l0gk7l+8eLG2v79/ZSqVGpcmPzS3b98+cfbs2dr8D9LGxsb7uV5DfX39vd7e3ideeumlzLVr15YfOXLk8/7+/pVXr15dsX79+jupVGo816s5ePDgjaGhodpcvVOnTjX8+te//qxUUElTPaJc3Z07d45LUn5bM5lMza9+9atEMpmcyO03v03JZHLi0KFDT/3iF7/4LL9dpV5j4f7z61y+fHlFuX339PRkDh8+/HgymZwYGhqqnY9/t71792a/9a1vfbNY+9LpdO13vvOdL6ezHQIMQBDef//9lZlMpkaSbt++XSNN/vWe6128++679c8999ztrq6u7PDw8PLW1ta7a9as+eqD/fDhw4/v3LlzvL29fSKTydT09fUl1q9ff6exsfF+V1dXdteuXS25U2P79+9/OndKbXh4eHnug/y73/3uhlQqNZ5Kpcb379//dCqVGt+4ceOdF1988ekPP/zwytWrV1ek0+na3D6LKaz75ptvNh07duxv+W39+c9//sSePXuy7e3tE7t3727o6enJ5LdJknp7e+9F6483NzdvTqVSl4q9xvyQKPZacj2gUvvu6+tTMpmcSKVS44lE4v7777+/stRrO3v2bG0mk6m5evXqijfeeOMvpYI8kUjc/+yzz1YU/vuePXu2Vpo6vVgJpxABBGHnzp3jufBYtWrV1z4YX3vttRvHjx9vam5u3nzz5s2v/XH+wQcfrGpoaLgnSRs3brxz5syZVe3t7RMfffRRbTqdrv3BD35wO7fu5s2bJ3KPW1tb7/b09GRy4VlsnS1btkxIUmNjY8meV6m6xVy8eLE2k8nUpNPp2p/85CejxerknxZsbm6+Mzw8vLzYa8yvU+q1lNv3mTNnVm3cuPHOdF7X9u3bJ1Kp1HhPT0+m3HdqmUym5qmnnnpomzt37hzfu3dvdrrHUCLAACwRv//971e99957Ix9//PH/LewlpNPp2i1btkx88sknKyTpk08+WbF169Yv//73v9c899xztzdt2nSn1F/96XS69vDhw4/H8Rpy+/v+979/W5rsYW7atKloeNy6deurELp+/fqK1tbWu8VeY+G2y72WYvveunXrl3/605/+UZoMnrm/Qumdd96pP3DgwI3C5xOJxP2ZDGThFCKARS2dTtf+9a9/XfHuu+/Wb9q06U46na69fv36infeead++/btE5cuXaodHh5e/tFHH9VK0oYNG+7s3r07K0lr166909/fv7K9vX3i2LFjf8t9eA8NDdUeOXLk8+Hh4eXHjx9vOnXq1P1sNltz6NChG5lMpubSpUu16XS6tr29feLKlSsr6urq7l++fHnF2rVr7548ebJ+w4YNd3L7/cMf/rDq4sWLtcPDw8sHBgZWrV69+l7+KcTC9l++fHlFYd1MJlOT39b29vaJwqDJb5Mk3bp1a1k6na49e/Zs7ZtvvvkXSSr2GtPpdG1uf8VeS1dXV7bcvo8cOfL54cOHH0+n07VDQ0O1H3zwwapMJpPJPz1Y+BqLleVOAV+9enWF9PAoxFzdhoaGe62trXen+94w7gcGoJyLFy/+ecuWLdP6TiI0+/bte/LYsWN/K7W8mO3ataul1AjMpejixYuJLVu2rM1/jh4YgKq1Z8+ebK5HdeXKlRWlhokvNv39/StzvaqZ9FiWGnpgAMpayj0whKNYD4xBHACAIBFgAIAgEWAAgCARYADm3x//uVl//OfmhW4GljYCDMCilk6na5955plv7tu378lMJlPT39+/srm5eXNfX19ieHh4+a5du1pK1T158mR9nG0tJtf+w4cPP37y5Mn6vr6+RO46q0rtL7et/v7+lSdPnqx/5plnvjnd+vv27XsyzouyHzWG0QNY1IrNRn/o0KH7e/fuzSYSifuVZqNf6NuptLe3T2zZsmUiN0ehJDU3N2/+6U9/mik3m36pbeVmds9ta8OGDXcymUxNuQmEc/bs2ZMtN5dhaAgwAMEKcTb6kydP1n/ve98bTyQS9/PbX2yW+lxIldtWLqDL1S82m3zh8So3AfFixSlEAEF4//33V/b396/s7+9fWWo2eknq6urKbty48U7hLOuHDx9+fPv27RPt7e0T69evv9PX15fo7+9fmZuN/vz58//Y1dWVTaVS49evX1+Ru69V/gzuvb29T0iTM8pfv359RSqVGt+9e3f2rbfeSqRSqfG2trYv0+l00VuOnD17tjadTtfW19ffa2tr+7Kw/YXbzL2eUseir68vkbs5ZLn6fX19idxs8rlbtxQ7XnP5t1koBBiAIIQ+G30uPFOp1PiZM2dWFft+rtIs9Tk7d+4c7+npyTz//PO3pcneVKn6pWaTr3S8QkCAAVgSQpqNPn8m+blobW29m8lkasrNEl9qNvlyxysUQaYugOqxFGajv3jxYm3+bOxr166929XVlc2fKf7mzZvLis1SXziz+6VLl77aVjabXdbX1/fEb3/722v528qvX2o2+WLHKzTMhQigrFnNhZi7Buy5/3X9UbRpvoQ8G321YTZ6AMgT6mz0mEQPDEBZzEaPxYDZ6AHMxoMHDx7YQjcC1St6/z0ofJ4AA1DJpdHR0dWEGBbCgwcPbHR0dLWkS4VlfAcGoKx79+69eOPGjbdv3LixWfzRi/g9kHTp3r17LxYWLLkASyQSvnbt2oVuBgAE5fz58xl3b1rodszEkguwtWvXamhoaKGbAQBBMbO/LHQbZir20wFm1mlmHWbWXaK8I/o5mvdc1swGzOxgfC0FACxmsQaYmXVKkrsPRssdBeVtktqi8jYzy90n5wV33+HuvXG2FwCweMXdA9smKXfvmxFJbfmF7n7B3XvNrE7SiLvn1q3LCzMAAGIPsLqC5cYS6yUlXctbbpB008yOF1vZzLrNbMjMhkZHR+feSgDAohd3gI1pMozKik4hrss75XjC3cckjeWeK1j/hLsn3T3Z1BTUIBoAwCzFHWDnNNULa5E0kF9oZkfzBneMSWqIelcPnWoEACDWAHP305JaosEbdXmDOXJBdlzSSF75CUmnonU687YBAKhyS24y32Qy6VwHBgAzY2bn3T250O2YCaaFAQAEacnNxAEU9Uvmof3KK0vrrAuqFz0wAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkJbFvUMz65Q0JqnF3U8UKe+IHu5w91enUwcAUH1i7YFFQSR3H4yWOwrK2yS1ReVtZtZSqQ4AoDrFfQpxm6SR6PGIpLb8Qne/4O69ZlYnacTdRyrVAQBUp7gDrK5gubHEeklJ16Zbx8y6zWzIzIZGR0fn1EAAQBjiDrAxSQ2VVopOF67L++6rbB13P+HuSXdPNjU1zUc7AQCLXNwBdk5TPaoWSQP5hWZ21My6o8UxTQZX2ToAgOoUa4C5+2lJLdFAjLq8gRm5UDouaSSv/ESpOgCA6hb7MHp3740eDuY9tyP6PaKpARuD5eoAAKobFzIDAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIIUe4CZWaeZdZhZd5GyOjNri9Y5mvd81swGzOxgvK0FACxWsQaYmXVKkrsPRssdBav8WFLS3U9H5bmQe8Hdd7h7b2yNBQAsanH3wLZJGokej0hqyy909xPufiJabMlbt87MWuJpIgAgBHEHWF3BcmOxlaKwupnrqUlqkHTTzI6XWL/bzIbMbGh0dHTeGgsAWLziDrAxTYZRJZ3u/nJuIeqZjUkay52GzBeVJ9092dTUNG+NBQAsXsti3t85TfXCWiQNFK5gZp2577rMrE1SUtKQu1+Iq5EAgMUv1h5YNDijJRq8UZc3mGMg+t0h6aiZnTez85rsrZ2KyjrztgEAqHJx98CUN5JwMO+5HdHvQUnrilS7EP0QXgAASVzIDAAIFAEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAI0rK4d2hmnZLGJLW4+4mCsjpJLdHPNnd/tVIdAEB1irUHFgWR3H0wWu4oWOXHkpLufjoq755GHQBAFZpxD8zM/r2mekljkm5KGnH3f5tG9W2SfhM9HpHUJmkwV1jQu2qRNCBpR7k6AIDqNK0AM7O1kn4m6RuaDJERTYaXSVon6Ydm1iLpmqSj7v7nEpuqK1huLLG/Fkk33X3QzF6oVMfMuiV1S9KaNWsqvh4AQPgqBpiZ/YukBkmvuvutCuuultRtZll3f7vIKmPRtirpdPeXp1sn6rmdkKRkMunT2D4AIHBlAywKr9Pu/ul0NhYF3Otm9g0z63H3voJVzmmqF5Y7RVi4z053740et02nDgCg+pQdxOHur083vArqfVokvBQNzmiJBmLU5Q3MGIh+d0g6ambnzey8pIZSdQAA1W02gzjWlvmOq6Jc70oPD97YEf0e1OR3ahXrAACq22yG0deb2Yu5BTP7T2b2/XlsEwAAFc04wNz9Y0nrc6Hl7v+qyVGI/2W+GwcAQCkzDjAz+6Mkl3Q+uiZMkv6HpN6SlQAAmGezOYW4TtLxaMShRUPn34p+AACIxWwC7IeSXjWzVdHpxA5JH7n7z+a3aQAAlDab78BG3H2fu9+Olv9V0i0GcgAA4jQvk/m6+1uSZny9GAAAszVvs9HP5oJnAABmq2yAmdm/RBP5zkhuKqlZtwoAgArKzsTh7q+b2UvR7PDHK83AYWarJP13SZliU0kBADBfKk4l5e5vmdk3JP1XM/uWpm6lck2Tk+w2Rr/XRc/1cjoRAPCoTWsuxCiQfiZNnh7U1A0tb2ly8MZINKQeAIBYzHgy3yjMPpV0Zv6bAwDA9Mw4wCQpmsw3d8rwVO6aMAAA4jKbuRD/p6T1kkzSjyV9ykS+AIC4zaYHNhDNviFJMrM6ST8zs//o7r+bt5YBAFDGnC9kdvexaB7ExnloDwAA0zKbABsxs3Nm9qPouq+cL+arUQAAVDKbAPvPkk5J+idJf47C7DeaHFYvSWJiXwDAozab78CuafJ7sNclKbq4uUOTd2X+b5q80FmSts1PEwEA+LrZ3E7lLUn1uTkS3f1jd3/d3X/o7o2SXpaUnd9mAgDwsFldB1Zu1g13v2Bmr86+SQAAVDZvt1PJx7RSAIBH7ZEEWDlm1mlmHWbWXaZ8oOC5rJkNmNnBeFoJAFjsYg0wM+uUJHcfjJY7Ctdx99NFqr7g7jvcvfcRNxEAEIi4e2DbNDVKcURS2zTr1UX3JAMAQFL8AVZXsDzd2TsaJN00s+PFCs2s28yGzGxodHR0Lu0DAAQi7gAb02QYzYi7n3D3MUljudOQRcqT7p5samqaeysBAIte3AF2TlO9sBZJA6VXnRT1rqZ7qhEAUCViDbBogEZLNHijLm8wx1dBFpUl83pap6LnO/O2AQCocrO6kHku8kYSDuY9tyPv8aCk+rzlMUkXoh/CCwAgaQGuAwMAYD4QYACAIBFgAIAgxf4dGKrML22hW4BCi+Hf5BVf6BZgCaAHBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACFLsAWZmnWbWYWbdZcoHZlIHAFB9Yg0wM+uUJHcfjJY7Ctdx99MzrQMAqD5x98C2SRqJHo9IantEdQAAS1zcAVZXsNw4H3XMrNvMhsxsaHR0dJZNAwCEJO4AG5PUMN913P2EuyfdPdnU1DTLpgEAQhJ3gJ3TVI+qRdJA6VXnVAcAsMTFGmDRAI2WaCBGXd7AjK9CKSpL5g3eKFoHAFDdlsW9Q3fvjR4O5j23I+/xoKT6SnUAANWNC5kBAEEiwAAAQSLAAABBIsAAAEEiwAAAQSLAAABBIsAAAEEiwAAAQSLAAABBIsAAAEEiwAAAQSLAAABBIsAAAEEiwAAAQSLAAABBIsAAAEEiwAAAQSLAAABBIsAAAEEiwAAAQSLAAABBIsAAAEGKPcDMrNPMOsyse7rlZpY1swEzOxhfSwEAi1msAWZmnZLk7oPRcsc0y19w9x3u3htjcwEAi1jcPbBtkkaixyOS2qZZXmdmLY++eQCAUMQdYHUFy43TLG+QdNPMjhfbqJl1m9mQmQ2Njo7OuZEAgMUv7gAb02QYzajc3U+4+5iksdxpxiLlSXdPNjU1zVNTAQCLWdwBdk5TvawWSQOVyqPeVeGpRgBAlYs1wNz9tKSWaHBGXd5gjYEy5aeidTrz1gEAVLllce8wbyThYN5zO0qVR6cOL0Q/hBcAQBIXMgMAAkWAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAgkSAAQCCRIABAIJEgAEAghT7bPSI0S9toVsAFLdY3puv+EK3AHNADwwAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAEKSlF2Dj1xd2///7p5M/C20xtAFY7Bb6/8ki+rx4ul7NC92MmVp6AQYAqAqxz8RhZp2SxiS1uPuJ6ZRXqgMAqD6x9sCiIJK7D0bLHZXKK9UBAFSnuHtg2yT9Jno8IqlN0mCF8sYKdRafC29M/gBY3BbD/9W2Awu7/4DFHWB1BcuN0yivVEdm1i2pW5KW1+j/mdn/mXUL5+jpejWP39E/3JzQJwvVhlw7JOkvWS3YqBaOxcNt4FhMtYFjMdWG8Ttv/MPNiTcW/FhkvtSqhWzDbMQdYGOSGmZYXqmOou/FFs13Y2Y25O7JhW7HYsCxmMKxmMKxmMKxmL24A+ycpnpULZIGplFeV6EOAKAKxTqIw91PS2qJBmLU5Q3MGChVXqoOAKC6mTs3dJtvZtbNcP9JHIspHIspHIspHIvZI8AAAEFiJg4AQJAIsJiY2dGFbsNCMrM6M2szs85qPBbR6+6ILvmoWtX+PiiFYzE7BFgMogEoLQvdjgX2Y0nJaFCOqumDnNlkHlK174NS+HyYvdjnQqw2ZtaiyRlEqlrBl9TVdjlEpRloqkaVvw++hs+HuaEH9ui1uDtv0Ej0H/ZmlV0OUVew/LXZZKpNlb4PiuHzYQ7ogc1RdHqocKaQEXcfNLOOavoPWu5Y5C13uvvLMTZrMRhThdlkqlA1vg8eUm2fD48CATZHuXP5JdzMXYCtyYux29z9Qjwti1+FYyEz63T33ujxkj4WBSrNQFNVqvh9UKiqPh8eBU4hPkLufiH6C6tBXz+NVFWi/6hHzey8mZ1XFfVImE1mSjW/Dwrx+TB3XMgMAAgSPTAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAECQCDAAQJAIMABAkAgwAECQCDAgBmbWYmbXzGwgWm6LZmQHMEsEGBCPVyXtkHQhuvtukttoAHPDXIhADMyszt3HzKxOk+FVtRP6AvOFAANiYmZt0uQs5AvdFmAp4BQiEIPoZp8jufCKlgHMAQEGPGJm1q3JG1m+ZWZ10XdgYwvbKiB8BBjwCEUjDUeiOxCPSPpU0jW+AwPmju/AAABBogcGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAIEgEGAAgSAQYACBIBBgAI0v8H3zDkkO7Z8OgAAAAASUVORK5CYII=
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAZT0lEQVR4nO3df2hc553v8c83Njarxfqtm0BWjlZyTWMb3DuaQijqH3tX2bULuQyLE4P9T7Tbq1wXwi1U1ym3/i8Od+NVwG3/8I0aVoXisnayF4H/iEPkLqVDMezYXS+ubnEsJSUtuFcja2xRgXJtP/ePOcc6Hs8vyaMz82jeLzA65zznmfPMaDwfPec88xxzzgkAAN88Ve8GAACwHgQYAMBLBBgAwEsEGADAS1vr3QAAje3KlSv/YevWre9J2if+6EX8Hki6fu/evW8ODg7+32gBAQagrK1bt773zDPPPN/T07P41FNPMWwZsXrw4IHNz8/vuXXr1nuS/nO0jL+mAFSyr6en5y7hhXp46qmnXE9Pzx3lzwA8WlaH9gDwy1P1DK90Ot3S29u778iRI89ls9ktU1NTO1pbW79y4sSJp2dmZrYdPHiwv15tq0bY/mPHjj2bzWa3xH38qampHV/72te+VIvHOnbs2LMnTpx4unB79DlOTk52HDt27NmpqakdxcrGx8e7JycnO0rVPXHixNN79+59Pvr4wfvvsbziFCKAtXnHBmv6eN9xV8oVDw0NLe/bt2/5W9/61nx3d/f9VCq11Nvbu/Ltb387293dff8nP/nJb0vVnZyc7BgZGVmsaXvXKGz/0aNHF7u7u++X2m+j2ppKpZbefffdnnL7VHvso0ePLl68eHFH4fahoaHlr3/960tHjx5dHBoaWh4ZGVlsbW39yt27d/+tsEzKB2FHR8e9VCq1FH19wvJq0QMD4K2ZmZltv/nNb7YXK8tms1s+/vjj1rjbtB71bOtajt3Z2Xmv2sdta2u7NzMzs61Y2euvvz7/ve99789KtSeZTFYVZPTAAHjt+PHjz/7yl7/8JJ1OtxSeort27VpLtHcxPj7e/cILLyxfvny5ZWxsLJvNZrecPn26O5lMLmcymZb29vb7XV1d98+fP9/xyiuvLM7Ozm47efLkH8JTXgsLC1vGxsayU1NTO06dOvXM8ePHb2UymZaBgYEvOjo67p0/f77zBz/4we/K9bQK6x44cGApm81uKWzriRMnnk4mk8s3b97cXtimgYGBL8bHx5956623fnfz5s3tu3btWkmlUkvFnmPh8QufSzqdbil37LGxsWy4nslkWqr5nWSz2S2tra339+zZ80Wx8j179nzx+eefF/3D48KFC63V9kTpgQHwwsWLF3dMTk52TE5Odty9e3eLlP8gbGtruy9JZ8+e7ZDyp8x27969kkqllnbu3LkS/VDetWvXytDQ0PKuXbtWxsfHu9PpdEt7e/v9VCq1dOXKlT8dGxvLjoyMLF6/fr1lZGRk8eTJk39Ip9Mts7Oz20ZGRhYnJyd7wmPcuXNnayqVWjpy5Mji+fPnO1Kp1FIikfhjOp0u+yFfWPfs2bMdhW09duzYs8lkcjmVSi3Nzs5uL2zTyMjI4s6dO1dSqdTS2NhY9vXXX3+u1HOMHrvUcyl37PHx8e5w/cCBA0uVfkdTU1M7fvzjH3f8/Oc/v1Fu36WlpUf+2Lh48eKOI0eOPLewsFD1dUICDIAXDhw4sDQyMrIYXF95rIfz5ptv3vroo49a9+7d+/zt27cfO7t05cqVP929e/eKJO3evXvl0qVLrWGvZWpqasc777zzu3Dfffv2PTyFNTQ0tJxMJpenpqZ2tLW1PTyFFl3u6+tbkaSurq6SPa+oaN1iPvvss+2Li4tb0+l0y8DAwEphmwr19vauzMzMbCv2HKP7lXou5Y599erVh49ZSRh0Y2Nj2XK90Gw2u2XPnj2PPJ8DBw4s/fSnP/3trl27qjqWRIAB2CQuXLjQeubMmd//+te//j+FAw3S6XTL4ODgH2/cuLFdkm7cuLF9cHDwj+l0uuUb3/jG3VQqtVTqdNf4+Hj3zZs3t4dhF56mDHt+61GubtjWL33pSytDQ0PLr776atHTaXfu3NkSWd66Z8+eL4o9x2qeS7ljJxKJh49ZK6dPn+4eGxu7VawsbFs1uAYGoKGl0+mW69evt5w9e7bjy1/+8ko6nW75/PPPt58+fbr7wIEDS9evX2+ZmZnZNjs7uy28vnPkyJFFKd8zmpyc7HjppZfuDg0NLYdDwDOZTMvJkyf/IEl79+59fufOnSt9fX0rb7755q3weOl0uiU8FZfJZFrS6XTL/v37ly9cuNDa0dFxL9zn4sWLO65du9YyMzOz7fz58x0dHR33ox/CxdpfWDebzW4p1tZowETbJOVDK51Ot1y+fLnlrbfe+p0knTx58g+FzzF6vGLPZWRkZLHcscNrYOFj/uxnP2vNZrOP9LDC62hSvpdXWPaLX/xiR1tb271PPvlk++zs7Lb29vb74SnL6OvT2dl5r9QfEsUY9wMDUM61a9c+279//2ODATaDEydOPB0Ox5+Zmdn2wx/+sOfMmTO/r3e7qnHw4MH+Dz/8cK7e7YjLtWvXuvfv398X3UYPDEDTSiaTD3tUi4uLW48ePVrX74xVa2pqakfY81xLj2WzoQcGoKzN3AODP4r1wBjEAQDwEgEGAPASAQYA8BIBBqD2PvrbXn30t721eKjNMBv93r17n4/O1B7OkLHW9heb2b23t/ex24yUUmo2eV8xChFAQ9sMs9Hv379/uXCm9ldffXVxz549X5Rrf7HHKpy5vdrZP6TSs8n7ih4YAG/5Oht9b2/vSvjds1Ltr0Y2m93y0ksv3S0163uhtcwm7wN6YAC85tts9JIUzpwRbX+xWeor3R8rnEmju7v7frn6xWaTL3y91jKFU6OgBwbAC77PRn/58uWWqampHQcPHuwP74UVbX+xWerLvRbHjh17dnZ29mHPq1T9UrPJF75eT/K7qRcCDIAXfJ+N/oUXXlhOpVJLH3744VxbW9u9wludFD5mpdfizJkzvw9v/BieQixWv9Rs8pVeLx8QYAA2Bd9moy8Wdmt9zFQqtZTNZreEz6tY/VKzyZd7vXzhZeoCaB6bYTb6a9eutZw9e7YjnI29r69vZWRkZDE81szMzLYbN25sLzZLfeHM7uFr8cknn2xfWFjYMjk52fP+++/PhvMjFtYvNZt8sdfLN8yFCKCsdc2FGH4H7K//8fONaFOt+DwbfbNhNnoAiPB1NnrkEWAAaq/Be14hH4eOYxWDOABU8uDBgwdW70ageQXvvweF2wkwAJVcn5+fbyPEUA8PHjyw+fn5NknXC8s4hQigrHv37n3z1q1b7926dWuf+KMX8Xsg6fq9e/e+WViw6QKsu7vb9fX11bsZAOCVK1euZJ1zPfVux1rEHmBmdkhSTlLCOXeqSPlwsPiic+6NYNvbzrk3zGzUOTdR7vH7+vqUyWRq3WwA2NTMrOpZ8RtFrKcDzCwhSc65aUm5cL2g/MWgPBEpHzWzWUlzcbYXANC44u6BHZb0cbA8J2lY0tWw0Dl3NbLeH6xL0stBqAEAICn+AGuXdDuy3lVsJzM7Lum1yKaEmUklTjsCAJpPQ44oCkLqNTNrD9eDHlhX5BrZQ2Y2amYZM8vMz8/H3FoAQD3EHWA5SZ3BcrukhWihmUWve80pf+3rUDDwQ8H+/YUP6pybcM4lnXPJnh6vBtEAANYp7gA7p9UA6pc0LUlhT0v5a2LRgJsL/oXXvwYkMcQQABBvgIWDMoLTgLnIII1Lwc8JSf1hj8s590GwzyvBttlIHQBAE9t0t1NJJpOO74EBwNqY2RXnXLLe7ViLhhzEAQBAJZtuKimgqHeYh/ah72yusy5oXvTAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF7aGvcBzeyQpJykhHPuVJHy4WDxRefcG9XUAQA0n1h7YGaWkCTn3LSkXLheUP5iUJ4ws0SlOgCA5hT3KcTDyvekJGlO0nC00Dl3Nex1Sep3zl2tVAcA0JziDrB2Sbcj613FdjKz45JeW0sdAEBzachBHMF1rtfMrL2a/c1s1MwyZpaZn5/f2MYBABpC3AGWk9QZLLdLWogWRq95KX+6cLRSHUlyzk0455LOuWRPT0/NGw0AaDxxB9g5Sf3Bcr+kaUmK9LSG9WhYzZWqAwBobrEGWDAoIxwqnwvXJV0Kfk5I6g+Gzcs590GZOgCAJhb798CccxNFtg0GP3PKh5gkfVCuDgCguTXkIA4AACohwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeij3AzOyQmQ2b2fES5aPBv7cj294Oy+JqJwCgscUaYGaWkCTn3LSkXLgeKR+WNO2cm5DUH6xL0qiZzUqai7O9AIDGFXcP7LCkXLA8J2m4oLw/sm0uWJekl51zA0HwAQCgrTEfr13S7ch6V7Qw6HmFEpLOhctmJkkJ59ypjWwgAMAPDTmIIzi1+LFz7qokOedOBb2vrshpxej+o2aWMbPM/Px83M0FANRB3AGWk9QZLLdLWiix33DY0woGfRwKti9o9bTiQ865Cedc0jmX7OnpqW2LAQANKe4AO6fVAOqXNC1JZtYe7mBmo5HwGlb+Wlh47WtAUiauxgIAGlesARaeEgyCKReuS7oU2f62mc2a2WKkzitBL2w2UgcA0MTiHsRROFAj3DYY/JyW1FFNHQBAc2vIQRwAAFRCgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8tDXuA5rZIUk5SQnn3Kki5aPB4oBz7o1q6gAAmk+sPTAzS0iSc25aUi5cj5QPS5p2zk1I6jez4Up1AADNKe5TiIeV70lJ0pyk4YLy/si2uWC9Uh0AQBNa8ylEM+uTlJDUKald+VDJOed+VkX1dkm3I+td0cKg5xVKSDonabBcHQBAc6o6wMzsv0t6UdKipIzyvaI7kgYkdZnZdyXNSnrXOfdvT9Ko4DThx865q2ZWzf6jkkYlaefOnU9yaACAJyoGmJn9uaTXJP2Tc+4fKuzbJmnUzJLOufeK7JJTvucm5XtjCyUeajgyWKNinaDnNiFJyWTSlWsjAGBzKHsNLAivv3TOfbeaXpVz7k4QcpfM7JtFdjmn/HUtBT+ng+O0R445GoZXMKijaB0AQHMrG2DOuU9L9KTKKlXPOXdVehhMuXBd0qXI9rfNbNbMFivUAQA0sfUM4mh1zt1d7wELBmqE2waDn9OSOqqpAwBobusZRj9gZl8JV8zsz83sP9WuSQAAVLbmAHPO/UrSV4Ph9HLOfSqpw8z+Z43bBgBASWsOMDM7p/xw+UUzaw02TysYxg4AQBzWcwpxUFLGOXdHkgVD54cl/X1NWwYAQBnrCbCXFfS2ghDrlNRR6TtiAADU0ppHIQbXwH4VWf/UzK6Y2VeedAYOAACqVZPbqTjnfhWcSgQAIBY1m40+OJ0IAEAsKk4lVWJKqLLWWw8AgGpVnEpK+XkN/1c1X1Y2s9Zg1vq/XM8UVAAAVKviNbAgxP6rmf2X4JYpTtJVrc4K36X8LPEDyn8/7FRQBwCADVP1IA7n3I8k/SgYrJFUPrQ6JX0qaS4YnQgAQCzWM4z+joLZ4wEAqJd1DaMPBmgMSroi6fyTzE4PAMB6rGcuxL+XtEvSHUmvSPrUzP6u1g0DAKCc9fTA/tU598/hSnA35e+a2d845/53zVoGAEAZT/xFZudczjn3XeVHIwIAEIv1BNicmf2rmf1F5HYq0uqwegAANtx6AuywpPOSjkn6LAizjyT1m9kOSTKzv6lhGwEAeMx6roHNSvo4vH2Kmf1H5e8H9leS/oeZhT0xrocBADbMmntgwReaO8ysL1j/lXPuH5xzf+Wc61S+h8ZMHACADbWuQRxBaH1WouyqpDdK1TWzQ2Y2bGbHy+yTKFh/O/g5up72AgA2n5rdTiWq1LRSYTA556Yl5QqDKthnWNKPCjaPmtmspLlatxUA4KcNCbAyDkvKBctzyl87e0QQbrcLNr/snBsIygAAqM0dmdegXY+GU7XfHUuYmSQlnHOnat0oAIB/4u6BrYtz7lTQ++oKTjECAJpc3AGWU/4WLFK+N1bxy8/BoI9DweqCpP4i+4yaWcbMMvPz8zVqKgCgkcUdYOe0GkD9kqalh/MpljIX7qf8TTMzhTs45yacc0nnXLKnp6d2rQUANKxYAywYYh+ONMyF64rcXyzobSXDXlewzyvB+mykDgCgicU9iEPOuYki2wYjyx9I+qBSHQBAc/NiEAcAAIUIMACAlwgwAICXCDAAgJdiH8SBJvOO1bsFKNQIv5PvuHq3AJsAPTAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJdiDzAzO2Rmw2Z2vMw+ibXWAQA0l1gDLAwm59y0pFxhUAX7DEv60VrqAACaT9w9sMOScsHynKThwh2CoLq9ljoAgOYTd4C169Fw6tqgOgCATY5BHAAAL8UdYDlJncFyu6SFWtQxs1Ezy5hZZn5+/okbCQBofHEH2DlJ/cFyv6RpSTKz9rXWiXLOTTjnks65ZE9PT+1aCwBoWLEGmHPuqvRwpGEuXJd0KdzHzA5JSgY/y9UBADSxrXEf0Dk3UWTbYGT5A0kfVKoDAGhuDOIAAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHgp9gAzs0NmNmxmx6stN7O3g5+jcbUTANDYYg0wM0tIknNuWlIuXK+ifNTMZiXNxdleAEDjirsHdlhSLliekzRcZfnLzrmBINgAANDWmI/XLul2ZL2ryvKEmUlSwjl3aqMaBwDwhxeDOJxzp4LeV5eZFfbaZGajZpYxs8z8/HwdWggAiFvcAZaT1Bkst0taqFQeDOo4FGxbkNRf+KDOuQnnXNI5l+zp6alxkwEAjSjuADun1QDqlzQtSWbWXqZ8LtxP0oCkTBwNBQA0tlgDzDl3VZKC04C5cF3SpVLlwbZXgl7YbKQOAKCJxT2IQ865iSLbBiuUP7YNANDcvBjEAQBAIQIMAOAlAgwA4CUCDADgJQIMAOAlAgwA4CUCDADgJQIMAOAlAgwA4CUCDADgJQIMAOAlAgwA4CUCDADgpdhno0eM3rF6twAorlHem99x9W4BngA9MACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlzZfgC19Xt/j/8u38//qrRHaADS6ev8/aaDPi+c61FvvZqxV7F9kNrNDknKSEs65U9WUV6oDAGg+sfbAzCwhSc65aUm5cL1ceaU6AIDmFPcpxMPK96QkaU7ScBXlleoAAJpQ3KcQ2yXdjqx3VVFeqU7jufr9/D8Aja0R/q8m/lt9j++xTTGZr5mNShqVpG1b9P/M7N/r1ZbnOtS7tKI/ub2sG/VqQ9gOSfrtouo2qoXX4tE28FqstoHXYrUNSyvf/5Pby9+v+2uR/aNa69mG9Yg7wHKSOoPldkkLVZaXqyPn3ISkiVo18kmZWcY5l6x3OxoBr8UqXotVvBareC3WL+4AOycp/EX1S5qWJDNrd87lSpWX2AYAaGKxDuJwzl2VJDMblpQL1yVdKlVepg4AoInFfg0sON1XuG2wQnnDnB6skm/t3Ui8Fqt4LVbxWqzitVgnc447ksbBzI7zJWwAxfD5sD6bYhRiowtOf3613u2ot2C0qCQNOOfeqGtjYsZsMqua+X1QDJ8P67f55kJEQwr+k04Hp4P7g/WmwGwyq5r5fYDaI8A2mJklgg+uZtev1VlU5oL1ZsFsMqua+X3wGD4fngynEDdeZ+VdNr+CgTgJ5b8y0Sza5dtsMhukyd8HxfD58AQIsCcUOZ8fNeecm+avq8cFp88+5usQzY33Ab2vWiDAnlCFIf79ZtYfWU5s5v+w5cI8sj7chIMYcqowm0wTasb3QaGm+nzYCATYBnLOfSA9/GBvr29rNl6l7+uZ2WjkHm/DTfTXZ6kZZppSE78PHtFsnw8bge+BIRbBaLP3lb8W1Cnp5Wb64Ao+pOYk9Xv4xfyaafb3AWqLAAMAeIlh9AAALxFgAAAvEWAAAC8RYAAALxFgAAAvEWAAAC8RYAAALxFgAAAvEWAAAC8RYEAMzCxhZrNm9n5kvb3OzQK8RoAB8RiWNCjp3XDWfudcrq4tAjzHXIhAjIJeV6dzbq7ebQF8R4ABMQlPGdLzAmqDU4hADMIbF4bhFbmRIYB14oaWwAYzs4TyN7S8bWbTyl8Pyyl/fzAA60QPDNhAkdOGE8rfjflTSV/lJo7Ak+MaGADAS/TAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXvr/rlQvqIXbTYAAAAAASUVORK5CYII=
 "
 >
 </div>
@@ -15411,11 +15130,11 @@ To construct this you need to give the quantiles edges (shape=(N)) and the locat
 <span class="c1"># Compute the corresponding locations</span>
 <span class="n">locs</span> <span class="o">=</span> <span class="n">norm_dist1</span><span class="o">.</span><span class="n">ppf</span><span class="p">(</span><span class="n">quants</span><span class="p">)</span>
 <span class="c1"># Construct the distribution using the quantile value and locations</span>
-<span class="n">quant_dist</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">quant</span><span class="p">(</span><span class="n">quants</span><span class="o">=</span><span class="n">quants</span><span class="p">,</span> <span class="n">locs</span><span class="o">=</span><span class="n">locs</span><span class="p">)</span>
+<span class="n">quant_dist</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">quant_piecewise</span><span class="p">(</span><span class="n">quants</span><span class="o">=</span><span class="n">quants</span><span class="p">,</span> <span class="n">locs</span><span class="o">=</span><span class="n">locs</span><span class="p">)</span>
 <span class="n">quant_vals</span> <span class="o">=</span> <span class="n">quant_dist</span><span class="o">.</span><span class="n">pdf</span><span class="p">(</span><span class="n">xvals</span><span class="p">)</span>
 <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;The input and output shapes are:&quot;</span><span class="p">,</span> <span class="n">xvals</span><span class="o">.</span><span class="n">shape</span><span class="p">,</span> <span class="n">quant_vals</span><span class="o">.</span><span class="n">shape</span><span class="p">)</span>
 <span class="c1"># Construct a single PDF for plotting</span>
-<span class="n">quant_dist1</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">quant</span><span class="p">(</span><span class="n">quants</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">atleast_1d</span><span class="p">(</span><span class="n">quants</span><span class="p">),</span> <span class="n">locs</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">atleast_2d</span><span class="p">(</span><span class="n">locs</span><span class="p">[</span><span class="mi">0</span><span class="p">]))</span>
+<span class="n">quant_dist1</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">quant_piecewise</span><span class="p">(</span><span class="n">quants</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">atleast_1d</span><span class="p">(</span><span class="n">quants</span><span class="p">),</span> <span class="n">locs</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">atleast_2d</span><span class="p">(</span><span class="n">locs</span><span class="p">[</span><span class="mi">0</span><span class="p">]))</span>
 <span class="n">fig</span><span class="p">,</span> <span class="n">axes</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">plotting</span><span class="o">.</span><span class="n">plot_native</span><span class="p">(</span><span class="n">quant_dist1</span><span class="p">,</span> <span class="n">xlim</span><span class="o">=</span><span class="p">(</span><span class="o">-</span><span class="mf">5.</span><span class="p">,</span> <span class="mf">5.</span><span class="p">),</span> <span class="n">label</span><span class="o">=</span><span class="s2">&quot;quantiles&quot;</span><span class="p">)</span>
 <span class="n">leg</span> <span class="o">=</span> <span class="n">fig</span><span class="o">.</span><span class="n">legend</span><span class="p">()</span>
 </pre></div>
@@ -15437,15 +15156,7 @@ To construct this you need to give the quantiles edges (shape=(N)) and the locat
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>(7,)
-(1, 7)
-(9,)
-(1, 9)
-The input and output shapes are: (11,) (1, 11)
-(7,)
-(1, 7)
-(9,)
-(1, 9)
+<pre>The input and output shapes are: (11,) (1, 11)
 </pre>
 </div>
 </div>
@@ -15459,7 +15170,7 @@ The input and output shapes are: (11,) (1, 11)
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAnDElEQVR4nO3de3hb5Z0n8O9Pki3fLSd2biQkUSANKQzFUWgG0kKpA2R6czumnTLbzrKl4TLT6TwFQjuFP3bLsy2hnaHd3acTA8NMdygLDd0ssEDXTqHUZYDYgbQ0pRDMJUCc+BJf4ousy2//0DmW4kiWbMvnSOd8P8+TJ5LOOfLPsnS+et/znveIqoKIiKjYeOwugIiIaC4YYEREVJQYYEREVJQYYEREVJR8dhdARORWXV1dS3w+370AzgUbFJnEAbwSjUav3bRp0/HUBQwwIiKb+Hy+e5ctW3ZOQ0PDCY/HwyHhacTjcent7d3Y09NzL4BPpy5j4hMR2efchoaGYYZXZh6PRxsaGoaQaKWeusyGeoiIKMHD8MrOeI1OyysGGBER5dX9999fZ94+dOhQ6fbt24MAsHfv3uqLLrro7Hz9HAYYERHlTV9fn7etra3GvL9x48bJJ598shsAmpubR2pra2P5+lkcxEFEVCDuOvfIpkzLLrmp9u0Lr6npA4AX7x+u/9UPhlZnWveWV1Z15fozb7jhhjOuuOKKYQA4fPiw/6yzzgrv2rVr2XPPPff6bbfdtrS/v9/34x//+D0g0YIy12lubh7Zu3dv9a5du5bt3Lmzp7Ozs+LKK68cAYCDBw9W7N27t7q5uXmko6OjYufOnWc899xzr6f+3L6+Pu/dd99dHwqFxg4fPuzfsmXLWF9fn/fEiRO+urq6aHNz80i22tkCIyJyqe9///v169atC5thMTg46E1tJV199dUnzHUPHTpUevjwYf/NN9/ct2vXrmVAokV15MgRf3Nz88jVV1994oEHHqjbunXr2Jlnnjn1nFu3bh1L1+q6/fbbl1155ZUjzc3NIwcOHKh84IEH6gDgmmuuObF+/fpwLvWzBUZEVCBybTldeE1Nn9kam499+/bVfPvb3+4BgPr6+hm79jZu3Di5cePGvr6+Pm/q4+eee+7YXH72wYMHK6644orhjo6OihtvvLF3w4YN4S996Uurv/a1r61+8MEHuwFMZnsOtsCIiFxq06ZNo88//3wFkOjSm778tdde85u3Ozo6Km677bals3n+jo6OikzLLrvssmEg0ULbsGFD+LHHHqt58sknu1966aU/PPXUU9W5PD9bYERELnXHHXccu+2225Z2dHRUdHZ2ToXNpk2bRjs6OioOHz7sf/bZZ2v6+vp6Xn/9dX8gEIi9+uqr/jVr1kzef//9dWeffXb4lVdeqTh06FDpE088UXPw4MGKvr4+75o1a8J79+6t3rp161hHR0eFuc7AwIDPvG3+bPNnvvjiixUAcPbZZ4dTuy5nIrweGBGRPQ4ePPjW+eefP++uwHzo6OioeOqpp6rvuOOOY3bXks7Bgwfrzz///DWpj7ELkYiI8MADD9R1dXVVputKLFTsQiQiIphD5YsJW2BERFSUGGBERFSUGGBERFSUGGBEREXkydsHVj15+8Aqu+soBAwwIiLKK85GT0RERYez0RMRkSU4Gz0RERWdYp+NngFGRORS+/btq9myZcsYkNts9DfffHNeZ6Pv6+vzmrPRf+c73+nZvXt3w6pVq84dGBjIqXeQAUZE5FKcjZ6IiIoSZ6MnIqI5mcts9OY5YNu/s+hIPmvhbPRERFSUOBs9EREtqHy3vEycjZ6IiGYjHo/Hxe4iCp3xGsWnP84AIyKyzyu9vb21DLHM4vG49Pb21gJ4ZfoydiESEdkkGo1e29PTc29PT8+5YIMikziAV6LR6LXTFzguwOrr63XNmjV2l0FEVFS6urr6VLXB7jpmw/IAE5EWAIMAgqraOsN6d6rqrbPZBgDWrFmDzs7O/BVMROQCIvK23TXMlqVNViOIoKrtxv2mDOs1AQjOZhsiInIXq/tcNwPoNm53A2icvoKIBFPWyWkbIiJyH6sDLDDt/uI06wRVNTXAsm4jIjtEpFNEOnt7e+dXIRERFQWrA2wQwKJMC0WkyewqzHUbAFDVVlUNqWqooaGojkESEdEcWT2IYz+SLaoggLZpyweMY1wBAEERacxhGyIiciFLW2CqugeJYGoCEEgZmNFmLD9gPLYIRmhl2oaIiNzNcbPRh0Ih5TB6IqLZEZEuVQ3ZXcdsOO5EZqKFNnw0ikdv6s+4/OPfCmD5eYnrAB746QgOPZ7+grXVS734zD/WT91/6NrjiIyd+oXSWyK4+K9rcOaFZXmonMhZGGBEsxSLKI7+djLj8snRZAgNH41lXHd81akfv2O/n0R45PQekZcePMkAI0qDAUY0S9VLffjLB5ZkXL44WDJ1+4IvVmF9U3na9bylp87felVrAzRlvu3jr0bQ9p0TmBg6bRJuIgKPgREVrFhEEQ0rSisFIpysnBYWj4EROdzhp8fxxjPjOOuycqy7JH3LKl+8JQJvCYOLKBNO3080C++9HMZvHxnF8VcjdpdC5HoMMKJZGOuPAQAqF1vz0Xn81n7c/9keDB+NWvLziIoJA4xoFkb7EwMqKuq9lvy8gTcj6Hs9gtG+mCU/j6iYMMCIZsHqFljF4kRQmsFJREkMMKJZGO1LBEmlRS0wMyjH2AIjOg0DjChHGleMDSSCpGKRNQHGFhhRZhxGT5SjaFixMuRHZFzh81szvL3SCDCz65KIkhhgRDkqKffgC/dmnoFjIVQYXYijDDCi0zDAiApY/boSnPe5Sqw4v9TuUogKDgOMKEeTY3FoHJZO7bRkQymu/C8zXpCcyLU4iIMoR7/7+Sh+tOU9/PJ7g3aXQkRggBHlzDyZuDxg7cem97VJvPmbCcQizpp4m2i+LA8wEWkRkSYR2ZFheZPx786Ux06ISJuI7LSuUqJTjfVbew6Y6WfX9WLPdb2cjYNoGksDTERaAEBV2437TdOWNwJoNJY3ikjQWHSVqm5T1V1W1kuUyhwJaJ6bZZXkUHqeC0aUyuoW2GYA3cbtbgCNqQtV9YCq7hKRAIBuVTXXDaSEGZEtrJ5GymSeNM2h9ESnsjrAAtPuL86wXgjAGyn3FwEYEJHd6VYWkR0i0ikinb29vfOvkiiNqYl8LW6BmeeCmbOAEFGC1QE2iEQYzcjoQlyX0uXYqqqDAAbNx6at36qqIVUNNTQ05LlkIkBVbWuBsQuRKD2rzwPbj2QrLAigLXWhMXDjDVVthRF2xmCPTlU9YGGdRKdSoPmH9Rg7EUdJucVdiJyNgygtSwNMVfeIyE5j8EYgZTBHm6puA7AbQDBleatxPCyY0hrbY2XNRAAgHkHwo+W2/Gy2wIjSE1VnnVsSCoW0s7PT7jKI8mZ8KIbRvjiqGrwoq+Gpm7QwRKRLVUN21zEbnEqKKAfHDk3i8NPjWPGhUqy92NqWWHmtF+W11g4cISoG/DpHlIP3Xg7juR8P4/V943aXQkQGBhhRDsYGjFk4LB5CDyRGQD552wD2XN+LeNRZXf5E88EuRKIc2DULBwCICLqfHcfYQBxjJxLHwoiILTCinEzNg2jxOWAmMzg5lJ4oiQFGlAM7W2CJn2vMxsEAI5rCACPKwdQsHPX2fGTMY2+jfTwXjMjEACPKQVmNB/4asWUQB8AWGFE6HMRBlIMvP7zM1p8/1QLjbBxEU9gCIyoC9etKsHZrGRat4XdOIhM/DURZqCpExNYa1l1ajnWX2jMXI1GhYguMKIvX28fxww+/i//3nwfsLoWIUrAFRq7y3sthvPHM6dNBbfxkJerPKgEAvPPiBN56bmJqWe8fI5gcVdg577WqYnwwjs5/GQHSNAarlnjReHX11P1n7x6cul0e8OBDf1GFkjJ+XyVnYYCRqzx1+wAG3oye9viyD5ZOBdj7L0/ihXtHTlundoV9H5d4FGi9/Cgi4+lTdOnGklMCbHr9VUt8OOfPKha0RiKrMcDIVcYHE6P4tny1+pQLUy5eVzJ1e2XIj4/8be0p25WUC85trrSmyDS8JYLP/Y96vP/yZNrl089PM+s//KtxHD04ifEhDr8n52GAkausu6QME8OKD3+1BqUV6bvUVjb6sbLRb3Fl2Z15YRnOvLAsp3W37KgBkLiW2NGDk4iFOQkwOQ8DjFxl+x2L7S7BUj5/IqSjDDByIAYYkYOt3uKHt7QGq0K5tdyIionlASYiLQAGAQRVtTXN8ibj5jZVvTWXbYhyEY8pht6NwlcmqF7qju9us+l2JCo2lo6rNYIIqtpu3G+atrwRQKOxvFFEgtm2IcrV+GAc936iB//acszuUogoD6w+MWQzgG7jdjeAxtSFqnpAVXeJSABAt6p2Z9uGKFexycRxIJ/f3lk1rDTSE8XrvxzH0d+F7S6FKO+sDrDAtPuZjqiHALyR6zYiskNEOkWks7e3d14FknNFJ9wXYEe6wtj7t33o/MlJu0shyjurA2wQwKJsKxndhetSjn3NuI2qtqpqSFVDDQ0N+aiTHCgSdl+A+UoTvytHIZITWR1g+5FsUQUBtKUuFJE7RWSHcXcQieCacRuiXMXcGGBlDDByLksDTFX3AAgaAzECKQMzzFDaDaA7ZXlrpm2IZivqxgDzM8DIuSwfS6yqu4yb7SmPbTP+70ZywEb7TNsQzZa5E/e6MMA4Ewc5kTtOhiECsPy8Unz+3gb4q9wzK7sZ1pEJBhg5DwOMXKM84MXqLV67y7BUidkCm2SAkfMwwIgcLLDKhxueXoGSMvd0m5J7MMDINd7tCuPwM+NYtcmPdZeW212OJTw+QVWDu1qd5B7uORhArvf+b8PYf/8I3tk/kX1lIip4DDByjamppErd052mccUjN/bi4a8et7sUorxjFyK5xtRUUi46HiQewZu/mYDGgFhE4S1xz+9OzscWGLlG1GiBeV3UAgNSzgXjSERyGAYYuYYbW2BAMsB4Lhg5DQOMXCNqXFHETcfAAE4nRc7FACPXKA94ULvSi7Jad73tOZ0UORUHcZBrXHpzAJfeHLC7DMtNdSEywMhhGGBEDnfmFj/qVvtQWuGurlNyPgYYkcNdtrPO7hKIFoS7DgaQqz34H4/jRxe9i57fT9pdChHlAQOMXGNiKI7wsMLjsqkBx4diGDwSRfhk3O5SiPKKAUauMTWVlMvOA2u/YxD3bD+KN341bncpRHlleYCJSIuINInIjjTLAiLSaKxzZ8rjJ0SkTUR2WlstOcnUicwuuiIzkHIeGE9kJoexNMBEpAUAVLXduN80bZXPAwip6h5juRlyV6nqNlXdZVmx5DjmibzuC7DE/1FOJUUOY3ULbDOAbuN2N4DG1IWq2qqqrcbdYMq6AREJWlMiOZVrA6yMLTByJqsDLDDt/uJ0KxlhNWC21AAsAjAgIrszrL9DRDpFpLO3tzdvxZJzqKp7A6yUk/mSM1l9HtggEmGUTYuqXmfeMVtlIjIoIi1mF+O05a0AEAqF+Cml0ylw6S0BxMIKj89lAcYWGDmU1QG2H8lWWBBA2/QVjIDaZdxuBBAC0KmqB6wqkpxHPILQl6rtLsMW5uVjeAyMnMbSLkSj5RQ0Bm8EUgZztBn/NwG4U0S6RKQLidbaw8aylpTnIKIcrd9WgZbd9fjQ56vsLoUor0TVWd/KQqGQdnZ22l0GFZjJ0The/+U4yms9CH603O5yiAqOiHSpasjuOmaDcyGSK5w8HsMT3xpA3WofA4zIIRhg5AoRl45ABID+7gh+/39GUbfah/M+x25Ecg5OJUWuYF7M0W3TSAHA8PtRvHDfCF79BaeSImdhgJErTJ0DVuq+AJsahcgLWpLDMMDIFaIuboGZv3OMAUYOwwAjVzBP4vW6sAVmtjojPJGZHIYBRq5gnsRb4uIWGLsQyWk4CpFcYcOVFTjrY+4cPm+OvGQXIjkNA4xcweMVlFa4r/UFACXlguplXlQtcdmlqMnxGGBEDlce8OL69hV2l0GUd7MOMBH5EBIT8QaRmF1+AEC3qr6cz8KI8ul3Pz+JVx4dw3nNlTi3udLucogoD3IKMBFZA+CbANYicZHJbiTCSwCsA3C5cQ2vNwDcqapvLUCtRHN24p0o3u0MY82fltldChHlSdYAE5FbkJgV/lZVHcqybi2AHSJyQlXvzVONRPNmjkL0+W0uxCatV7yPsYE4bnh6BfxVHHxMzjBjgBnhtUdV38zlyYyAu0tE1orIzar6/XwUSTRf5nlgbjyRGQAmxxSR8cRVqf2cDpEcYsYAU9W75vKkRuAxvKhgxCbdO5UUkBxKz3PByElm3ZdgHA8jKipub4FxOilyorl0hteJyLXmHRH5cxG5LI81EeVddDLxvxunkgJSppNigJGDzDrAVPUlAGeZoaWqjyAxCvEr+S6OKF9WbvJjw/YK1K5w56mPbIGRE83lPLBfADgAoEtEPmSc//VdJIbW35fD9i1IDMEPqmrrtGUBJM8x26yqt2bbhigXm/+q2u4SbMVjYOREc+lCXAdgtzHiUIyh8/cY/2ZkBBFUtd243zRtlc8DCKnqHmP5jhy2IaIs/qSlEpfcVIvale5sgZIzzSXALgdwq4jUGN2JTQBeVNVv5rDtZiRaajD+b0xdqKqtKS2soLHOjNsQ5WLgrQgG3oogFnFnC2TjJypx4TU1ru1CJWeayzGwblW9QVWHjfuPABjKcSBHYNr9xelWMmb1GDBaXVm3MVpqnSLS2dvbm0MZ5DaP3NiH+z7Zg6H3onaXQkR5kpdT8lX1HgC5nOw8iMSsHtm0qOp1uW5jtNxCqhpqaGjI4enJbczBC+axILc59odJ/OGJMQy8FbG7FKK8yducMjnO1rEfyRZVEEDb9BVEpEVVdxm3G3PZhiibqMsD7LePjOLxnf1467kJu0shypsZA0xEbpnLicvmVFLTHzcGZwSNgRiBlIEZbcb/TQDuFJEuEekCsCjTNkSzMRVgbj2R2RyFOOHOY4DkTFmnkhKRrxrHpHZnm2VeRGoA/D2AvkzzIJqtKwDtKY9tM/5vR2KUY9ZtiHKlqskAc+uJzGaATTLAyDmyDklS1XtEZC2A60XkAiQvpfIGEl17i43/1xmP7cp18l8iK8SjgMYBjw/w+FweYGyBkYPkNKbWCKRvAonuQSRPNh5CYvBGtzGknqjgmK0vt04jBSQvI8MWGDnJrE8KMcLsTQD78l8OUf6VlAmu/p9LEI+5d+dtHvtjC4ycZE5nNRqT+Zpdhg+b54QRFSKPT3DGBS69kqXBPPYXYwuMHGQucyH+ExLHwIDE1E93ishOVc06DyIR2eOcT1Ri/bYK147CJGeaSwuszZh9A8DUBLzfFJHPqerP81YZUZ4MH43ixX8eQWCVD6Evu3NSX59fXHsOHDnXvE9kVtVBYx7EtNNCEdlt5FgMLz14Eq8+NWZ3KUSUR3MJsG4R2S8inzXO+zL156soonxy+ywcAND72iQe+spxtN1xwu5SiPJmLgH2BQAPA/gigLeMMHsIiWH1AABeoZkKidvnQQSAyITinRfC6Hll0u5SiPJmLsfA3kDiONhdAGCc3NyExFWZv4XkpU8256dEovmJMMCmRiHygpbkJHO5nMo9AOrMORJV9SVVvUtVL1fVxQCuA8B+CioYbIGlnAfGACMHmdN5YDPNuqGqB0Tk1rmXRJRf5sm7rg4w43ePMcDIQfJ2OZVUnFaKCklppQeL1/lQtdRrdym2mZoLkQFGDsLri5PjbdhegQ3bK+wuw1bsQiQnYoARuYDPL/jAFeUoKXdvNyo5DwOMHE9VIeLuHbfHK/j0D+rtLoMorxbkGBhRIXn6rkH8wwVHcOCnI3aXQkR5ZHmAiUiLiDSJyI4ZlrdNe+yEiLSJyE5rqiQniU4oYhFAXP51bej9KPoORxCL8DgYOYOlH2kRaQEAVW037jdNX0dV96TZ9CpV3aaquxa4RHIg8xIibh5GDwAPfvk47m/uwcnjMbtLIcoLq7+TbkZypo5uAI05bhcQkWD21YhOlzwPzN1NMI5EJKex+hMdmHY/1xnsFwEYEJHd6RaKyA4R6RSRzt7e3vnURw6UnMzX5kJsxnPByGmsDrBBJMJoVlS1VVUHAQya3ZBplodUNdTQ0DD/KslRouHE/26/mCMDjJzG6gDbj2QrLAigLfOqCUbrKteuRqLTTLXAShlgAAOMnMPSADMGaASNwRuBlMEcU0FmLAultLQeNh5vSXkOopxt+g9V+NitAdStLrG7FFtxPkRyGstPZE4ZSdie8ti2lNvtAOpS7g8COGD8Y3jRrK3f5u5ppExmgEUYYOQQnImDyCUu/usahL5cjcXr+LEnZ+A7mRzv0OOj0Diwfls5SsrdO5S+YX2p3SUQ5RUDjBxv33cHMTEUx9qtK1BSbnc1RJQvDDByvKmZOFw+jL772XG89dwE1n6kHGsvLrO7HKJ5c29/CrmCqiIywWH0APD+wUl0/dtJHP1d2O5SiPKCAUaOFo8CUMDjAzw+dweY1whwc2otomLHACNHM3fWXpe3vgDOhUjOwwAjRzN31iUuP/4FcCYOch4GGDlalJdSmWJOZswAI6fgKERytNoVPtx0cCUv4ojk5WR4DIycggFGszY5GkfvaxGccUHy+iRH9k8gFk2/fmClD4FVibfaaH8Mva9FMj73qpAf3pJEa+nYHyYxPhhPu15FnQdLNiROzI2GFe8eyDyybsmGElTUeWf8ndygrNaDRWt9qGpIvBZvvzABTf/yYtEaH2qWJ/5mJ3tj6Duc+W925oV+eLyJv9nR34URPpk+ICvrPWg4O/E3mxyL4/2Dkxmfc9kHS1FWww4imhkDjGbtsVv60fvHCK7ft2LqsUdv6sfYQPq94cV/U4OLrq8FALz/chh7v96f8blv/NUKVC5O7GB//cMhvNkxkXa9sy4rx2d/VA8AGBuI4WdfzXwduD//cT2CH+EZzGsvLsNXHls+df/nN/Zl7E782K0BhL5UDQB4+98n8MTfD2R83r/rPGMqwJ7eNYj3XkofTBs/WYFPfC9xCcDhozP/zb74kyVY2ejyC7hRVgwwmpXho1F0/3oCUCAyHp+ammnlJj8mRtIHWO0ZybdZeZ0XZ27JvGPypgx1X/KBEsSi6XewDeuTM8t7S2XG5ywP8Jt8Oqsu9GfsWq1elmyxVtbP/DcTT/JvtuyDpfBmON5Yf1byb1ZSPvPfzF+VeI6Rnij6Dkewdiu/gNDpRNVZ/eGhUEg7OzvtLsOxXrh3GM/ePYQPXFGOT/+g3u5yyMGG3o+i9Yqj8FcJbnzmDA7EWWAi0qWqIbvrmA1+NaWcqSp+/+goAOCDn6q0uRpyutoVPiw9pwThEcUbz4zbXQ4VIAYY5ezYoQj6u6OoWOTBGs6lRxb44KcTX5TML05EqRhglDNzJ3LOn1VMjRQkWkgbtldAvEB3xwRG+2N2l0MFhgFGOVFVvPNCYkSg+a2YaKFVLvYiuLUMGgNefWLM7nKowFgeYCLSIiJNIrJjhuVts9mGFp6I4Ms/W4ar7mnAknNKsm9AlCdT3YiPsRuRTmVpgIlICwCoartxv2n6Oqq6Z7bbkDW8JYI1f1oGEXYfknXWXVqOikUe1Cz3ITKR4cxrciWrW2CbAXQbt7sBNC7QNkTkED6/4Lr2FWj+YT1KynjUg5KsfjcEpt1fnI9tRGSHiHSKSGdvb+az+2luTrwdwX+76D089J+O210KuZTbL0ZK6VkdYIMAFuV7G1VtVdWQqoYaGhrmWBplMj4Ux8RwHOGT7L4he2hcMT4Uw8k+jkSkJKsDbD+SLaoggLbMq85rG8qjsDFFFCdXJbu89/Ik/vvF72Pv1/vsLoUKiKV7JGOARtAYiBFIGZgxFUrGslDK4I2025B1JoYS042V1TLAyB7mey88zF4ASrJ8Ml9V3WXcbE95bFvK7XYAddm2IetMGDsNP1tgZJOy6sR7b4IBRim4R6KszG+97EIku/hrEoM4wsNxOG0Ccpo77pEoK/MyKea3YCKrlZR54C0FYhFeUZqSeD0wymrt1jKUVghWbuIFBsk+ZTUejPYlRsSa16Ejd2OAUVarP1yG1R/m7PNkr9QAq15qdzVUCBhgRFQULvtmHTSuqF3B3RYl8J1AWR1+ZhxQ4MwL/SitZNcN2WPNRewFoFNxb0RZ/fK7J/C/v9aH0X4OYSaiwsEAo6zMc2/KajkfHdnn7Rcm8OsfDeGdFyfsLoUKBAOMZqRxRfhkYtiyv4pvF7LPkf1hPN86jCP7w3aXQgWCeySaUXhEAQVKqwQeL1tgZB/zRHrOxkEmBhjNaIKzcFCBYIDRdNwr0YwYYFQo/NXGdFIjDDBK4F6JZsQAo0LBFhhNx/PAaEart/jx9RfPQDTM+efIXubVEHhJFTIxwGhGIoLSCkFphd2VkNuV13pQWe9BecBrdylUIBhgRFQUqpf5cOMzZ9hdBhUQHtigGR346Qj+1zXH8cdfjNldChHRKSwPMBFpEZEmEdmR63IROSEibSKy07pKCQD6DkdwZH8YowMxu0shIjqFpQEmIi0AoKrtxv2mHJdfparbVHWXheUSeDVmKiwP/tVx3L35XfR3R+wuhQqA1XulzQC6jdvdABpzXB4QkeDCl0fTTYwkRh8ywKgQxCYVkXHlUHoCYH2ABabdX5zj8kUABkRkd7onFZEdItIpIp29vb3zLpKS2AKjQsKh9JTK6r3SIBJhNKvlqtqqqoMABs1uxjTLQ6oaamhoyFOpBPBEZiosPJmZUlm9V9qPZCsrCKAt23KjdTW9q5EsYu4o/AwwKgDmdFITnE6KYHGAqeoeAEFjcEYgZbBG2wzLHzbWaUlZhyzygcvLsf7ycrbAqCCUsQuRUlh+InPKSML2lMe2ZVpudB0eMP4xvCy27faZenyJrMUuRErFmTiIqGis2uzHR79RixXnldpdChUABhhlNDkWx4m3o6hY5EH1Ur5VyH7Lz/Nj+Xl+u8ugAsEDG5TRsd9P4idXHcNjt/TbXQoR0Wn4tZoy4hB6KjSTo3F0/3oC4gE+cDkvkeB2DDDKiAFGhWZsII7Hbu5HzQovA4zYhUiZTQxzGikqLByFSKm4Z6KMwsbJov5qvk2oMPirBRBg8qQiHuNVwt2OeybKiF2IVGjEI1OzcYQ5G4frcc9EGU0McRopKjzJbkS2wNyOgzgoo498vRYX/EUVAqv4NqHCUVbjwRBinE6KGGCUWe0KH2pX8C1ChWXqkionGWBux70TERWV5rvr4fMLvCVidylkMwYYZdT+X09AJNGVWFrB42BUGPxVfC9SAt8JlNFv95zEgQdOQvhFl4gKEAOM0opMxBGbBLwlgK+MCUaF49Unx/Bvf3kM+/91xO5SyGYMMEorbAxR9td4IGyCUQEZH4rj6MFJDLwVsbsUshmPgVFaqScx//J7JwAAl32z7pTbxSYftc/1OazebqGex2rp3nvL/yRxORUOoye2wCgtM8B4EjMVmrLaRI+AeaI9uZflLTARaQEwCCCoqq25LM+2DeVfmNNIUYHihL5ksjTAjCCCqraLyA4RaVLV9pmWAwjMtM108YhipCeadln5Ii98pca3t+E4ImPpPwDiE1TVe6fujxyLAhlmrfFXe1BamfhARcbjM34rrFrihXgSP39sIIbYZPon9ZUJygOJnx+LKMb6Yxmfc6F+J1+ZYPl5pVgcLIFy0lQqIGaADb6b/JzHo4rRvhk+J3Ve+PzJORQnRzN8TryCqobcPielVZ6pIf0L8dm38ncq1oFaVrfANgN4yLjdDaARQHuW5YuzbHOK469F8E9NR9Mu+8I/N+DMC8sAAP++exidGUYx1a324dr/u3zq/n2f6kFkLP0b7pKbanHhNTUAgMNPj+PxnQOZSsPXXzgDpZWJN8qj3+jHkc5w2vU2bK/Ap+5aDAAYei+K+z7Zk/E5F/J3Wr0l8bzmsQeiQmBeHSGcMhficE8M91yZ/nMPAFe1NmDNRYn38/P3DuPF+9J/TmrP8GLHL1ZM3f+Xzx7L2NL76N/V4sPXJj773b+ewKPfyHzl8r/5zQqU1yZC5PGd/Xj7+fSf/fXbyvGZf6y3/HfasL04r61mdYAFpt1fnMPybNtARHYA2AEAKyvORdVS7/RVAADe0uS3DH+1ZFyvYvGp3WZVS7yIjKff2aee4OvzZ37ORKHJm+WLPBnXLatNPqfHO/NzLvTvRFRoyus82LC9YurLIAB4vMjyOUne9ldm/uxV1J/6eNUSD3zl6VsnJSk/P9tnX1I+/OV13hw/+9b9Tqk/t5hYHWCDABbNcnm2bWAcF2sFgFAopDfsWzHT6gCAi66vxUXX12ZdDwCufXx59pUAnP3xCpz98dy+yXzmH+pzWi+wyodcfh9gYX4nokIjIlM9FKaa5bl/TrbsqMGWHTU5rXvN3tw+J+suKccN+8pzWnd67ZlY/jvdntPmBcXqANuPZIsqCKAth+WBLNsQEZELWdpuVNU9AILm4AxzMIaItGVanmkbIiJyN8uH0avqLuNme8pj27IsP+0xIiJyN1F11hDpUCiknZ2ddpdBRFRURKRLVUN21zEbxTn0hIiIXI8BRkRERYkBRkRERYkBRkRERclxgzhEpBfA2zaXUQ+gz+YaCgVfiyS+Fkl8LZIK5bVYraoNdhcxG44LsEIgIp3FNppnofC1SOJrkcTXIomvxdyxC5GIiIoSA4yIiIoSA2xh8KKbSXwtkvhaJPG1SOJrMUc8BkZEREWJLTAiIipKDDCLiMiddtdgJxEJiEijiLS48bUwfu8m4+KrruX290EmfC3mhgFmAeNSMEG767DZ5wGEjMvjwE07chFpAYCUywc12VuRrVz7PsiE+4e5s/xyKm4jIkEA3XbXYTfjqtkmt12YdDOAh4zb3QAa4dJLA7n8fXAa7h/mhy2whRdUVb5BDcYHdsBlFyYNTLuf2zXlHcyl74N0uH+YB7bA5snoHlo07eFuVW0XkSY3fUBnei1S7reo6nUWllUIBnH66+J2bnwfnMJt+4eFwACbJ7MvP4MBo387ACAoIo2qesCayqyX5bWAiLSYV9d2+msxzX4kW2HsNnPv+2A6V+0fFgK7EBeQqh4wvmEtwundSK5ifFDvFJEuEemCi1okRrAHzZ2Vm791u/l9MB33D/PHE5mJiKgosQVGRERFiQFGRERFiQFGRERFiQFGRERFiQFGRERFiQFGRERFiQFGRERFiQFGRERFiQFGRERFiQFGZAERCYrIGyLSZtxvNGZkJ6I5YoARWeNWANsAHDCuvhviZTSI5odzIRJZQEQCqjooIgEkwsu1E/oS5QsDjMgiItIIJGYht7sWIidgFyKRBYyLfXab4WXcJ6J5YIARLTAR2YHEhSzvEZGAcQxs0N6qiIofA4xoARkjDbuNKxB3A3gTwBs8BkY0fzwGRkRERYktMCIiKkoMMCIiKkoMMCIiKkoMMCIiKkoMMCIiKkoMMCIiKkoMMCIiKkoMMCIiKkoMMCIiKkr/H0cXAWHsd/72AAAAAElFTkSuQmCC
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAoQUlEQVR4nO3de3hb5Z0n8O9Pku832Y5zIReCDbQEaIqjMp2UDm0x5TLApEwglO52YEpN0y2dzjYEWmDbZ2CmJaWzne20DIFppmV4ltB0yELLZXGgZVOgxTGEhsBAbEgDJME3OY7vsn77xzlHkh3Jkh3pHOmc7+d58vhc3iO9UqTz0/ue9/xeUVUQEREVGp/TFSAiIpoLBjAiIipIDGBERFSQGMCIiKggBZyuABGRV+3atWt+IBC4D8AZYIMilSiAPZFI5LpVq1a9n7iDAYyIyCGBQOC+hQsXntbQ0NDv8/k4JDyJaDQq3d3dKw4dOnQfgMsS9zHiExE554yGhoYjDF6p+Xw+bWhoGIDRSp26z4H6EBGRwef24LV3797iiy66qBEAtm/fXrV69epTZvsY5nt0TLxiACMioqzasmVLrbW8YsWK8fvvv38/AKxZs2awpqZmMlvPwwBGRERZ09PT43/qqaeqrfW9e/cWv/766yW5eC4O4iAiyhPfO+PAqlT7zv16zf6zr63uAYDfbzky7zffHzgxVdkb9yzdlelzrl+/fvEFF1xwBAD27dtXcvLJJ49t2rRp4XPPPffm+vXrFwPA3Xff/S4Qb1n19vb6N2zY0LN9+/aqTZs2Ldy4ceOh9vb28gsvvHCwp6fHv3v37vItW7bUXnvttf0AsHHjxsXPPffcm9Of+9Zbb10QCoWG9+3bV/LRj350uKenx2/tW7NmzWC6urMFRkTkUXfddde8+vr6iBUswuGwPzFw3HDDDd3W8s6dO8s7OzuLr7322v4tW7Y0AEaQGRgYCKxZs2bw6quv7n/ggQdq16xZM7hs2bIxK3itWLFiPFm34fr16xeHQqHhNWvWDHZ2dpY88MADtdZjnnrqqWOZ1J8tMCKiPJFpy+nsa6t7rNbY8ejo6Kj48pe/3A0Ap5566lh7e3s5ACQLOOecc85wT0+Pf/v27VU1NTURa3vi8my8/fbbJf39/YGdO3eWNzU1jV1zzTX9t91228JbbrllyT333LMfwHi6x2ALjIjIo5qbm4deeOGFcgB44403jrlOlbjtrrvumrdv374Sq4VmdffNNChj586d5an2rVq1auiUU04ZO+ecc4avueaa/kcffbT67rvvfvfVV1997YknnqjKpP5sgRERedSGDRt61q9fv3j79u1VVusLMILL9u3bq/r7+wPPPvts9d69e7tPPvnksfb29vKdO3eWr1y5cvjRRx+trq2tjezZs6d8586d5U888UTV7t27y3t6evzLly8f27JlS+2ll156ZOfOneV79uwp37t3b3FfX1/AKn/HHXccvvXWWxdYgbCzs7PYusZ29dVX92dSf+F8YEREzti9e/fbK1euPO6uwGywgtAdd9xx2Om6JLN79+55K1euXJ64jV2IRESEBx54oPbpp5+uThwJmO/YhUhERLGh8oWELTAiIipIDGBERFSQGMCIiKggMYARERWQx2/rW/r4bX1Lna5HprKRjT4VBjAiIsoqZqMnIqKCw2z0RERkC2ajJyKiglPo2egZwIiIPKqjo6PiwgsvHASMbPTW9lTZ6EOh0HCustHffvvth5588snq008//bS+vr6MegcZwIiIPIrZ6ImIqCAxGz0REc3JXLLRW/eAXXR73YFs1oXZ6ImIqCAxGz0REeVUtlteFmajJyKi2YhGo1FxuhL5znyPotO3M4ARETlnT3d3dw2DWGrRaFS6u7trAOyZvs/2LkQRWQsgDKBZVTfNUG6jtT/TY4iICkkkErnu0KFD9x06dOgMsEGRShTAnkgkct30HbYGMBFpBgBVbRORRhFpVtWOJOVaAHxkNsdY5s2bp8uXL8/NCyAicqldu3b1qGqD0/WYDbtbYOsAPGUudwFoAZAyGM3lmOXLl6O9vf04q0lE5C0ist/pOsyW3U3WIIC+hPX66QXMFlbbbI4hIiLvycc+1zqnK0BERPnP7gAWRjxABQH0Ju5M0vpKe4x5XKuItItIe3d39/TdRETkQnYHsK0AGs3lRgBtACAiQWubiKw1Rx02mgM4kh6TSFU3q2pIVUMNDQV1DZKIiObI1gBmjR40RxmGE0YT7jD3b1PVbTBaXME0xxARkYe5LplvKBRSjkIkIpodEdmlqiGn6zEb+TiIg4iIKC0m8yWaBY0qnvxWP3o6J6ZsP/2yCpx1VSUA4L3dY3j6znDKx1jzT/NQ2WAk/P7N/wzjwIvJZ09fdGYxzvtGbXYqTuRCDGBEs9DTOYE/PDx0zPZlZ8cnsx07GsXBV8ZTPsbkeLzbvn9/JGXZkkp2kBDNhAGMaBaGeoyE2AtWFKHllnjrqHJ+fAqlRWeW4HMPzE/5GBUN8bJ/9rUanH1t8tnTGcCIZsYARjQLkVFFSbWg9sQinLCyJGmZ0mpfyn3T1S0vSrlvbDCK5+85AlXF6i/VzKm+RG7GAEY0Cyd/sgxffW4JNJr70bvRqGLnDwdQXCkMYERJsI+CaA7El/vpm0qrffAFgPGjisiYu253IcoGBjCiPCUiKK83rpcN9U46XBui/MMARjQLj3y9B/defBDvdCQf+p5tFfXGV3SohwGMaDoGMKJZCB+IIPzHCPypx15kVYXZAhvujdrzhEQFhAGMaBaGzEBide3lGrsQiVJjACPKkKpi2AwkFTYFsJrFfgSXBuAP5H7QCFGh4TB6ogyNHokiGgGKKwWBEnsCyur1NVi9nkPoiZJhC4woQ8NmFg67Wl9ENDMGMKIMWdehyuvt/9pEJ3kfGNF07EIkylD1ogDOuaEaFfPsa4H175/Av3/2fVTM8+GvH1lk2/MSFQIGMKIMBZcG8KfX23s9qqTKh9EjHEJPlIztfSEislZEWkRkY4r9Lea/OxO23Wn+bbWrnkT5oCzog/iNASSTE+xGJEpkawATkWYAUNU2AGFrfdr+8839zQn7W0WkE0CXnfUlSnSgfRT7nhmxNSuG+ATltcbXdJj3ghFNYXcLbB2AsLncBaAlcaeqdqjqTeZqo6p2mMtXqGqTGdiIHPH7nwzi4Rt68N4Mk1XmQvxmZnYlEiWyO4AFAfQlrNcnK2R2L16fsKl5pm5HIjvEb2K292sTTyfFFhhRorwcRq+qmwBcLyJBa91sfdWLSMv08iLSKiLtItLe3d1tc23JK2JppOrsvQ/MGrbPdFJEU9k9CjEMoM5cDgLoTdyZcI2sA0YXY6uIdJnbtpnlG6c/qKpuBrAZAEKhEK90U9apKob7nLkPbMUlFThhZXHGszwTeYXdAWwrgJC53AigDQBEJKiqYRjXxKzrXkEAL8IIZNbgjSYA99hUV6KY8aOKyXGgqExQXG5vADvpY6UASm19TqJCYOs30RqUYXYDhhMGaeww/24G0Cgia83y28wyV5rbOhOOIbKNk1k4iCg5229kNrv7pm9bZf4Nw+wKBLBtpmOI7DTc51wexOH+SXT9ZhT+YuC0iytsf36ifMVMHEQZWNJcgq+9uBjjw/ZfYj16eBKP39qH+qYAAxhRAgYwogwVlflQVGb/85abuRetViARGdihT5TnyoM+QICRcBTRCAfZElkYwIgy8NsfDeDBa97HW78dtf25fQEznZQCw/1shRFZGMCIMvD+6+M40D6GiWFnAkg8nRRvZiayMIARZSCWhcOh2Zit4ftMJ0UUxwBGlIFYHsR5znxlKur98BcD40O8BkZk4ShEojRUNdYCc+I+MAC46I46/Pl36yAijjw/UT5iACNKY2JEERlVBEoEReXOBBB/EQMX0XTsQiRKY6jHuv7lYwuIKI+wBUaURqAYWHlFBYornfu9d/APY3jif/SjvjGAy74/z7F6EOUTBjCiNKoWBvDpb9WlL5hDvoCg580JR+tAlG8YwMhT3n15DJ2/HgEALPpQCU75lJEb6sjBCF7eejTlcc2fq0JlgzMDOID44JEj70Xw7A/Cse1/+qVqFJUaLcNXfnEU4QORY44tC/rw4asqY+WI3IIBjDzlidv60PeWcZL/8LpoLIAd7Z7E7+4bTHncBy8sdzSAldX6UFQmGB/SKfU8+6+rUWROFfbaY8P44+/Gkh5fOT+A0y4ut6OqRLZhACNPGQkbAzI++sUqLFkVn+G4aoEfH/9qTcrjKuY5F7wAYxTi5T+ah/deHp+yPVASH1Ry5mcqcOKfTJ348sV/G0TlAr9joyeJcklU3XVjZCgU0vb2dqerQXnqB2e/g4lhxd/8bjGKK9ilRmQRkV2qGnK6HrPBbzB5SmTM+MGW2HIhosJkexeiiKwFEAbQrKqbkuxvMRfPV9WbMjmGKBPRiEInAfEbo/q8IDqpiIwpRIz5zIjcxNZPtIg0A4CqtgEIW+vT9p9v7m8WkeZ0xxDNxgXfrsV536h1uhq22XX/IP7p7Hex858HnK4KUdbZ/ZNsHYyWFAB0AWhJ3KmqHVarC0CjqnakO4YoU76A4ENrK3HWVZVOV8U2frOrNJJ8cCJRQbM7gAUB9CWs1ycrJCIbAVw/m2OI6FhFVgAbdddgLSIgTwdxmNe5rheRYCblRaRVRNpFpL27uzu3laOCNTIwiZe3HsUbbcNOV8U28RYYAxi5j90BLAzAyskTBNCbuDPxmheM7sLWdMcAgKpuVtWQqoYaGhqyXmlyhyMHJ/HU7f147sdHnK6KbQIMYORidgewrQAazeVGAG0AkNDSasHUYNWV6hii2Zr04BB6BjByM1sDmDkowxoqH7bWAeww/24G0GgOm4eqbpvhGKJZ8eI9YAxg5Ga23wemqpuTbFtl/g3DCGIAsG2mY4hmyzqJ+z0UwOqbinDxd+pQOd/ZVFhEucBciOQZ1kg8L7XAKur9OP3SCqerQZQTeTkKkSgXIuPeC2BEbsYWGHlG1JwP0ksBbHw4ile2DcEXAJqvrnK6OkRZxQBGnnHGmgqcflk5opNO18Q+EyOKZzaFUVbrYwAj12EAI08Rn8DvoY7zolJm4iD38tBXmch7/MVmABtnACP3YQAjz9j174P42ZWHsGf7kNNVsY2/SCB+QCeByQkGMXIXBjDyjCMHIzi8dwIjYQ9dBAMQMFthk2yFkcswgJFnxO4DK/XOKEQg/noneB2MXIaDOMgzYqmkir0VwEqrfdBJIMouRHIZBjDyDGtSR6+1wK771SKnq0CUE+xCJM+I5UL0WAuMyK0YwMgzrGtgRR5rgRG5FQMYeUbjx0vxob+sQNUib/WcP3ZLLzZf+B7efWnM6aoQZZW3vsnkaav+qzdTKQ33RjHwziTGjkadrgpRVrEFRuRysWwcHEZPLmN7ABORtSLSIiIbU+xvNf/dmbDtTmufXfUk9zm8dxyH9457Lq1SLB+ix143uZ+tAUxEmgFAVdsAhK31hP0tANrMGZgbzXUAaBWRTgBddtaX3OXhG3rwsysPY7jXW5k42AIjt7K7BbYOQNhc7gLQMm1/Y8K2LnMdAK5Q1SYz8BHNiVeH0QfYAiOXsnsQRxBAX8J6feJOs+VlaQaw1VoWEQBoVtVNuawguZcVwLw2jD5QYvxlC4zcJi9HIZpdi0+pagcAWEFLRM4XkZbpLTHz2lgrACxbtszu6lIBUNV4KikPzcgMAMvOLoXPL1h0RrHTVSHKKrsDWBhAnbkcBNCbolxLQtBaCwCqus0s3zi9sNly2wwAoVCIPzPpGNEIoFFA/IAv4K0A1nRuGZrOLXO6GkRZZ/c1sK2IB6BGAG0AICJBq4CItCYErxYY18KsFlcTgHa7Kkvu4dXWF5Gb2RrArC5BMzCFrXUAOxK23ykinSLSn3DMlWZLrDPhGKKMeTmAHe2exP4XRtH95rjTVSHKKtuvgU0bqGFtW2X+bQNQm8kxRLNRWu3DX/1iAdSDySi6nh3Bk9/qxxlrynHRHfXpDyAqEHk5iIMo2/xFgvkf8OYghtgweqZCJJdhKikil7O6Ta1uVCK3YAAjT+jfP4HHbunF735yxOmq2I4BjNyKAYw8YfDwJF79P8N469lRp6tiOwYwcisGMPKE2ChEj2XhAOKveZIBjFyGAYw8wUqj5LU8iAAQMF/zBFNJkctwFCJ5glfzIAJAXWMRrntsIYrK+XuV3IUBjDzBq5noAaMFVrusyOlqEGUdf5KRJ3j5GhiRWzGAkSeUBf1YdGYxgkv8TlfFdpFxxaMbevDI13ucrgpRVs26C1FElsOYq6sORkb5Lhh5DZ/Oas2Isui0i8tx2sXlTlfDET4f8PoTIxCfMa2MObceUcHLOICJyI0AzgfQDyMjfBjAAIwM8fUicjOATgD3qOrLWa8pEc2JLyAQP6CTxrQyfl4OI5dIG8BE5CQA1wN4UFW/l6ZsDYBWEQmp6n1ZqiPRcZucUIh4by4wS6BEMDFsTOrpL/Lme0DuM+M1MDN4naeqN2fSqlLVATPI7RCR67JUR6Lj9vR3+/H9D7+Dlx4cdLoqjohl4+C9YOQiM7bAVPUtALNuSc31OKJciY1C9OAweiAhgI0zgJF7zHoUoohU56IiRLlkTSXi1WH0bIGRG83lRuYmEVGrS9HsZjyJoxApn3n5RmYAWNJcguDSgGdfP7nTrAOYqr4kIl8UkbCqvq2qb4lIs4h8R1W/ke54EVkLYwRjs6puSrK/1VxsUtWbMjmGKB2r5eHFVFIAcOHtdU5XgSjr5tKFuBXGcPn+hO7ENgCtqY+KHdsMAKraBiBsrSfsbwHQpqqbATSKSEu6Y4gyYV37sbrSiKjwzSUTxyoA7ao6AEDMofMtAL6bwbHrYLSkAOMG6JZp+xsTtnWZ6+mOIUorlo3eowFsYiSKod5JTIxGna4KUdbMJYBdAbO1ZQaxOgC16e4RMwUB9CWs1yfuVNXNZusLMLJ9tKc7higTq9dX44Jv1yK41Jv5q395Ux9+fO57eOv/eW9CT3KvOV0DA/BSwvpbIrJLRD6crQwcZjfhU6rakUnaG/O6WSsALFu2LBtVIJdpOrfM6So4yrr2x2H05CZZSeZrBrW3MigahtFiA4yWVW+Kci0JgzXSHmO23EKqGmpoaMis0kQeYo0+5DB6cpOsZaM3uxPT2QrjuhbMv20AICJBq4CItFrByxzUkfQYotl46cGjeOnBo55tgQTYAiMXSptKai4poVIdp6od5v4WGBnsO8xdOxK23ykinSLSn+YYooz95vthtN3Rj2jEmyfwQInxly0wcpO0qaREZIeI/AuAh9LdrGwOq78eQH+qZL4JgzQSt60y/7YBqM3kGKJMqSpTSZUYv1Wt94HIDdIO4jDzGn7JvHn5ZgAKoAPxa1H1MK5NNcG4P2yTeQxRXohGAI0CvoC3s9EDwCQDGLlIxqMQVfVeAPea932FYAStOhiDN7rMgRxEecfraaQA4NSWMtQ1BlDfyMnAyD3mMox+AOY1K6JC4PU0UgBQ31SE+iYGL3KXOd3VaQ7QWAVgF4xrY0eyWiuiLLJG3nm5BUbkRnPJhfhdACcDGABwJYC3ROQL2a4YUbZEJxSBUkFRmXcDWG/XBJ6/5whef3zY6aoQZc1cWmAvquovrBXzHq6bReRyVf2PrNWMKEtqTyzC37Yvgap3BzD0dk1g5w8HcPKnyvDBi8qdrg5RVhz3jcyqGlbVm8EchZTnMklL5laxVFK8D4xcZC4BrEtEXhSRT06bnTlVWigiclgslRQzcZCLzCWArQPwEID1AN42g9mTMObvqgIAEbk8i3UkOi5//P0ofnLZQbT9fb/TVXFMgC0wcqG5XAPrhJEp/nsAICJnwZij69MAvikiVkuM18MoL4wORNHbFUHt8kmnq+IYKwMJM3GQm8y6BWbe0FwrIsvN9ZdU9Xuq+mlVrYPRQmMmDsob1knby/eBxVpgDGDkInO6D2ymrBvmHF43zb1KRNkVy4Po0dmYASN4l1b7UFLp3feA3Ccn09MyrRTlk1gqKQ8HsKqFAdzw3GKnq0GUVVmbD4woX7EFRuRODGDkerwGRuROtgcwEVkrIi0isnGGMs3T1u80/7bmun7kPovOKEbz5ypxwspip6viqPsuOYgfnfsuJic4kIPcwdYAZgUmc+LK8PRAZZZpAXDvtM2tItIJoCv3tSS3OemcMpz3jVo0/lmZ01Vx1FD3JIZ7oxyJSK5hdwtsHYCwudwF4/6xKczg1jdt8xWq2mTuI6I5sK4B8mZmcoucjEKcQRBTg1Om+RObzTx2zaq6KduVInfr6ZzA6EAUdScFUF7rd7o6jokFMKaTIpcoiEEcqrrJbH3Vm12MRBl7/u4B/O/Pv4/9z486XRVH+dkCI5exO4CFAdSZy0FkkADYHPSx1lztBdCYpEyriLSLSHt3d3eWqkpuwWH0hlgLjNfAyCXsDmBbEQ9AjQDagNicYql0WeUANAFon15AVTerakhVQw0NDdmrLblCZMz4ywDGAEbuYmsAU9UOIDbSMGytA9hhlTFbWyGr1WWWudJc70w4higjbIEZzvxMBVavr0blfO9eByR3sXsQB1R1c5JtqxKWtwHYlu4YokwxlZRh5RWVTleBKKsKYhAH0fFgC4zInRjAyPUYwAzdb46j89cjOHIw4nRViLKCAYxc78p7G3DNwwtQfYLtPeZ5ZdfPjuI/vtKDt3/r7dsJyD28/Y0mT6hZzI85kHAfGG9kJpdgC4zII5hKityGAYxcTVXx6I29eOyWXqh6+8TNVFLkNgxg5GrRCPD648N47VfDMPNpehZbYOQ2DGDkahyBGBcoMf6yBUZuwQBGrma1NhjAgEApW2DkLhyeRa5mtTYYwIAVl1Tg5E+WoaSSv1vJHRjAyNViLbBSBrCSSh+DF7kKAxhl5MjBCPrejuCElcUoLjdOgt1vjGOoN5q0fGm1DwtPLwYARCOKP744lvKx551ShMp5RoLZgfci6N+fPFOEzw8sO7s0tv7uS2OYSNEdVr3Ij7rlRYiMKfxFgL+YAQwAJkaiePfl8aT7ymp9WPBB4/8sMq54Z1fq/7P5HyhCeZ3xfxY+EEH4neT/Z/4iYGko/n92oH0UkxPJHzO4JIDgUuOUNNw3iff/c2rBQLHghJXF8AX4f0kGBjBKa3w4ip9cdggTI4ov/HIh6pYbAeyFewfx+uPDSY9ZGirBVf82H4AxkOLnX0w9T9slm+pw2sUVAIA3/u8wfn3XQNJyReWCr/1+SWz98Vv7Uga70F9V4pM31qKkyodPf7sOu39+NP0LdbnuN8ex838NYN8zyTNxNJ1bist/ZExHNBqOzvh/dvk/z0PTJ8oAAK8+MoTn7j6StFxFgw9ffmZxbP3RDb0Y6kn+o2f1+mp87L/VAADee2UcD3+lZ8YyRAxglNZQ9yQmRoyWTlFCV9y8k4uw7KMlSY+Z/4Gi2LL4kLIcAJTXx6f3qF4USFm2aNp1rBNWFqNqUfKpQWqXGc8fXBLAxHAUf/KF6pTP7xW1y4pQUuVL+f42fKA4tuwrmvn/rKw23hVZsyT1/1lZzdQuyyWrSjAykDyA1SyJn47KglPrOdwbRc+bEyl/sJA3idtu7gyFQtrefsycl3QcDu0Zx/1XHcaCFUX4/EMLna4OedC+Z0bw8A09aPyzUvzljzlpbS6IyC5VDTldj9lgC4zSGhsyfjEXV3AAADlj8VnF+OxP56OigZ9BimMAo7TGjxoBrKSKJw9yRlnQjyWrOJM0TWX7GUlE1opIi4hsnKFM82yPodwZO2p0MxdXcPQXEeUPWwOYFZhUtQ1AeHqgMsu0ALh3NsdQbvkCQM1iPyrn8xcwOWNiNIqn7+xH2z/0O10VyiN2t8DWAQiby10AWqYXMANV32yOodxa8ecVaH3yBJz7t0Gnq0IeJT7BrvuPYvdDRz0/qwDF2R3AgpganOpzdAwRuUigWOAvNmYXsBI0E/GqPBEVBCsN1vhRBjAy2B3AwgDqzOUggN5sHCMirSLSLiLt3d2pswfQ3Dz2zV788GPv4o225Fk3iOxQbAWwoeQ3QpP32B3AtgJoNJcbAbQBgIgEZ3tMIlXdrKohVQ01NPAmx2wbCUcxOhBlDjpyVEml8fkbG2QLjAy2BjBV7QBiIw3D1jqAHVYZEVkLIGT+nekYssn4kHHCKOEwenKQdSP9GFtgZLL9RmZV3Zxk26qE5W0AtqU7huwzNmhm4uBUHOSg+sYAxoei8BfxhxQZmImD0rKuOXAuKXLS+bfVpS9EnsIzEqUVy8RRyV++RJQ/GMBoRqqKsaNM5kv5QaOKyQkO4iADz0g0I40Cn7wxiHNuqEGAsxqTg1786SDuWvkOdv4w+YSn5D28BkYz8vkFq/5LldPVIEKgRACNDyoiYguMiAqCdR+YdVsHEQMYzWioZxKvPjKEAy+OOl0V8jjrNg7rmiwRAxjNqKdzAo99sw/P3X3E6aqQx1k30rMFRhYGMJoRb2KmfFFszgjOa2Bk4VmJZmT92uVszOS0kgom86WpOAqRZjR+lFk4KD+U1/vQcmsQ5bWcGZwMDGA0o1gWDrbAyGHF5T6cdRVv6aA4/qymGcXyIFbxo0JE+YVnJZoR00hRPnntsWG03z/IofQEgF2IlMb5t9biExuCEMYvygO//dEA+vdH0PjxUl6XJQYwmpn4BMXlvP5F+cG6Fsuh9ASwC5GICojV6uLNzAQ4EMBEZK2ItIjIxkz3i8id5t9Wu+pJhkc39ODBa99H+J2I01UhYjopmsLWACYizQCgqm0AwtZ6BvtbRaQTQJed9SXg4B/GceDFMaerQQQg3oXIFhgB9rfA1gEIm8tdAFoy3H+FqjaZgY1sNDZonChKOBsz5QHrdo5xtsAI9g/iCALoS1ivz3B/s4gAQLOqbspV5WgqVcXYEIfRU/4oqRD4AkBknC0wKpBRiFbQEpHzRaRlekvMvDbWCgDLli1zoIbuFBlV6KQxkaC/iC0wct7HvlKDc75aA/MHLXmc3T+rwwDqzOUggN50+81BHWvNbb0AGqc/qKpuVtWQqoYaGhqyXGXvGmMiX8ozPr8weFGM3QFsK+IBqBFAGwCISHCG/V1WOQBNANrtqCglJPJlGikiykO2nplUtQMARKQFQNhaB7Aj1X5z25VmK6wz4RjKsUCJ4MzLK3DKeWVOV4UIAPBOxxi2fOYQHr+1L31hcj3br4Gp6uYk21al2X/MNsq96kUBXPh3dekLEtlEo4qeNydQUsVuRGImDiIqINaNzONHOQqRGMBoBkM9kzj8+jiGeiadrgoRgPiszMzEQQADGM3g9SeG8bO1h/H8PUecrgoRAMS6DtkCI4ABjGYQm8ySWTgoT1g31I8NRaHKIOZ1DGCU0pj5K7eY8y5RnvAXCQIlAp00brQnbyuITBzkDM7GTPnorM9WQnwAG2DEAEYpWdcZOGSZ8sknNgSdrgLlCf60ppRimTjYAiOiPMQzE6UUy0TPQRyUR3q7JrD/hVEM9fL2Dq9jFyKldNEddRjujWLeKUVOV4Uo5tkfDGDf0yP4ix/U49SWcqerQw5iAKOUapcVoZaz01Ceic3KzHvBPI9diERUUKzZEZiNgxjAKClVxeO39mLHP/RDo/ylS/mjxGqBDTGAeR0DGCUVGVXs2T6MV34xBPFxEAflD+vG+rFB/rDyOgYwSiqehYPBi/JLYjop8jYGMEoqdg8Y00hRnrFyc3IQB3EUIiUVTyNlnCye/m7/lP2furnW9jodL+s1HE/d5/oYdh+Xq8exW2K9reXVX67BFx5diLJa/rjyOtsDmIisBRAG0KyqmzLZn+4Yyr6xWBopniQov5RW+1Bazc8l2dyFKCLNAKCqbQDC1vpM+9MdQ7kxzkS+RJTn7G6BrQPwlLncBaAFQEea/fVpjpkiOqEYPBRJuq+szo9AsdElNnokionh5BeBJSConOePrQ8ejgAputtLqnyxk/zESBSjA6kvLFfO98dG9A33TWJyPPmDBkoFZUHj+ScnFMMzpMzJ1WsqKhcsOrMY9Sexl5nyy0h4Eju+E4bPD3z8qzVT9vkCggrzc66qOHo49XenpNqH4nLjuzs+HMXYkdTf3aqF8e/BUM8kopHkX56iMh9Ka4zHTPfdLa/3w19kfncHopgYSf78drymQr0lwe6zUxBAX8J6fQb70x0zxftvTOBfWg4m3bfuJw1YdnYpAOD5e46g/aeDScvVnhjAdb9aFFv/10sPYWI4+Qf23K/X4OxrqwEA+54ZwS839iUtBwB/87vFsWtKj/z3XhxoH0ta7oMXlePS7xkvc+DdCP71kkMpHzOXr+mkj5WlfF4iJ732q2EAwKuPDE/ZvmBFET7/0MLYeqpzAQB8+tu1WLm2EgCw95fDeOrv+lOWvXHP0tjytvXdeP+1iaTlPnRFBS74Vh0AoPs/J3D/VYdTPubnH1qABSuKAQC/+ccwXvnFUNJydryml7ceTVkun7ni57WItAJoBYAl5WegcoE/aTl/cXxIeEmVpCxXXj+126xyvh8TI8lP9tavHQAIlKR+TKOi8cWyOl/KstYvOADw+Wd+zFy/JqJ8U1rjw2kXl+PArmN/AJbXT/38z/TdKSqTKcszfncTn6POj8oFyVsspQnXjH2BmZ/fl3D2LalKfT6w4zUVFeh33u4AFgZQZy4HAfRmuH+mY6CqmwFsBoBQKKTrd5yQtiKrv1SD1V+qSVsOAK775aL0hQCccl45Tjkvs+Sif/GP8zIqF1waQCavB8jNayLKNyKCSzbN2BETK5fpd+f0Sytw+qUVGZW94p6GjMrN/2Bxxs//iQ3BjOY5y9VrOuuqSuCzGRXNK3YHsK0AQuZyI4A2ABCRoKqGU+1PsY2IiDzM1najqnYAgIi0AAhb6wB2pNo/wzFERORhtl8DM7v7pm9blWb/MduIiMjbRNVd6VhCoZC2t7c7XQ0iooIiIrtUNZS+ZP4ozKEnRETkeQxgRERUkBjAiIioIDGAERFRQXLdIA4R6Qaw3+FqzAPQ43Ad8gXfizi+F3F8L+Ly5b04UVUzu0s7T7gugOUDEWkvtNE8ucL3Io7vRRzfizi+F3PHLkQiIipIDGBERFSQGMByg5lD4vhexPG9iON7Ecf3Yo54DcwmIrJRVTc5XQ8iyj88P8yNK+YDy3dmIuKPOF0Pp5nztgFAk6re5GhlbCYia2FMF9Ts9ROVlz8HyfD8MHfsQiRbmF/SNjMxc6O57gki0gwAqtoGIGyte5GXPweUfQxgOSYizeaJy+saAVgnqy5z3SvWwWh9AcZr9/JJ28ufg2Pw/HB82IWYe3Xpi7jftClxmmFMXuoVQQB9CevppxN2KY9/DpLh+eE4MIAdp4T+/ERdqtrGX1fHMrvPnuLEpN7GzwFbX9nAAHac0ky22SgijQnLzW7+ws4UzBPWWzw4iCGM+C/tIIBex2qSP7z4OZjOU+eHXGAAyyFV3QbETuxBZ2uTe+lmzhaRVuukJSItHvr1uRWAlSqoEYBXXndSHv4cTOG180Mu8D4wsoU52uznMK4F1QG4wksnLvMk1QWgMV2gdzOvfw4ouxjAiIioIHEYPRERFSQGMCIiKkgMYEREVJAYwIiIqCAxgBERUUFiACMiooLEAEZERAWJAYyIiAoSAxgRERUkBjAiG4hIs4h0isjPE9aDDleLqKAxgBHZowXAKgD3WFn7VTXsaI2IChxzIRLZyGx11alql9N1ISp0DGBENrG6DNnyIsoOdiES2cCauNAKXgkTGRLRHHFCS6IcE5FmGBNa9olIG4zrYWEY84MR0RyxBUaUQwndhpthzMb8FoCPcBJHouPHa2BERFSQ2AIjIqKCxABGREQFiQGMiIgKEgMYEREVJAYwIiIqSAxgRERUkBjAiIioIDGAERFRQWIAIyKigvT/AWYnZMmpbvQuAAAAAElFTkSuQmCC
 "
 >
 </div>
@@ -15568,7 +15279,7 @@ To construct this you need to give the x and y values (both of shape=(npdf, N))<
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAst0lEQVR4nO3de3hU9bkv8O87M7mSyxAyJCRchgACAcmFgBBiW91BQbwEjVZtVXhq8dh92u7n2W7bfWrPefbedu8t9Tmnl71PK/UUtLqtSiUq3prU2goBJRCC3C8hECYkJIRcIOQymd/5IyswRCaXyWStWTPfz/PwZNb81pp5HWfyzVrzrt8SpRSIiIjMxmJ0AURERP5ggBERkSkxwIiIyJQYYEREZEo2owsgIjK73bt3T7TZbC8CmA/uGASaB8B+t9v9+MKFC895DzDAiIhGyWazvZiamjrX4XBcsFgsbO0OII/HI42NjZn19fUvArjbe4x/KRARjd58h8PRxvAKPIvFohwORyv69m6vHTOgHiKiUGNheI0d7bX9Ul4xwIiITO7gwYORK1euzBhsnY0bN44fi+cuKSmJz8/PnxWI537yySfTn3nmmZThPjcDjIjI5DIzM7s/+OCDal/jTU1N1tLS0oSxeO6ioqL2xMTE3kA89ze+8Y0LI3luNnEQEQXQP2yumnK0vj02kI95Q2p8x0+Ls2p9jW/bti326aefTi8vLz9WUlISv379+tSnn366vqKiInbFihXtAFBVVRVbUlISX1RU1N7U1GT92c9+lpyXl9dx/PjxqJkzZ3atX78+9dvf/nbTiRMnIvPy8jp+9KMfTf7JT35ypn+8qKioHQCef/755CVLlnTs3Lkz9qmnnmoaWEtJSUm89zaHDx+OGuy5n3rqqaZnnnkmJS8vr6OiomJErxv3wIiITK6goKCjfy+oqKiovba2NqqoqKj94YcfvvDqq6+OLygo6Jg6deqVEPrxj3+cumLFivaioqL2PXv2jOvfZu3atReeffbZBm2vyl1UVNT+1FNPNX33u9+dBgDPPPNMypIlSzoKCgo6Zs6c2fX8888ne9dx8ODByP5QWr9+fWp/bYM99/PPP5+cl5fXUVRU1N4ftsPFPTAiogAabE9JL/Pnz+8YbLyqqir29ttvb9u2bVvsd77zncbrbeN9WHDKlCldBw8ejPz4448THn744QsAcMMNN3S98MILDu+9sMzMzO7MzMympqYm63Cf+yc/+UnqHXfcccaf/07ugRERhZFt27bF3nrrrW1A397RnDlzuq63Xmtr65UQqq2tjcrMzOzOysrqOHr0aBQAHD16NGrhwoWXBj72YE0Y13vuhQsXXvrss8/GAX3fl43kv4V7YEREJrdt27bY/fv3xx48eDCyubnZ1n/7/fffT6iqqoptamqyOp3OrpKSkviCgoKOgoKCjoFBs3///tht27bFFhQUdABAa2urbdu2bbE7d+6M/eUvf3kKAH71q1+5+rerqKiIffbZZxu8n/vYsWNRdru99/Dhw1FOp7N748aN49euXXthsOd+9tlnG5555pmUbdu2xVZUVMR+/PHHCU1NTU3Jyck+G0P6Ca8HRkQ0OlVVVTVZWVlfamgws5UrV2YM1tmot6qqquSsrCyn9308hEhERNcoKSmJ79+rMrqWwTDAiIjoGlpX4v7MzMxuo2sZDAOMiIhMiQFGRDR6Ho/HI0YXEaq019Yz8H4GGBHR6O1vbGxMZIgFnnY5lUQA+weOsY2eiGiU3G734/X19S/W19fzgpaBd+WClgMH2EZPRESmxL8UiIjIlBhgRERkSgwwIiIyJQYYERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZlSyM1Gn5ycrJxOp9FlEBGZyu7du5uUUg6j6xiJkAswp9OJiooKo8sgIjIVETlldA0jxUOIRERkSgwwIiIyJQYYERGZEgOMiIhMiQFGRESmpHuAiUixiBSKyLoh1ntupNsQEVH40DXARKQYAJRSZdpyoY/1CgFkjGQbIiIKL3rvgS0CUK3drgaQO3AFEcnwWmdY2xAFu9PnO7B59xmjyyAKKXoHmH3A8oTrrJOhlPIOsCG3EZF1IlIhIhWNjY2jq5BoDPzLewfx1JtV2O9qNboUopChd4C1AEjyNSgihf2HCoe7DQAopTYopfKUUnkOh6lmQqEwUNvcgbJDDQCAl8prjC2GKIToHWC7cHWPKgNA6YDxZq1ZoxhAhojkDmMboqD2UnkNrCJYnpmCt6vqcP5il9ElEYUEXQNMKbUZfcFUCMDu1ZhRqo3v0e5LghZavrYhMoNLXW68XlGLlTdOwtO3z0a324PXPj9tdFlEIUH3yXyVUuu1m2Ve9y0fsM4GABsG24bIDN6qdKG90401+U7MSonHzbOS8budp/DEV2cgwsrTMIlGg58gojGilMKm7SexYHIicqfaAQBr8p1oaOvCh/vrjS2OKAQwwIjGyLbjTTjReAlr8p0QEQDALbMnYtqEWGxiMwfRqDHAiMbIxu01SI6LwqoFk67cZ7EIHlvqxO5TF7DvTItxxRGFAAYY0Rg42XQJHx8+h2/cNBVRNus1Y8V5kzEu0opN22uMKY4oRDDAiMbAyztqEGEVfOOmqV8aS4iOQPHCyXh3Xx3OtXcaUB1RaGCAEQXYxS433qw4g1U3TsLEhOjrrvNovhM9vQqvfVarc3VEoYMBRhRgf9h9Bhe73FizbLrPdWY44vDVGxx45bNT6HZ7dKyOKHQwwIgCyONR2FReg5ypdmRPsQ+67tplTjS2d+H9L87qUxxRiGGAEQXQX4414mRTX+v8UL4yy4GM5HHYyJZ6Ir8wwIgCaNP2GkyMj8LK+ZOGXNdiETyW70RVbQsqT1/QoTqi0MIAIwqQE40X8ZejjfjmkmmItA3vo3XfwsmIi7LxxGYiPzDAiALk5fIaRFoteGjxl1vnfYmLsuH+vMl4b99ZNLSxpZ5oJBhgRAHQ1tmDzbvP4K6sNDjio0a07WNLnehVCq/uPDVG1RGFJgYYUQC8WXEGl7p7h9W8MZAzeRxunT0Rr352Gl3u3sAXRxSiGGBEo9TrUXipvAZ508bjxsmJfj3GmmVOnL/Uja1VbKknGi4GGNEofXLkHE43d2DNMqffj1EwMxkzJ8ZhU3kNlFKBK44ohOkeYCJSLCKFIrLOx3ih9u85r/suiEipiDytX6VEw7OpvAapCdG4fV6q348hIliT78QXrlbsYUs90bDoGmAiUgwASqkybblwwHgugFxtPFdEMrSh+5VSy72uzEwUFI41tOPTY014ZOm0UV9h+d7cdMRH2/BbzlJPNCx674EtAlCt3a4GkOs9qJTao5RaLyJ2ANVKqf517V5hRhQ0NpXXINI2stZ5X2IjbXhw0RR8uL8eZ1svB6A6otCmd4DZByxP8LFeHoATXstJAJpF5IXrrSwi60SkQkQqGhsbR18l0TC0dvTgrT0uFGWnIWlcZEAe89GlTniUwitsqScakt4B1oK+MBqUdghxhtchxw1KqRYALf33DVh/g1IqTymV53A4Alwy0fW9UVGLyz29eMyP1nlfpiTFonBuCv7rs9Po7GFLPdFg9A6wXbi6F5YBoNR7UESe82ruaAGQpO1dXXOokchovR6Fl3bUYPH0JMxL86913pe1y5y40NGDd6rqAvq4RKFG1wBTSm0GkKE1b9i9mjn6g+wFANVe4xsAvKGtU+z1GESG+tOhBpy5cBlrA7j31W9pxgTMTonHpu1sqScajE3vJ/TqJCzzum+59rMaV5s8yrT7WgDs0f4xvCgobNxeg3R7DJZnpgT8sUUEa5Y58Y9vfYHPTzbjpgxfXxUThTeeyEw0Qofr27Cj+jweWToNtlG2zvtSlJ2OxJgIzlJPNAgGGNEIvVReg+gICx5cNGXMniMm0ooHF0/BRwfq4WphSz3R9TDAiEbgwqVubKl0YXVOOuyxgWmd9+XRpU4AwO92sKWe6HoYYEQj8HpFLTp7PAFtnfcl3R6D2+el4ve7TuNyN1vqiQZigBENk7vXg5fLa5A/YwLmpCbo8pxr8p1o6ehByV6XLs9HZCYMMKJhKj3YgLrWTr+u+eWvxdOTMHdSAlvqia6DAUY0TBvLazB5fAz+Zm7gW+d9ERGszXfiSEM7dlSf1+15icyAAUY0DAfqWvH5yWY8ttQJq0V0fe67tbkWN3GWeqJrMMCIhuGl8hrERFjxQN7Ytc77Eh1hxUOLp6DsUANqmzt0f36iYMUAIxrC+YtdKNlbh/sWpiMxNsKQGr65ZBpEBC/vqDHk+YmCEQOMaAi/31WLbrcHj2nnZRlhUmIMVsxPxe931eJSl9uwOoiCCQOMaBA9vR78bscp3DwrGbNS4g2tZW2+E+2dbmypZEs9EcAAIxrURwfqUd+mb+u8LwunjceN6YnYVM6WeiKAAUY0qE3bazBtQixumT3R6FL6ZqnPd+L4uYvYfpwt9UQMMCIfvjjTiopTF/DYUicsOrfO+3Jn1iQkx0Vi4/aTRpdCZDgGGJEPG8tPYlykFcV5k40u5YoomxUPL56Kj4+cQ03TJaPLITIUA4zoOhrbu7C16iyKF05GQrQxrfO+fHPJNFhF8DJnqacwp3uAiUixiBSKyDof44Xav+eGuw1RoL32+Wl093rwaBA0bww0MSEaqxZMwpsVtbjIlnoKY7oGmIgUA4BSqkxbLhwwngsgVxvPFZGMobYhCrRutwev7DyFr97gwAxHnNHlXNeafCfau9x4a88Zo0shMozee2CLAFRrt6sB5HoPKqX2KKXWi4gdQLVSqnqobYgC7YP9Z3GuvQtrlzmNLsWnnKnjkTXFjk3ba+DxsKWewpPeAWYfsDzBx3p5AE4MdxsRWSciFSJS0djYOKoCiTZur0FG8jh8ZZbD6FIGtTbfieqmS/jrMb7nKTzpHWAtAJKGWkk7XDhDO3w45DZKqQ1KqTylVJ7DEdy/dCi4VZ6+gL21LXgsP3ha532548ZJcMRHYVN5jdGlEBlC7wDbhat7VBkASr0HReQ5r0aNFvQF16DbEAXSS+U1iIuy4b6FwdM670ukzYJv3jQNnxxpRHXjRaPLIdKdrgGmlNoMIENrxLB7NWb0h9ILAKq9xjf42oYo0M61deK9L87i/rzJiIuyGV3OsDx801REWNlST+FJ90+pUmq9drPM677l2s9qXG3YKBtsG6JAe/Wz03B7lKGzzo+UIz4Kdy1Iw5sVtfj7225AfJCds0Y0lngiMxGALncvXv3sFG6dPRHO5HFGlzMia5Y5cam7F29WsKWewgsDjAjAe/vOouliN9YEceu8Lwsm27Fw2ni8tIMt9RReGGAU9pRS2Li9BjMnxqFgZrLR5fhlTb4Tp8534JOj54wuhUg3DDAKe3tOt+ALVysey3dCJLhb531ZMT8VKQlR2Li9xuhSiHTDAKOwt6m8BvHRNtybk250KX6LsFrwyJJp+PRYE46faze6HCJdMMAorNW3duKDL87iwUVTMM4krfO+PLR4KiJtFp7YTGGDAUZh7ZWdp9CrFB41Ueu8LxPionBPVhr+sNuF1ss9RpdDNOYYYBS2Ont68V+fn0bh3BRMSYo1upyAeCzfics9vXizotboUojGHAOMwta7VXVovtSNtUF4zS9/zU9PxGJnEl7aUYNettRTiGOAUVhSSmFTeQ1mp8Rj6QxfF0UwpzXLnKhtvoyPD7OlnkIbA4zC0q6aCzhQ14Y1y8zbOu/LbZkpSEuMxsbtJ40uhWhMMcAoLG0qP4nEmAgUZZu3dd4Xm9WCR5Y6UX7iPI7Us6WeQhcDjMKOq+UyPjrQgAcXT0FMpNXocsbEg4umIIot9RTiGGAUdl7ZeQpKKTyyZJrRpYyZ8eMisTonHVsqz6Clo9vocojGBAOMwkpnTy9e+/w0bstMxeTxodE678tj+U509njw+i621FNoYoBRWCmpdKGlowdrTTjr/EjNnZSAJRlJeHnHKbh7PUaXQxRwDDAKG/2t83MnJWDx9CSjy9HF2mXT4Wq5jLJDDUaXQhRwugeYiBSLSKGIrLvOmF1EcrV1nvO6/4KIlIrI0/pWS6FkZ3UzDte3Y62JZ50fqcK5KUi3x3CWegpJugaYiBQDgFKqTFsuHLDKAwDylFKbtfH+kLtfKbVcKbVet2Ip5GwqP4nxsRG4OzvN6FJ0Y7UIHsufhs9ONuNgXZvR5RAFlN57YIsAVGu3qwHkeg8qpTYopTZoixle69pFJEOfEikU1TZ3oPRgAx5aPBXREaHZOu/L1/OmIibCipfYUk8hRu8Asw9Yvu4cPlpYNffvqQFIAtAsIi/4WH+diFSISEVjY2PAiqXQ8crOUxARPLI0dFvnfUmMjcC9ueko2etC8yW21FPo0DvAWtAXRkMpVko90b+g7Zm1AGjpPwzpTRvPU0rlORyOgBVLoaGj243XPj+NFfNTMSkxxuhyDLEm34kutwevfX7a6FKIAkbvANuFq3thGQBKB64gIsX933VpDR3rRCR34HpEw7Wl0oW2TndIzTo/UrNS4lEwMxmv7DyFHrbUU4jQNcC05owMrXnD7tXMUar9LATwnIjsFpHd6Ntbe0MbK/Z6DKJhUUrhpfIazE9PwMJp440ux1Br8p0429qJPx5gSz2FBt2voe7VSVjmdd9y7WcZgBnX2WyP9o/hRSOy70wrjjZcxL/fe2PYtM77csuciUhLjMbm3bVYtWCS0eUQjRpPZKaQtqXShUibBStv5C9sq0VwT046/nqsCU0Xu4wuh2jUGGAUsnp6PXi3qg6FcyciMSbC6HKCwuqcdPR6FLZW1RldCtGoMcAoZG073oTzl7pD8ppf/rohJR6ZkxKwZS8DjMyPAUYhq6TSBXtsBL42e6LRpQSV1TnpqKptQXXjRaNLIRoVBhiFpItdbnx0oB6rbpyESBvf5t7uzk6DCFDCvTAyOX6yKST98UA9Ons8WJ3Dw4cDpSREY9mMZJRUuqCUMrocIr+NOMBEJFtE7hWRp0Tkce129hjURuS3LZUuTB4fE/bnfvlSlJOO080d2HO6xehSiPw2rAATEaeI/FpEPgLwBPrO1WoFINrt/yYifxSRX4mIc8yqJRqGc22d2H68Catz0sP+3C9fbp+XgugIC0oqXUaXQuS3IU9kFpF/QN+MGD9QSrUOsW4igHUickEp9WKAaiQakXeq6uBRfXsZdH3x0RFYnpmKrfvq8OM7M/k9IZnSoO9aLbw2K6X+cajwAgClVKtS6qcA/iQiTwWqSKKRKNnrQtbkRMxwxBldSlBbnZOGCx09+OtRXsGBzGnQAFNK/VQpdXKkD6qUOqmUet7/soj8c6yhHftdbdz7GoabZzmQNC4SW/byMCKZkz9NHM4xqIMoIEr2umC1CO5cED5XXfZXhNWCuxZMQtnBBrR19hhdDtGI+XPge7yIPN6/ICL3icitAayJyC8ej0JJZR1unpUMR3yU0eWYQlFOOrrcHny4v97oUohGbMQBppSqBDCzP7SUUn8AcJuIfCvQxRGNRMWpC3C1XOa5XyOQPcUO54RYdiOSKflzCPEjAArAbq/zv/4NwHqfGxHpYEulC7GRVizPTDG6FNMQERTlpGNH9Xmcbb1sdDlEI+LPIcQZAF7QuhJFa53/jfaPyBBd7l68t68OK+alIjZS98vcmVpRdjqUAt7h1FJkMv4E2G0AfiAiCdrhxEIAnyulfhjY0oiG78+HG9HW6Wb3oR+cyeOQM9WOLTyMSCbjz3dg1UqpJ5VSbdryHwC0DreRQ0SKRaRQRNZdZ8wuIrnaOs8NZxsioG/meUd8FPJnTDC6FFO6Nycdh+vbcehsm9GlEA1bQE6/V0r9BsCQ54uJSLG2fpm2XDhglQcA5CmlNmvj64axDYW51o4efHz4HO7OSoPNyhkl/LFqQRpsFkEJzwkjEwnYp32YJzwvAlCt3a4GkDvgMTYopTZoixnaOoNuQ/T+/rPo7uXM86ORNC4SX5vtwNuVdfB4OEM9mcOQU0n5c+KyiEz3MZWUfcDydY/3iEgGgGZtr2vIbbQ9tQoRqWhs5LQ44WZLpQszJ8ZhXlqC0aWYWlFOOurbOrHz5HmjSyEaliGnkgKwXET+bThBJiIJIvLvAO7zMZVUC/omBh5KsVLqieFuo+255Sml8hwOxzAenkLFmQsd+PxkM2eeD4DCuSmIi7LxnDAyjSH7jZVSvxGR6ei7ZEoO+g7jtQA4gb69ownazxnafesHOZy4C1f3qDIAlA5cQUSKlVLrtdu5w9mGwtfbWuv33VmcOmq0oiOsWDk/FR98UY9/vmc+oiOsRpdENKhhfQemTc77Q6XU7eg7YbkMfdcCawVQAWCDUuo2rTvR53dhWnNGhtaIYfdqzCjVfhYCeE5EdovIbgBJvrYhUkphS6ULi51JmJIUa3Q5IWF1Tjrau9z406FzRpdCNKQRn/GpBdRJAH/y5wn7967QF4L99y3Xfpahb09uyG2IDtS14fi5i/jX1TcaXUrIuCljAlITorGl0oVVCyYZXQ7RoPzqQhSRx7XvxR4XEX5zTobYUulCpNWCVTfyF22gWC2Ce7LT8MmRc2i+1G10OUSD8mcuxF8DmIm+Q4gPADjJiXxJb+5eD96pqsMtcxxIjI0wupyQUpSTDrdH4b19nFqKgps/e2Cl2vdhP1RK3Ya+Q36zROTeANdG5FP5ifNobO/iuV9jYO6kBMxJjefUUhT0Rn0is1KqRZsHkXP4kG5KKl1IiLbha7MnGl1KSCrKScee0y04df6S0aUQ+eRPgFWLyC4RWT3g+y+e/Ui66Oh248MD9Vi1YBJbvcfI3VlpEAFKKnkYkYKXPwH2dQBvAHgIQI0WZq+j7xwtAACv0ExjqfRgAzq6e1GUzcOHYyXNHoMl0yegZK8LSnFqKQpO/gTYCQBvKqUeUEolAViHvnPBbhOR8yKyC8Bzgz4C0ShsqXQh3R6DRc7hTOpC/lqdk46TTZdQdabV6FKIrsufy6n8BsD4/qmllFKVSqmfaicyTwDwBIALgS2TqE9jexc+PdaEe7LTYLFw6qixtOLGVETaLJxaioKWX00cWmjV+BjbA+AHoymKyJet++rQ61HsPtRBQnQEls9NwbtVdejp9RhdDtGXjMnFk7QrNRMFXEmlC/PSEjArJd7oUsJCUU46zl/qxrZjTUaXQvQlvPofmcaJxouoOtPKvS8dffUGB+yxETwnjIISA4xM4+1KFywC3MWZ53UTabPgzgWT8MeD9bjY5Ta6HKJrMMDIFJRS2LLXhWUzk5GSEG10OWFldU46Ons8+Gh/vdGlEF2DAUamsOf0BdQ2X+a5XwbInToeU5JiULKXhxEpuDDAyBS2VLoQHWHB7fNTjS4l7IgIVmenY/vxJjS0dRpdDtEVDDAKet1uD7buO4vbMlMRFzXiS9hRANyTkw6PAt6t4tRSFDx0DzARKRaRQhFZN8h46YD7LohIqYg8rU+VFEz+crQRLR097D400AxHHLImJ7IbkYKKrgEmIsXAlSsvQ0QKB66jlNp8nU3vV0ot97oyM4WRkkoXJoyLRMGsZKNLCWtFOek4UNeGow3tRpdCBED/PbBFAKq129UAcoe5nV1EMoZejUJNW2cPSg814K6sNERYecTbSHcuSIPVIpxaioKG3r8R7AOWh3sNsSQAzSLyQmDLoWD34Rf16HZ7UMTDh4ZzxEfh5lnJeHtvHTwezlBPxtM7wFrQF0YjopTaoJRqAdDSfxjSm4isE5EKEalobGwcfZUUNLZUujA9eRyyJicaXQqh75wwV8tl7KppNroUIt0DbBeu7oVlACj1vWofLZwGPdSoBVyeUirP4XCMvkoKCnUtl7Hz5HkUZadDhDPPB4PlmSmIjbTynDAKCroGmNagkaE1b9i9mjmuBJk2lue1p/WGdn+x12NQGHinqg5KAUU5nDoqWMRG2rBiXiq27juLzp5eo8uhMKf7STVenYRlXvct97pdBmC813ILgD3aP4ZXGCmpdCF3qh3TJowzuhTyUpSTjrcqXfjkyDmsmD/J6HIojLGti4LSobNtOFzfznO/glD+jAlwxEfxnDAyHAOMglJJpQs2i2DVAh4+DDY2qwV3Z6Xhz4cb0dLRbXQ5FMYYYBR0ej0Kb++tw9dmO5A0LtLocug6Vueko7vXg/e/4Az1ZBwGGAWdz6rPo76tk+d+BbF5aQmYOTGOJzWToRhgFHS2VLoQF2VD4dwUo0shH0QEq3PS8XlNM2qbO4wuh8IUA4yCSmdPLz7YX4+V81MRHWE1uhwaxN3albHf4Qz1ZBAGGAWVskMNuNjlZvehCUxJisViZxLe2nMGSnFqKdIfA4yCSkmlC6kJ0bgpY7jTZJKRinLScaLxEg7UtRldCoUhBhgFjeZL3fjkSCPuye6b9ZyC36obJyHSauE5YWQIBhgFjff21cHtUVidy8OHZpEYG4Fb5jjwTlUd3L0eo8uhMMMAo6CxpdKFOanxmJOaYHQpNAKrc9LR2N6F8hPnjS6FwgwDjILCqfOXsOd0C5s3TOhrsyciIdrGc8JIdwwwCgollXUQAe7O5tRRZhMdYcWqBZPw4YF6dHS7jS6HwggDjAynlELJXheWZkzApMQYo8shPxRlp6OjuxelBxuMLoXCCAOMDFd1phUnmy5x6igTW+RMQro9ht2IpCsGGBmupNKFKJsFK+anGl0K+cliEdyTnYZPjzWhsb3L6HIoTDDAyFA9vR68W1WHwswUJERHGF0OjcLqnHT0ehS27uPUUqQP3QNMRIpFpFBE1g0yXjqSbci8th1rwvlL3VidzcOHZjcrJR7z0hLYjUi60TXARKQYAJRSZdpy4cB1lFKbR7oNmdeWShfGx0bgKzc4jC6FAmB1TjqqzrTiRONFo0uhMKD3HtgiANXa7WoAuWO0DZnAxS43/niwHncuSEOkjUezQ8FdWWmwCPA298JIB3r/1rAPWB7OjK1DbiMi60SkQkQqGhsb/SyN9PbR/np09njYfRhCUhKisWxmMrbsdXGGehpzegdYC4CkQG+jlNqglMpTSuU5HDwUZRYle12YmhSL3Kl2o0uhACrKTkdt82XsOX3B6FIoxOkdYLtwdY8qA0Cp71VHtQ0FuYa2Tmw/3oSinHSIcOb5UHL7/FRER3CGehp7ugaY1qCRoTVi2L0aM66EkjaW59W8cd1tyNzeraqDRwFFnDoq5MRF2XBbZiq27juLbjdnqKexY9P7CZVS67WbZV73Lfe6XQZg/FDbkLltqXQha4odGY44o0uhMbA6Jx3vVNXhL0cbsTwzxehyKESx9Yt0d7ShHQfq2rCae18hq2BWMiaMi+Q5YTSmGGCku5JKF6wWwZ1ZDLBQFWG14K6sNJQeakBbZ4/R5VCIYoCRrjwehbf31uErs5KRHBdldDk0hopy0tHt9uDDL+qNLoVCFAOMdLWrphmulss89ysMZE1OxPTkcexGpDHDACNdlex1YVykFbdlcub5UCciKMpOx86T51HXctnocigEMcBIN509vdi67yxun5+KmEir0eWQDopy0qAU8E4VZ6inwGOAkW4+OXIO7Z1urObhw7AxbcI45E61sxuRxgQDjHTz1h4XHPFRyJ+RbHQppKPVOek4XN+Og3VtRpdCIYYBRrpo6ejGn4+cwz1ZabBaOHVUOFm1IA02i6BkL/fCKLAYYKSL9744i55exe7DMJQ0LhJfm+3A23td6PVwhnoKHAYY6aKk0oVZE+MwLy3B6FLIAEU56Who68LO6vNGl0IhhAFGY662uQO7ai5w5vkwVjg3BXFRNp4TRgHFAKMx97b23cc9nPswbEVHWLFyfio+3F+Py929RpdDIYIBRmNKKYUtlS4snp6EyeNjjS6HDLQ6Jx0Xu9woO9RgdCkUIhhgNKb2u9pwovESz/0i3JQxAakJ0TwnjAKGAUZjakulC5FWC+6YP8noUshgVovgnuw0/OVoI85f7DK6HAoBDDAaM+5eD96pqsOtcyYiMTbC6HIoCBTlpMPtUXjvi7NGl0IhQPcAE5FiESkUkXXDHReRCyJSKiJP61cpjdZHBxrQdLGL537RFXMnJWBOajxe31WLzh42c9Do6BpgIlIMAEqpMm25cJjj9yulliul1utYLvmp16Pwn38+ju/9vhIZjnG4ZY7D6JIoiHyrYDoO1LWh6D+34/i5i0aXQyam9x7YIgDV2u1qALnDHLeLSMbYl0ejda6tE4/8v8/w04+O4I4bJ+Htv12GKBtnnqer7s+bgo1rFuFcexfu+uU2vFFRC6U4QweNnN4BZh+wPGGY40kAmkXkhes9qIisE5EKEalobGwcdZHknz8fOYeVP/8Ue05fwPr7FuAXD2YjPprffdGX3TJnIj74/s3InmLH05v34e9e34v2zh6jyyKT0TvAWtAXRiMaV0ptUEq1AGjpP8x4nfE8pVSew8HDVXrrdnvwr+8fwtqNu+CIj8LW7xbggUVTOOsGDSolIRqvPH4T/n75DXi3qg53/nIb9p1pMbosMhG9A2wXru5lZQAoHWpc27saeKiRgsTp8x24/9fl2PDXajyyZBpK/nYZZk6MN7osMgmrRfDdv5mF159Yih63B/f9qhwvfloNDyf9pWHQNcCUUpsBZGjNGXavZo3SQcbf0NYp9lqHgsA7VXW44xef4mTTJfz6m7n4l6L5iI7g9100coucSXj/+zfjltkT8ex7h/Ctl3bxXDEakoTal6d5eXmqoqLC6DJCWke3G//0zkG8XlGLhdPG4+cPZnOaKAoIpRR+t/MUnn3vEOwxEfjZg9m8AKpORGS3UirP6DpGgicy04gcrm/D3f+xHW/srsV/v2UmXl+3hOFFASMieHSpEyXfWYa4aBu+8eJn+N9/PAJ3r8fo0igIMcBoWPr/Mr77P7aj9XIPXv3WTXjq9tmwWfkWosDLTEvA1u8W4P6Fk/GLj4/jod/shKvlstFlUZDhbx8aUmtHD558ZQ9+XLIf+TMm4IPv34z8mTysQ2MrNtKG9cVZ+PmD2Th0th13/PxTfHSg3uiyKIgwwGhQFTXNuOMXn6LsUAN+dMdc/PaxRUiOizK6LAoj92SnY+t3CzA1KRZP/G43/ufb+zkNFQFggJEP/dNBfX3DTlgtgj88mY9vfyUDFgvP7SL9OZPH9b0Hb56Ol3ec4jRUBIABRtcxcDqo975XgKwpdqPLojAXabPgR6syOQ0VXcEAo2twOigKdpyGivoxwAgAp4Mic+E0VAQwwAicDorMidNQEQMszHE6KDI7TkMVvhhgYaqj240fbN6H771Widmp8Xj/+zdjxfxJRpdF5Bd7bCReeGQh/vmeedh+4jxW/vxTlJ9oMrosGmMMsDDE6aAoFHEaqvDDAAsjA6eDeoXTQVEI6p+GqjiX01CFOv7mChPe00EtzeibDmoZp4OiEBUbacNP78/Cz76ejYN1bZyGKkQxwMLA7lNXp4P6H3fMwcY1nA6KwkNRTjre+97NV6ah+l+chiqkMMBCWP90UA+80Dcd1OYn87HuKzM4HRSFlf5pqB4vmI6XdpzC6v9bzmmoQgQDLAQppXC29TIe/W3fdFAr56di6/cKkM3poChMRdoseObOTPx2TR4a2jqvTEPVy3PGTE33KzKLSDGAFgAZSqkNwxkfahtvoXJF5m63B22dPWi73IO2TjdaL/ff7kHbZW1ZG2/V1mnX7mu93IOeXoXoCAv+6e55eCCPM2oQ9Wto68Tf/X4vdlSfBwDERdmQGBOB+GgbEmIikBgTgYToCCTE2JAQrS3HRCAh2nb1trYcF2ULmc+WGa/IbNPzybQgglKqTETWiUihUqpssHEA9sG2CVa9HoWLndcGTX+4tF12e93uC5+rQdQ3fnmI4/QRVrnyQYvXPkxTxsdoH6y+D91t81IwwxGn038xkTn0T0P19l4XTp3vuPKZ6/9M1jZ3oF37TLZ3uQd9LIvgymcuIcZ2NfyiI5AY2/e59P5MDgzFKJslZALQCLoGGIBFAF7XblcDyAVQNsT4hCG2ucaR+nbcvP5jAED/zuXAncz+vU6Fa8eVds/V5YHb+xq/9vHcvQoXh/HGjx/wpp7hiLv2TR7r6y/BCERH8I1P5C+rRXBv7uQh13P3enCxy/2lox4D/xj1PhJyru3ilfHOnsHPQYu0WhATaUX/R7n/E93/2b663L+FXLM8cFx8jl/7u+LK+IDtzEbvALMPWJ4wjPGhtoGIrAOwDgAS0jKQNy0JA/5/D/I/1sf4KN4wFotowdN/OMLrrzDtr7JxkTY2UxAFOZvVAntsJOyxkX5t3+XuRfs1XwFc52hLd98fu6P+g3qY2/WPe/9QSuFTv/4LjaV3gLUASBrh+FDbQPtebAPQ9x3Y//l6tr/1EREFTJTNiqg4qylOW/n5Q0ZXMHJ6B9guXN2jygBQOoxx+xDbEBFRGNK1jV4ptRlARn9zRn8zhoiU+hr3tQ0REYU33dvox1qotNETEenJjG30PJGZiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUQq4LUUQaAZwyuIxkAE0G1xAs+FpcxdfiKr4WVwXLazFNKeUwuoiRCLkACwYiUmG2dtSxwtfiKr4WV/G1uIqvhf94CJGIiEyJAUZERKbEABsbg150M8zwtbiKr8VVfC2u4mvhJ34HRkREpsQ9MCIiMiUGmE5E5DmjazCSiNhFJFdEisPxtdD+uwu1i6+GrXB/H/jC18I/DDAdaJeCyTC6DoM9ACBPuzwOwukXuYgUA4DX5YMKja3IUGH7PvCFvx/8p/cFLcOOiGQAqDa6DqNpV83uF24XJl0E4HXtdjWAXABheV27MH8ffAl/P4wO98DGXoZSim9QjfaBbQ6zC5PaByxPMKKIYBKm74Pr4e+HUeAe2Chph4eSBtxdrZQqE5HCcPqADvZaeC0XK6We0LGsYNCCL78u4S4c3wfXCLffD2OBATZK/cfyfWjWjm/bAWSISK5Sao8+lelviNcCIlKslFqv3Q7p12KAXbi6F8bDZuH7PhgorH4/jAUeQhxDSqk92l9YSfjyYaSwon1QnxOR3SKyG2G0R6IFe0b/L6tw/qs7nN8HA/H3w+jxRGYiIjIl7oEREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKbEACMiIlNigBERkSkxwIh0ICIZInJCREq15VxtRnYi8hMDjEgfPwCwHMAe7eq7ebyMBtHocC5EIh2IiF0p1SIidvSFV9hO6EsUKAwwIp2ISC7QNwu50bUQhQIeQiTSgXaxz+r+8NKWiWgUGGBEY0xE1qHvQpa/ERG79h1Yi7FVEZkfA4xoDGmdhtXaFYirAZwEcILfgRGNHr8DIyIiU+IeGBERmRIDjIiITIkBRkREpsQAIyIiU2KAERGRKTHAiIjIlBhgRERkSgwwIiIyJQYYERGZ0v8HNOvDJrMYg2YAAAAASUVORK5CYII=
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAthUlEQVR4nO3deXhU93kv8O87M1rRhqRBQsMylsAYgdHqBYHTOJUd41U42DhOHKMnLrm+bZI+T12Se+u2z22dtiY89zZpe9uQ3IBjuwkxDfIW20F2FgsZ20JCmMXGSAjECAltIwmEltH87h86A4OsXTPnzJn5fp7Hj8468yLPzFfnzHt+R5RSICIiMhuL0QUQERHNBgOMiIhMiQFGRESmxAAjIiJTshldABGR2R06dGiBzWb7CYDV4IFBoHkBHPV4PE8UFRVd8F/BACMimiObzfaTzMzMlXa7vdtisbC1O4C8Xq+0t7fntra2/gTA/f7r+JcCEdHcrbbb7b0Mr8CzWCzKbrf3YPTo9tp1BtRDRBRuLEaG1/Hjx6M3bNiQbcRzV1RUJJaUlCwPxGM9+eSTjqeffjpj7HLtd/uZvGKAERGZXG5u7tDzzz9/ZrJtdu3aNT8Yz11WVtaXnJw8Eojn/spXvtI9k+dmgBERmdzx48ejP/7445iJ1nd0dFj379+fpGdNs3nu1NRUz0wem00cREQB9Jd76xefbO2LD+RjXp+Z2P/9TXnNk22zbds2R3V19acVFRWJ27dvz9y2bVtrTU1N/F133dXX0dFhra+vj9+1a9f88vLybgB4+umnM4qLi/tPnToVk5aWNvLLX/5y/sMPP9zd0NAQnZOTM7Rjx47M733ve+dOnToVs2zZssGysrI+ANixY0f6rbfe2n/w4MH4p556qmNsHb6jrc7OTutTTz3VUVVVFT/Zcz/11FMdvvmampoZ/d54BEZEZHK5ublDvtN4ZWVlfT09PbaysrK+Rx99tPvFF1+cX1ZW1rdkyZJBX4A8+eSTjuLi4v6ysrK+hoaGmPLy8u6jR4/Gl5eXdz/zzDNt5eXl3UuWLBksKyvre+qppzq++c1vLgVGg2fZsmWD69ev71+2bNngjh070v3rqKqqim9oaIguLy/v3rVrl91Xz2TPvWPHjnTf/F133dU3k383j8CIiAJoqiMlPSQnJ096Kq6pqSmmu7vbVlVVFZ+TkzMIAKtXr+6faPvFixcPHj9+PPrQoUPzHn300W4AuP766wd/9KMf2f2PwtavX9/f0dFhraioSJyohrHPXVtbO+/uu+/unc2/k0dgRERhZrKmiqqqqviioqJLy5cvH1y/fn3/li1bxm2c6OnpsfpN23Jzc4eKioounTx5MgYATp48GVNUVHTJf58dO3aknzp1KsZ3urGjo8Pqv3685y4sLLzymDPFIzAiIpOrqqqKP3r0aPzx48ejT548GXP06NH4qqqq+DfffDOxvr4+vqOjw+p0Ogd37do1/7777utdv359/9NPP53hHzC+fdavX98PjIZWVVVV/MGDB+O/973vnQOAZ555ps3X5l5TUxP/zDPPtPmeu6qqKn7ZsmWDNTU18VVVVfF5eXn9r776alJ5eXn3ZM/t+w7M95jvvPNOUkdHR0d6evqknY0AILwfGBHR3NTX1zfl5eV9pqHBzDZs2JD9xhtvNBpdh099fX16Xl6e038ZTyESEdE1KioqEn1HdEbXMhkGGBERXaOsrKyvubn5aG5u7pDRtUyGAUZERKbEACMimjuv1+sVo4sIV9rv1jt2OQOMiGjujra3tyczxAJPu51KMoCjY9exjZ6IaI48Hs8Tra2tP2ltbeUNLQPvyg0tx65gGz0REZkS/1IgIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKbEACMiIlNigBERkSkxwIiIyJQYYEREZEphNxp9enq6cjqdRpdBRGQqhw4d6lBK2Y2uYybCLsCcTidqamqMLoOIyFRE5IzRNcwUTyESEZEpMcCIiMiUGGBERGRKugeYiGwSkVIR2TbFdttmug8REUUOXQNMRAoBQClVCcDtmx9nu1IAN81kHyIiiix6H4FtBuDWphsBlAZpHyIiCnN6B1gKgC6/+bSxG4hIoXa0Ne19iIgo8oRiE0eq0QUQBdrZzn7sPXTO6DKIworeFzK7cTWgUgB0+q8c5+hryn20/bYC2AoAS5YsCVStRAHz968fx/7jbbghMxGrHclGl0MUFvQ+AtsDIFubzgZQCQAikuJbpnUcbtKmCyfax59SaqdSqlgpVWy3m2okFIoAzV39qDzRBgB4rrrJ2GKIwoiuAaaUqgWudBm6ffMA3tbW71VK7cXoEVfKFPsQmcJz1U2wiuCO3Ay8XN+CzouDRpdEFBZ0HwtRKbVznGVF42yzc7J9iMzg0qAHe2qaseHGhfjWF5Zh//E2/PyDs/izLyw3ujQi0wvFJg6isPGrOhf6BjzYUuLE8oxE3LY8Hc8fPIPhEa/RpRGZHgOMKEiUUth94DTWLEpG4ZIUAMCWEifaegfx5tFWY4sjCgMMMKIgqTrVgYb2S9hS4oSIAABuX7EAS9PisZvNHERzxgAjCpJdB5qQnhCDe9YsvLLMYhE8vtaJQ2e6ceSc27jiiMIAA4woCE53XMI7H1/AV25Zghib9Zp1m4oXYV60FbsPNBlTHFGYYIARBcHP3mtClFXwlVs+e2F9UmwUNhUtwqtHWnChb8CA6ojCAwOMKMAuDnrwUs053HPjQixIih13m6+VODE8ovDz95t1ro4ofDDAiALsvw6dw8VBD7asu27CbXLsCfij6+144f0zGPKwpZ5oNhhgRAHk9Srsrm5CwZIU5C9OmXTb8nVOtPcN4tcfndenOKIwwwAjCqDff9qO0x2jrfNT+dxyO7LT52EXW+qJZoUBRhRAuw80YUFiDDasXjjlthaL4PESJ+qb3ag7261DdUThhQFGFCAN7Rfx+5Pt+OqtSxFtm95b60tFi5AQY+OFzUSzwAAjCpCfVTch2mrBl2+e/j3pEmJseKh4EV4/ch5tvWypJ5oJBhhRAPQODGPvoXO4Ly8L9sSYGe37+FonRpTCiwfPBKk6ovDEACMKgJdqzuHS0Mi0mjfGcqbPwxdWLMCL75/FoGck8MURhSkGGNEcjXgVnqtuQvHS+bhxUfKsHmPLOic6Lw3htXq21BNNl+4BJiKbRKRURLZNsL5U++9Zv2XPaj+36lUn0XT97pMLONvVjy3rnLN+jPXL0rFsQQJ2VzdBKRW44ojCmK4BJiKFAKCUqgTg9s2PWX+Htr7Qb/1WEWkA0KhnvUTTsbu6CZlJsfjiqsxZP4aIYEuJEx+5elDLlnqiadH7CGwzALc23Qig1H+lUqpWKfUdbTZbKVWrTT+klMrRgo0oZHza1od3P+3AY2uXIso6t7fTg4UOJMba8FOOUk80LXoHWAqALr/5tPE20k4vfsNvUeFkpx2JjLK7ugnRtpm1zk8kPtqGR25ajDePtuJ8z+UAVEcU3kKyiUMptR3AN0QkxTevHX2liUjp2O1FZKuI1IhITXt7u87VUqTq6R/Gr2pdKMvPQuq86IA85tfWOuFVCi+wpZ5oSnoHmBtAqjadAqDTf6WI+H/v1YjR7742icgmbVkngOyxD6qU2qmUKlZKFdvt9qAUTjTWL2uacXl4BI/PonV+IotT41G6MgP/+f5ZDAyzpZ5oMnoH2B5cDaBsAJUA4DvSwuh3Yv4B16j95/vuKwdAjQ51Ek1qxKvw3HtNuPm6VKzKml3r/ETK1znR3T+MV+pbAvq4ROFG1wDzNWVopwHdfk0ab2s/dwLI9h1xKaX2ats8rC1r8NuHyDBvn2jDue7LKA/g0ZfP2uw0rMhIxO4DbKknmoxN7ydUSu0cZ1mR9tON0RADgL2T7UNkpF0HmuBIicMduRkBf2wRwZZ1TvyPX32ED0534ZbscXudiCJeSDZxEIWyj1t78V5jJx5buxS2ObbOT6Qs34HkuCiOUk80CQYY0Qw9V92E2CgLHrlpcdCeIy7aikduXoy3jrXC5WZLPdF4GGBEM9B9aQj76lzYWOBASnxgWucn8rW1TgDA8++xpZ5oPAwwohnYU9OMgWFvQFvnJ+JIicMXV2XiFx+exeUhttQTjcUAI5omz4gXP6tuQklOGm7ITNLlObeUOOHuH0bFYZcuz0dkJgwwomnaf7wNLT0Ds7rn12zdfF0qVi5MYks90TgYYETTtKu6CYvmx+GPVwa+dX4iIoLyEic+aevDe42dU+9AFEEYYETTcKylBx+c7sLja52wWkTX575fG2txN0epJ7oGA4xoGp6rbkJclBUPFwevdX4isVFWfPnmxag80Ybmrn7dn58oVDHAiKbQeXEQFYdb8KUiB5Ljowyp4au3LoWI4GfvNRny/EShiAFGNIVffNiMIY8Xj2vXZRlhYXIc7lqdiV982IxLgx7D6iAKJQwwokkMj3jx/HtncNvydCzPSDS0lvISJ/oGPNhXx5Z6IoABRjSpt461orVX39b5iRQtnY8bHcnYXc2WeiKAAUY0qd0HmrA0LR63r1hgdCmjo9SXOHHqwkUcOMWWeiIGGNEEPjrXg5oz3Xh8rRMWnVvnJ3Jv3kKkJ0Rj14HTRpdCZDgGGNEEdlWfxrxoKzYVLzK6lCtibFY8evMSvPPJBTR1XDK6HCJD6R5gIrJJREpFZNsE60u1/56d7j5EgdbeN4jX6s9jU9EiJMUa0zo/ka/euhRWEfyMo9RThNM1wESkEACUUpUA3L75Mevv0NYXikjhVPsQBcPPPziLoREvvhYCzRtjLUiKxT1rFuKlmmZcZEs9RTC9j8A2A3Br040ASv1XKqVqlVLf0WazlVK1U+1DFGhDHi9eOHgGf3S9HTn2BKPLGdeWEif6Bj34Ve05o0shMozeAZYCoMtvPm28jbRThd+YyT5EgfLG0fO40DeI8nVOo0uZUMGS+chbnILdB5rg9bKlniJTSDZxKKW2A/iGiKRMZ3sR2SoiNSJS097eHtziKOztOtCE7PR5+Nxyu9GlTKq8xInGjkv4w6d8zVNk0jvA3ABStekUANdczOL/nRdGTxdunWofAFBK7VRKFSuliu320P7QodBWd7Ybh5vdeLwkdFrnJ3L3jQthT4zB7uomo0shMoTeAbYHQLY2nQ2gEgD8jrRKcW1YNU60D1EwPFfdhIQYG75UFDqt8xOJtlnw1VuW4neftKOx/aLR5RDpTtcA05oyICKlANy+eQBvaz93AsgWkU3a9nsn2YcooC70DuD1j87joeJFSIixGV3OtDx6yxJEWdlST5FJ93epUmrnOMuKtJ9ujIYYAOydbB+iQHvx/bPweJWho87PlD0xBvetycJLNc34izuvR2KIXbNGFEwh2cRBpLdBzwhefP8MvrBiAZzp84wuZ0a2rHPi0tAIXqphSz1FFgYYEYDXj5xHx8UhbAnh1vmJrFmUgqKl8/Hce2ypp8jCAKOIp5TCrgNNWLYgAeuXpRtdzqxsKXHiTGc/fnfygtGlEOmGAUYRr/asGx+5evB4iRMiod06P5G7VmciIykGuw40GV0KkW4YYBTxdlc3ITHWhgcLHEaXMmtRVgseu3Up3v20A6cu9BldDpEuGGAU0Vp7BvDGR+fxyE2LMc8krfMT+fLNSxBts/DCZooYDDCKaC8cPIMRpfA1E7XOTyQtIQYP5GXhvw650HN52OhyiIKOAUYRa2B4BP/5wVmUrszA4tR4o8sJiMdLnLg8PIKXapqNLoUo6BhgFLFerW9B16UhlIfgPb9ma7UjGTc7U/Hce00YYUs9hTkGGEUkpRR2VzdhRUYi1uaE1x16tqxzornrMt75mC31FN4YYBSRPmzqxrGWXmxZZ97W+YncmZuBrORY7Dpw2uhSiIKKAUYRaXf1aSTHRaEs37yt8xOxWS14bK0T1Q2d+KSVLfUUvhhgFHFc7st461gbHrl5MeKirUaXExSP3LQYMWyppzDHAKOI88LBM1BK4bFblxpdStDMnxeNjQUO7Ks7B3f/kNHlEAUFA4wiysDwCH7+wVncmZuJRfPDo3V+Io+XODEw7MWeD9lST+GJAUYRpaLOBXf/MMpNOOr8TK1cmIRbs1Pxs/fOwDPiNbocooDTPcBEZJOIlIrItgnWb9X+e9Zv2bO+dXrVSeHH1zq/cmESbr4u1ehydFG+7jq43JdReaLN6FKIAk7XABORQgBQSlUCcPvm/daXAqjU7sCcrc0DwFYRaQDQqGe9FF4ONnbh49Y+lJt41PmZKl2ZAUdKHEepp7Ck9xHYZgBubboRQOmY9dl+yxq1eQB4SCmVowUf0azsrj6N+fFRuD8/y+hSdGO1CB4vWYr3T3fheEuv0eUQBZTeAZYCoMtv/pohEJRSO7WjLwAoBFDjm57stCPRVJq7+rH/eBu+fPMSxEaFZ+v8RDYXL0FclBXPsaWewkxINnFopxb3K6VqAUAptV07+krzO63ov/1WEakRkZr29na9yyUTeOHgGYgIHlsbvq3zE0mOj8KDhQ5UHHah6xJb6il86B1gbgC+b89TAHROsF2pUmo7cKXpY5O2vBNXTyteoR25FSuliu12e2ArJtPrH/Lg5x+cxV2rM7EwOc7ocgyxpcSJQY8XP//grNGlEAWM3gG2B1cDKBtAJQCISIpvAxHZ6hdepRj9Lsz33VcOrp5WJJqWfXUu9A54wmrU+ZlanpGI9cvS8cLBMxhmSz2FCV0DzHdKUAsmt28ewNt+y58VkQYR6fbb52HtKKzBbx+iKSml8Fx1E1Y7klC0dL7R5RhqS4kT53sG8JtjbKmn8KD7PdT9mjT8lxVpPysBfOZTZrx9iKbjyLkenGy7iH968MaIaZ2fyO03LEBWciz2HmrGPWsWGl0O0ZyFZBMHUaDsq3Mh2mbBhhv5gW21CB4ocOAPn3ag4+Kg0eUQzRkDjMLW8IgXr9a3oHTlAiTHRRldTkjYWODAiFfhtfoWo0shmjMGGIWtqlMd6Lw0FJb3/Jqt6zMSkbswCfsOM8DI/BhgFLYq6lxIiY/C51csMLqUkLKxwIH6Zjca2y8aXQrRnDDAKCxdHPTgrWOtuOfGhYi28WXu7/78LIgAFTwKI5PjO5vC0m+OtWJg2IuNBTx9OFZGUizW5aSjos4FpZTR5RDN2owDTEScIvKgiDwhIk9p018IRnFEs7WvzoVF8+Mi/tqviZQVOHC2qx+1Z91Gl0I0a9MOMBH5SxH5DYBnMToihgDo0abvFJHfiMi/i0h+UColmqYLvQM4cKoDGwscEX/t10S+uCoDsVEWVNS5jC6FaNamvJBZRK4D8A0Av1BKfX+KbZMxeu+uYqXUTwJUI9GMvFLfAq8aPcqg8SXGRuGO3Ey8dqQFf31vLr8nJFOa9FWrhdcfK6W+q5Q6PNWDKaV6tJB7W0SeCFCNRDNScdiFvEXJyLEnGF1KSNtYkIXu/mH84STv4EDmNGmAKaVOz+ZIarb7Ec3Vp219OOrq5dHXNNy23I7UedHYd5inEcmcZtPEkRSMQogCoeKwC1aL4N41kXPX5dmKslpw35qFqDzeht6BYaPLIZqx2Zz4zvFv1BCR69iFSKHA61WoqGvBbcvTYU+MMbocUygrcGDQ48WbR1uNLoVoxmYcYEqpOgA3iYhTmz8NYL6I/GOAayOakZoz3XC5L/ParxnIX5wCZ1o8uxHJlGZzCnEPgAYA3X6nEysBbA1kYUQzta/OhfhoK+7IzTC6FNMQEZQVOPBeYyfO91w2uhyiGZnNKcQiADVKqR4AorXOlwL4p4BWRjQDg54RvH6kBXetykR8tO63uTO1snwHlAJe4dBSZDKzCbCHoB1taSGWCmD+VNeI+YjIJhEpFZFtE6zfqv337HT3Ifrtx+3oHfCw+3AWnOnzULAkBft4GpFMZlbfgSmldvjNnwZwaDojcIhIobZPJQC3b95vfSmASu0OzNlaaE26DxEwOvK8PTEGJTlpRpdiSg8WOPBxax9OnO81uhSiaQvI5fdaY8fpaWy6GYBbm27E6KlHf9l+yxq1+an2oQjX0z+Mdz6+gPvzsmCzckSJ2bhnTRZsFkEFrwkjEwnYu107nTiVFABdfvPX/LmslNqpHX0BQCGAmqn2Ifr10fMYGuHI83OROi8an19hx8t1LfB6OUI9mcOUQ0nNZkio2e7nt38hgP1Kqdppbr9VRGpEpKa9ncPiRJp9dS4sW5CAVVm8xn4uygocaO0dwMHTnUaXQjQtUw4lhdFxDf9jOhcri0iSiPwlRsdPHG8oKTdGmz6A0SOrid4ppUqp7dPdRztyK1ZKFdvt9qnKpDByrrsfH5zu4sjzAVC6MgMJMTZeE0amMWW/sRZi/01E/kREvgtAAajF1SBJw2iw5GD0+rDt2j7j2QOgWJvOxuj1YxCRFKWUW5ve6gsvralj3H2IAOBlrfX7/jwOHTVXsVFWbFidiTc+asXfPbAasVFWo0simtS0vwNTSv1YKXUngIcxGiKnMXo/sBoAO5VSdyqlnpwkvOA7JagFk9vvFOHbfsufFZEGEemeYh+KcEop7Ktz4WZnKhanxhtdTljYWOBA36AHb5+4YHQpRFOa8RWfWrPG27N9Qr8mDf9lRdrPSgCfuYXuePsQHWvpxakLF/EPG280upSwcUt2GjKTYrGvzoV71iw0uhyiSc2qC1FEntDuvvwER6cno+yrcyHaasE9N/KDNlCsFsED+Vn43ScX0HVpyOhyiCY1m7EQ/wnAMoyePnwYwGkR+XqgCyOajGfEi1fqW3D7DXYkx0cZXU5YKStwwONVeP0Ih5ai0DabI7APtTs0f1f7TiwHwHIReTDAtRFNqLqhE+19g7z2KwhWLkzCDZmJHFqKQt6cL2RWSrmVUt8FLzAmHVXUuZAUa8PnVywwupSwVFbgQO1ZN850XjK6FKIJzSbAGkXkQxG5fcz3X7z6kXTRP+TBm8dacc+ahWz1DpL787IgAlTU8TQiha7ZBNhmAL8E8CSAJi3M3sLo4LuJAMDTiRRM+4+3oX9oBGX5PH0YLFkpcbj1ujRUHHZBKQ4tRaFpNgHWAOAlpdTDSqlUjN5apRLAnQDOiMinAJ6d7AGI5mJfnQuOlDjc5EydemOatY0FDpzuuIT6c9MZ5pRIf7O5ncqPAcwXEac2X6eU+r52IXMqRo/QpjMyPdGMtfcN4t1PO/BAfhYsFg4dFUx33ZiJaJuFQ0tRyJpVE4cWWk0TrKsF8J25FEU0kdeOtGDEq9h9qIOk2CjcsTIDr9a3YHjEa3Q5RJ8RlJsnafcHIwq4ijoXVmUlYXlGotGlRISyAgc6Lw2h6tMOo0sh+gze/Y9Mo6H9IurP9fDoS0d/dL0dKfFRvCaMQhIDjEzj5ToXLALcx5HndRNts+DeNQvxm+OtuDjoMbocomswwMgUlFLYd9iFdcvSkZEUa3Q5EWVjgQMDw168dbTV6FKIrsEAI1OoPduN5q7LvPbLAIVL5mNxahwqDvM0IoUW3QNMRDaJSKmIbJtkm8Ix889qP7cGuz4KTfvqXIiNsuCLqzONLiXiiAg25jtw4FQH2noHjC6H6ApdA8wXTNp9v9xjg0rbphTAj8cs3ioiDQAag18lhZohjxevHTmPO3MzkRAz41vYUQA8UOCAVwGv1nNoKQodeh+BbQbg1qYbAZSO3UALt64xix9SSuVo6yjC/P5kO9z9w+w+NFCOPQF5i5LZjUghRe8AS8G14TTdEewLpzrtSOGros6FtHnRWL883ehSIlpZgQPHWnpxsq3P6FKIAJikiUMptV07+krTTjFShOgdGMb+E224Ly8LUVZTvFzD1r1rsmC1CIeWopCh9yeCG4BvBNYUTOMWLFrTxyZtthNAdlAqo5D05ketGPJ4UcbTh4azJ8bgtuXpePlwC7xejlBPxtM7wPbgagBlY3QUe4hIyiT7NPq2w+jdn2vGbiAiW0WkRkRq2tvbA1ctGW5fnQvXpc9D3qJko0shjF4T5nJfxodNY7+mJtKfrgGmDfTr6zR0++YBvO3bRjvaKvYddWnbPKzNN/jt4/+4O5VSxUqpYrvdHvR/B+mjxX0ZB093oizfARGOPB8K7sjNQHy0ldeEUUjQvSdZKbVznGVFftN7Aeydah8Kf6/Ut0ApoKyAQ0eFivhoG+5alYnXjpzH3963infEJkPxW3EKWRV1LhQuScHStHlGl0J+ygoc6Bvw4HefXDC6FIpwDDAKSSfO9+Lj1j5e+xWCSnLSYE+M4TVhZDgGGIWkijoXbBbBPWt4+jDU2KwW3J+Xhd9+3A53/5DR5VAEY4BRyBnxKrx8uAWfX2FH6rxoo8uhcWwscGBoxItff8QR6sk4DDAKOe83dqK1d4DXfoWwVVlJWLYggRc1k6EYYBRy9tW5kBBjQ+nKDKNLoQmICDYWOPBBUxeau/qNLociFAOMQsrA8AjeONqKDasz2aId4u7X7oz9CkeoJ4MwwCikVJ5ow8VBD7sPTWBxajxudqbiV7XnoBSHliL9McAopFTUuZCZFItbsqd7owIyUlmBAw3tl3CspdfoUigCMcAoZHRdGsLvPmnHA/mjo55T6LvnxoWItlp4TRgZggFGIeP1Iy3weBU2FvL0oVkkx0fh9hvseKW+BZ4Rr9HlUIRhgFHI2Ffnwg2ZibghM8noUmgGNhY40N43iOqGKe+ORBRQDDAKCWc6L6H2rJvNGyb0+RULkBRr4zVhpDsGGIWEiroWiAD353PoKLOJjbLinjUL8eaxVvQPeYwuhyIIA4wMp5RCxWEX1manYWFynNHl0CyU5TvQPzSC/cfbjC6FIggDjAxXf64HpzsucegoE7vJmQpHShy7EUlXugeYiGwSkVIR2TbJNoUz3YfMq6LOhRibBXetzjS6FJoli0XwQH4W3v20A+19g0aXQxFC1wDzBZNSqhKAe2xQaduUAvjxTPYh8xoe8eLV+haU5mYgKTbK6HJoDjYWODDiVXjtCIeWIn3ofQS2GYBbm24EUDp2Ay2oumayD5lX1acd6Lw0hI35PH1odsszErEqK4ndiKQbvQMsBdeG03TGC5rNPmQS++pcmB8fhc9dbze6FAqAjQUO1J/rQUP7RaNLoQjAJg4yzMVBD35zvBX3rslCtI0vxXBwX14WLAK8zKMw0oHenxpuAKnadAqA6Vy6P+U+IrJVRGpEpKa9vX3ORZI+3jraioFhL7sPw0hGUizWLUvHvsMujlBPQad3gO0BkK1NZwOoBAARSZnpPv6UUjuVUsVKqWK7naeizKLisAtLUuNRuCTF6FIogMryHWjuuozas91Gl0JhTtcAU0rVAlc6Dd2+eQBv+7YRkU0AirWfk+1DJtbWO4ADpzpQVuCACEeeDydfXJ2J2CiOUE/BZ9P7CZVSO8dZVuQ3vRfA3qn2IXN7tb4FXgWUceiosJMQY8OduZl47ch5/M29q/j9JgUNX1lkiH11LuQtTkG2PcHoUigINhY44O4fxu9P8jtpCh4GGOnuZFsfjrX0YiOPvsLW+uXpSJsXzWvCKKgYYKS7ijoXrBbBvXkMsHAVZbXgvrws7D/Rht6BYaPLoTDFACNdeb0KLx9uweeWpyM9IcbociiIygocGPJ48eZHrUaXQmGKAUa6+rCpCy73ZV77FQHyFiXjuvR57EakoGGAka4qDrswL9qKO3M58ny4ExGU5Ttw8HQnWtyXjS6HwhADjHQzMDyC146cxxdXZyIu2mp0OaSDsoIsKAW8Us8R6inwGGCkm999cgF9Ax5s5OnDiLE0bR4Kl6SwG5GCggFGuvlVrQv2xBiU5KQbXQrpaGOBAx+39uF4S6/RpVCYYYCRLtz9Q/jtJxfwQF4WrBYOHRVJ7lmTBZtFUHGYR2EUWAww0sXrH53H8Ihi92EESp0Xjc+vsOPlwy6MeDlCPQUOA4x0UVHnwvIFCViVlWR0KWSAsgIH2noHcbBxOndQIpoeBhgFXXNXPz5s6ubI8xGsdGUGEmJsvCaMAooBRkH3svbdxwMc+zBixUZZsWF1Jt482orLQyNGl0NhggFGQaWUwr46F26+LhWL5scbXQ4ZaGOBAxcHPag80WZ0KRQmGGAUVEddvWhov8Rrvwi3ZKchMymW14RRwDDAKKj21bkQbbXg7tULjS6FDGa1CB7Iz8LvT7aj8+Kg0eVQGNA9wERkk4iUisi26a4XkWe1n1v1qpPmzjPixSv1LfjCDQuQHB9ldDkUAsoKHPB4FV7/6LzRpVAY0DXARKQQAJRSlQDcvvlprN8qIg0AGvWsl+bmrWNt6Lg4yGu/6IqVC5NwQ2Yi9nzYjIFhNnPQ3Oh9BLYZgFubbgRQOs31DymlcrRgoxA34lX4t9+ewrd+UYds+zzcfoPd6JIohHx9/XU41tKLsn87gFMXLhpdDpmY3gGWAqDLbz5tmusLJzvtSKHjQu8AHvt/7+P7b32Cu29ciJf/dB1ibBx5nq56qHgxdm25CRf6BnHfv1ThlzXNUIojdNDMmaKJQym1XTv6ShORsUdtEJGtIlIjIjXt7e0GVEgA8NtPLmDDD95F7dlubP/SGvzwkXwkxvK7L/qs229YgDe+fRvyF6dg294j+PM9h9E3MGx0WWQyegeYG0CqNp0CYOy4Mp9ZrzV1bNKWdQLIHvugSqmdSqlipVSx3c7TVXob8njxD78+gfJdH8KeGIPXvrkeD9+0mKNu0KQykmLxwhO34C/uuB6v1rfg3n+pwpFzbqPLIhPRO8D24GoAZQOoBAARSZlkfaNvOwA5AGr0KJSm52xnPx76j2rs/EMjHrt1KSr+dB2WLUg0uiwyCatF8M0/Xo4931iLYY8XX/r3avzk3UZ4OegvTYOuAaaUqgUA7TSg2zcP4O2J1mvLHtaOwhr89iGDvVLfgrt/+C5Od1zCf3y1EH9fthqxUfy+i2buJmcqfv3t23D7igV45vUT+PpzH/JaMZqShNuXp8XFxaqmhgdpwdQ/5MH/euU49tQ0o2jpfPzgkXwOE0UBoZTC8wfP4JnXTyAlLgr//Eg+b4CqExE5pJQqNrqOmTBFEweFjo9be3H/vx7ALw81489uX4Y9W29leFHAiAi+ttaJiv++DgmxNnzlJ+/jf//mE3hGvEaXRiGIAUbT4vvL+P5/PYCey8N48eu34KkvroDNypcQBV5uVhJe++Z6PFS0CD985xS+/OODcLkvG10WhRh++tCUevqH8eQLtfjriqMoyUnDG9++DSXLeFqHgis+2obtm/Lwg0fyceJ8H+7+wbt461ir0WVRCGGA0aRqmrpw9w/fReWJNvzV3Svx08dvQnpCjNFlUQR5IN+B1765HktS4/GN5w/hb14+ymGoCAADjCbgGw5q886DsFoE//VkCf7kc9mwWHhtF+nPmT5v9DV423X42XtnOAwVAWCA0TjGDgf1+rfWI29xitFlUYSLtlnwV/fkchgquoIBRtfgcFAU6jgMFfkwwAgAh4Mic+EwVAQwwAgcDorMicNQEQMswnE4KDI7DkMVuRhgEap/yIPv7D2Cb/28DisyE/Hrb9+Gu1YvNLosollJiY/Gjx4rwt89sAoHGjqx4Qfvorqhw+iyKMgYYBGIw0FROOIwVJGHARZBxg4H9QKHg6Iw5BuGalMhh6EKd/zkihD+w0GtzR4dDmodh4OiMBUfbcP3H8rDP2/Ox/GWXg5DFaYYYBHg0Jmrw0H9z7tvwK4tHA6KIkNZgQOvf+u2K8NQ/S2HoQorDLAw5hsO6uEfjQ4HtffJEmz9XA6Hg6KI4huG6on11+G5985g4/+t5jBUYUL3ABORTSJSKiLbprt+qn3oWkopnO+5jK/9dHQ4qA2rM/Hat9Yjn8NBUYSKtlnw9L25+OmWYrT1DlwZhmqE14yZmk3PJxORQgBQSlWKSLaIFCqlaidb71s30T7hasjjRe/AMHovD6N3wIOey77pYfRe1ua19T3aNn3asp7LwxgeUYiNsuDZL92Ih4s5ogYRAHzhhgy88e3b8Oe/OIxte49g294jSIixITkuComxNiTFRSE5LgpJsVFIirMhKVabj4tCUqzt6rQ2nxBj43vLQLoGGIDNAPZr040ASgHUTrE+bYp9QtKIV+HiwLVB4wuX3ssev+nR8LkaRKPrL09xnj7KKlfeaInam2nx/DjtjTX6prtzVQZy7Ak6/YuJzME3DNXLh10409l/5T3ne082d/WjT3tP9g16Jn0si+DKey4pznY1/GKjkBw/+r70f0+ODcUYm4UBOAd6B1gKgC6/+bRprJ9qn2t80tqH27a/AwDwDVI9drBq3+jVCteuV9qSq/Nj959o/bWP5xlRuDiNF37imBd1jj3h2hd5/ER/CUYhNoovfKLZsloEDxYumnI7z4gXFwc9nznrMfaPUf8zIRd6L15ZPzA8+TVo0VYL4qKt8L2Vfe9o33v76rxvD7lmfux6mXD9tZ8VV9aP2c9s9A6woBCRrQC2AkBSVjaKl6ZizP/vSf7HTrB+Di8Yi0W04PGdjvD7K0z7q2xetI3NFEQhzma1ICU+Ginx0bPaf9Azgr5rvgIY52zL0Ogfu3P+g3qa+/nW+/9QSuHdWf0LjaV3gLkBpGrTKQA6p7l+sn2glNoJYCcAFBcXq/+zOT8gxRIRzUWMzYqYBKspLlv5wZeNrmDm9A6wPQCKtelsAJUAICIpSin3ROsnWEZERBFM1zZ6X/egiJQCcPt1E7490fpJ9iEiogim+3dg2um+scuKplj/mWVERBTZOBIHERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpiRo7zpLJiUg7gDMGl5EOoMPgGkIFfxdX8XdxFX8XV4XK72KpUspudBEzEXYBFgpEpEYpVTz1luGPv4ur+Lu4ir+Lq/i7mD2eQiQiIlNigBERkSkxwIKDI4dcxd/FVfxdXMXfxVX8XcwSvwPTiYhsU0ptN7oOIgo9/HyYnbC4H1io0wYivsnoOoym3bcNAHKUUt8xtBidicgmjN4uqDDSP6gi+XUwHn4+zB5PIZIutDdppTYwc7Y2HxFEpBAAlFKVANy++UgUya8DCjwGWJCJSKH2wRXpsgH4PqwatflIsRmjR1/A6L89kj+0I/l18Bn8fJgbnkIMvtSpNwl/Y26JU4jRm5dGihQAXX7zaQbVYbgIfx2Mh58Pc8AAmyO/8/n+GpVSlfzr6rO002f7eWPSyMbXAY++AoEBNkdT3GwzW0Sy/aYLw/kNO1mY+82XRmATgxtX/9JOAdBpWCWhIxJfB2NF1OdDMDDAgkgptRe48sGeYmw1wTfVnbNFZKvvQ0tESiPor889AHxDBWUDiJR/97gi+HVwjUj7fAgGXgdGutC6zV7C6HdBqQAeiqQPLu1DqhFA9lRBH84i/XVAgcUAIyIiU2IbPRERmRIDjIiITIkBRkREpsQAIyIiU2KAERGRKTHAiIjIlBhgRERkSgwwIiIyJQYYERGZEgOMSAciUigiDSLykt98isFlEZkaA4xIH6UAigD8yDdqv1LKbWhFRCbHsRCJdKQddaUqpRqNroXI7BhgRDrxnTLkkRdRYPAUIpEOfDcu9IWX340MiWiWeENLoiATkUKM3tCyS0QqMfp9mBuj9wcjolniERhREPmdNtyJ0bsxnwZwE2/iSDR3/A6MiIhMiUdgRERkSgwwIiIyJQYYERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRK/x/3dQ76LKvSlgAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -15638,7 +15349,7 @@ To construct this you need to give the x and y values (both of shape=(npdf, N))<
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAsbklEQVR4nO3deXQU150v8O+vu7UvtJaWxCZwi0UCbEA0GBMb2yCwY08SL7ITx3ESJ0YxnizvZZxlEs9M5j3nJDh5mcy8cWKwM3EcL/GShCzzvCBwjDExIAlks8gOEpLYhCTUrQ1trb7vjy5BW0aoJbWqurq+n3N0WtW3qvVTH0lf3apb94pSCkRERGZjM7oAIiKi8WCAERGRKTHAiIjIlBhgRERkSg6jCyAioslRWVmZ43A4ngCwCObtsAQAHPT7/fctW7asObSBAUZEFKMcDscTeXl5RS6Xy2uz2Uw55DwQCEhLS8uCpqamJwB8PLTNrIlMRESjW+RyuTrMGl4AYLPZlMvlakewF/nBNgPqISIifdjMHF5DtO/hQ3nFACMiokmxdevWtI9+9KPukdo3btw4/aGHHsod7+szwIiIaFLccsstnZdqv/vuu70TeX0O4iAisoBvvFQ98/2mzuRIvua8vLRzPypdfDycfVetWjV3w4YNrffee6/3oYceyvV4POcqKirO19Pa2mr/6U9/mu3xeM4dPXo04cEHH2wd7TXZAyMiokm1devWtCeeeKLh3nvv9f74xz/O9ng852655ZbOG2+88XwP7Z/+6Z/ybrzxxs5bbrmls6qqKiWc12UPjIjIAsLtKUVaY2NjwubNm13f/e53mwD0b9++Pf2mm246MXy/6urq5BtuuKFj165dyQ888EBLOK/NHhgREU2axYsXn3v55Zfrvv/97+cBwLJly7r37NmTAgRPGw7tt2bNmg4AuPrqq88VFhb2hfPaDDAiIpoUW7duTauurk4+fPhwfHt7u33jxo3TH3744TO1tbXxu3btSq6oqEjesWNHemtrq/3hhx8+U1FRkbx169a0Xbt2hXWtTrgeGBFRbKqurq5fvHjxqIMhzKC6ujp78eLFs0OfYw+MiIhMiQFGRESmxAAjIiJTYoAREcWuQCAQEKOLmCjtewgMf54BRkQUuw62tLRMMXOIacupTAFwcHgbb2QmIopRfr//vqampieamppiYkHL4Q0cRk9ERKZk1kQmIiKLY4AREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKbEACMiIlPSPcBEpFRESkSkbJT9No31GCIisg5dA0xESgFAKVWubZeMsF8JAPdYjiEiImvRuwe2HECd9nkdgOLhO4iIO2SfsI4hIiLr0Xs2euew7ayL7ONWSpWLnJ/9P5xjzsvOzlazZ88eT21ERJZVWVnZqpRyGV3HWOgdYD4AmSM1ikjJ0KnCcI/RjisDUAYA+fn5qKiomFiVREQWIyINRtcwVnqfQtyHCz0qN4Btw9rbtMEapQDcIlIcxjFQSm1RSnmUUh6Xy1T/QBAR0TjpGmBKqZcQDKYSAM6QgRnbtPYq7blMaKE10jFERGRtMbegpcfjUTyFSEQ0NiJSqZTyGF3HWPBGZiIiMiUGGBERmRIDjIiITIkBRkREpqT3fWBEBEAphaaOXtQ0deL9pk4Uz8rA8tmXvN2RiIZhgBHpoLN3AP/9zmkcOd2BmqZO1DR1or1n4Hx7nF2w+Z5lWFOYa2CVRObCACOaZP3+AL7w5D7sq/ciJd6O+XlpuPmKqSjMS0NhXjqmORNx/9OVuP/pKvzicx5cM5c34xOFgwFGNMn+958PY1+9F//njsW4del02GzyoX1+/YUrcdfjb2PDUxV48t4VWOm+5JSfRAQO4iCaVM/va8Sv325A2Wo3bl8246LhBQAZKfF4+r4rMd2ZhC8+uQ+VDV6dKyUyHwYY0SSpavTin7YewjVzs/HNG+aPun92agKe3bASrrQEfP6/9uKdE77JL5LIxBhgRJOgubMXG5+uRO6UBPzfu5bCYQ/vVy03PRHPbFiJ9KQ43POLvTh8qmOSKyUyLwYYUYT1+wPY+HQVOnr82HKPB87k+DEdP92ZhOc2rERSnB33/GIPGs52T1KlRObGACOKsO/96RAqG7z40R1XoGhq+rheIz8rGc9uuBLd/X5s3lk3+gFEFsQAI4qgZ/c04tk9jbj/2gL83RXTJvRablcqbr58Gv6w/yS6+/wRqpAodjDAiCLkaHMn/uWPB7F6ngvfCGPQRjg+fWU+uvsH8afqUxF5PaJYwgAjipD/2H4UcXYb/u3OxbCPMFx+rIrznZifm4bn9jZG5PWIYgkDjCgCjjZ34U/vnMI9V81CVmpCxF5XRHDXipmoPtGOgyfbI/a6RLGAAUYUAY++fhSJDjvKrnFH/LVvXToDCQ4be2FEw+geYCJSKiIlIlI2QnuJ9rEp5DmviGwTkW/qVylReOpauvCHAycj3vsaMiU5DjdfMRV/OHCKgzmIQugaYCJSCgBKqXJtu2RYezGAYq29WESG/p29Qym1Tin1iJ71EoXj0ddrEe+wYcMk9L6GfHpFPrr6/PjzOxzMQTRE7x7YcgBDN7XUASgObVRKVSmlHhERJ4A6pdTQvs6QMCOKGg1nu7H1wEncfeUsuNIi3/sasmxWBubmpOLZvccn7WsQmY3eAeYctj3SlNseALUh25kA2kRk82QURTRe/7njKBw2wZdWT+7/V8HBHPmoPu7DoVMczEEE6B9gPgTD6JK0U4gFIacctyilfAB8Q8+FEpEyEakQkYqWlpYIl0x0ccfbzuF3+0/irhX5yElPnPSvd1vxdCQ4bPgNe2FEAPQPsH240AtzA9gW2igim0IGd/gAZGrh9IFTjcNpAedRSnlcLi4GSPp49PWjsNsEG68r0OXrOZPjcfPlU7F1/0mc6+dgDiJdA0wp9RIAtzZ4wxkymGMoyDYDqAtp3wLgBW2f0pDXIDLU8bZzeKnyBD61fCZydeh9Dbnrynx09vnx53dO6/Y1iaKV7isyh4wkLA95bp32WIcLgzzKted8AKq0D4YXRYWfv1ELm+jX+xrimZWBOTmpeG5vI+70zNT1axNFG97ITDRGJ309eLHiOO5cPgNTpyTp+rWHBnPsb/ThyGmuFUbWxgAjGqPH/hIcILvxujmGfP3blk5HvMOG33BmDrI4BhjRGJzy9eD5fcdRumwmpjv17X0NyUiJx02L8vC7/SfROzBoSA1E0YABRjQGP/vLUSgo/P31+l77Gu624hno7PVjd22roXUQGYkBRhSmod7XHZ6ZmJGRbGgtV7ozkZrgwLbDzYbWQWQkBhhRmB59/SgA4O+vN+baV6gEhx2r52VjR80ZBALK6HKIDMEAIwrDCe85vFBxHHd6jLv2Ndzawlyc6ejDQU4tRRbFACMKw8+0kYfR0Psacn1hDmwClB/haUSyJgYY0ShOeM/hxYrj+OTymZgWJb0vAMhMiceyWRkoP3zG6FKIDMEAIxrFo6/XQiBR1fsaUlKUi8OnO3DK12N0KUS6Y4ARXcLxtmDv61MrZuo+60Y41hblAgC21/A0IlkPA4zoEh59/aghcx6Gq8CVgtlZyTyNSJbEACMawdCM83dFae8LCM6NWFKUi7/WnkV3H5dYIWthgBGN4D93HIXNJobNeRiutUW56B8M4M2/cTFXshYGGNFFNJ49h99WncCnV+Qjb4p+632Nh2d2BqYkxXE4PVkOA4zoIn7+xlDvKzqvfYWKs9tw3XwXdtQ0Y5CzcpCFMMCIhmnu7MVvK0/ijmUzdF1teSLWFuWirbsfB457jS6FSDcMMKJhntrdgIFAAPdd4za6lLBdO88Fh014GpEsRfcAE5FSESkRkbIR2ku0j03hHkMUKd19fvz67QasX5CLy7JTjC4nbFOS4rDiskwOpydL0TXARKQUAJRS5dp2ybD2YgDFWnuxiLhHO4Yokl6sOI72ngGUrY7+a1/DrS3Kxd+au9BwttvoUoh0oXcPbDmAOu3zOgDFoY1KqSql1CMi4gRQp5SqG+0YokjxDwbwxK5j8MzKwLJZGUaXM2YlRTkAOLkvWYfeAeYctp01wn4eALXhHiMiZSJSISIVLS28F4bG5+WDTTjh7cGG1ea59hVqVlYK5uakYvsRnkYka9A7wHwAMkfbSTtdWKCdPhz1GKXUFqWURynlcblckaiTLEYphS076+DOTsE6bX5BMypZkIu9x9rQ3jNgdClEk07vANuHCz0qN4BtoY0isilkoIYPweC65DFEkfB2XRvePdmO+65xw2YTo8sZt5KiHPgDCm+8zzMRFPt0DTCl1EsA3NpADGfIwIyhUNoMoC6kfctIxxBF0padtchKicdtxdONLmVClszMQGZKPEcjkiU49P6CSqlHtE/LQ55bpz3W4cKAjfJLHUMUKe+f6cTr77Xg6+vmITHObnQ5E2K3CdYU5uC1Q00YGAwgzs5bPSl28aebLO/xnXVIjLPhnpWzjC4lIkqKctDR60dFPWfloNjGACNLO9PRi60HTuJOz0xkpMQbXU5EXDPXhXi7DeUcjUgxjgFGlvbk7noMBhS+ePVlRpcSMSkJDlxVkIXyI2egFCf3pdjFACPL6urz4+m3G3DjojzMyjLPtFHhKFmQi4az51Db0mV0KUSThgFGlvXqwSZ09vpjqvc1ZG0hZ+Wg2McAI8vaUdOM3PQEFOebb9qo0UxzJmHhtHQOp6eYxgAjS+r3B7Dz/RasKcyBiHlvXL6UtUW5qGr04mxXn9GlEE0KBhhZUkV9Gzr7/FhTaN5po0azrigXAQW8/h5n5aDYxAAjS9pe04x4hw0fmTPSfNLmt2h6OnLTEzi5L8UsBhhZ0o6aZqwqyEJyvO6T0ehGRLC2KBc7329Bn3/Q6HKIIo4BRpZT19KFY63d50fqxbKSohx09w/i7bo2o0shijgGGFnOjprg0PLrLRBgqwqykRRn52hEikkMMLKc7UeaUZiXhhkZyUaXMukS4+y4em42tnNWDopBDDCylPaeAeyrb8MaC/S+hqwrysWp9l4cPt1hdClEEcUAI0t5828t8AcU1hZZJ8CuL8yBSLDnSRRLGGBkKTuONCMjOQ5LZsbe7BsjcaUlYMlMJ2enp5jDACPLGAwo/OX9Flw3Pwd2W2zOvjGSkqJcvHOiHWc6eo0uhShiGGBkGQeO+9DW3W+p619DSoqCM47wNCLFEt0DTERKRaRERMou0uYUkWJtn00hz3tFZJuIfFPfaimW7Kg5A7tNsHqey+hSdDcvNxUzMpI4KwfFFF0DTERKAUApVa5tlwzb5U4AHqXUS1r7UMjdoZRap5R6RLdiKeZsP9KM5bMzMCUpzuhSdCciKCnKxa6jrejp56wcFBv07oEtB1CnfV4HoDi0USm1RSm1Rdt0h+zrFBG3PiVSLDrp60FNUyfWxvDkvaMpKcpFnz+AN//GyX0pNugdYM5h2xedSVULq7ahnhqATABtIrJ5hP3LRKRCRCpaWvjLSR82NPvGGgsNnx9uxWWZSEtwnH8viMxO7wDzIRhGoylVSn1paEPrmfkA+IZOQ4bS2j1KKY/LZb3rGzS6HUfOYHZWMtzZKUaXYph4hw2r57mwo6YZgQBn5SDz0zvA9uFCL8wNYNvwHUSkdOhalzago0xEiofvRxSuc/1+vFV7FmsKc2N28cpwrSnMQXNnHw6d4qwcZH66Bpg2OMOtDd5whgzm2KY9lgDYJCKVIlKJYG/tBa2tNOQ1iMK2++hZ9PsDlpp9YyTXzXcFZ+Wo4WhEMj/dF0MKGUlYHvLcOu2xHEDBRQ6r0j4YXjRm22uakZrgwPLZ4Zy9jm1ZqQlYOtOJHTXN+B8l84wuh2hCeCMzxTSlFF6vacbqedmId/DHHQDWarNyNHNWDjI5/kZTTDve1oOmjl6sKsg2upSoMTQTyevvcTQimRsDjGJaZWNwJWLPbOtM3juawrw0TJuSyGmlyPQYYBTTKhu8SEtwYG5OmtGlRA0RwZqiHOw62oreAc7KQebFAKOYVtngw5J8p+Vmnx/N2sJcnOsfxJ5jbUaXQjRuDDCKWZ29A3ivqQPF+Tx9ONxVBVlIjLNhByf3JRNjgFHMqj7ejoACls1igA2XGGfH1XOysb2mGUpxVg4yJwYYxayqRi9EgCX5TqNLiUprCnNxwtuDvzV3GV0K0bgwwChmVTZ4MT83DemJ1ls+JRxDw+k5GpHMigFGMSkQUKhq9KKYpw9HlDclEQunpWMHp5Uik2KAUUw62tKFzl4/B3CMYm1hDiobvPB29xtdCtGYMcAoJlU2eAFwAMdo1hTlIqCAN97nOnpkPmOezFdEliC4FIobwfW92gDUKaUORLIwoomobPAiMyUes7OSjS4lql0xfQqyUxOwvaYZtyydbnQ5RGMSVoCJyGwA3wZwGYA67cMHQBCcPX69topyLYBNSqn6SaiVKGxVjV4U52dYfv2v0dhsgjWFLrxysAkDgwHE2XlShsxj1AATkW8guC7Xt5RS7aPsOwVAmYh4lVJPRKhGojFp6+5HXUs3SpfNMLoUU1hTmIsXKk6gssGLle4so8shCtsl/93SwuslpdQ/jhZeAKCUaldK/QjAdhF5MFJFEo3F/kbt+hcHcITl6rnZiLfbsKOGw+nJXC4ZYEqpHymljo31RZVSx5RSPx5/WUTjV9nghcMmuGKG0+hSTCE1wYEr3ZnYzmmlyGTGfMJbux5GFLUqG7xYOC0dSfF2o0sxjbWFOaht6UZ9a7fRpRCFbTxXbDNE5L6hDRG5XUTWhHuwiJSKSImIlF2kzSkixdo+m8I5hijUwGAA75xo5w3MY7S2KBcAsO0we2FkHmMOMKXUfgBzhkJLKfVbBEchfnG0Y0WkVDumXNsuGbbLnQA8SqmXtPayMI4hOq/mdCd6BgZ5A/MYzcxMxoKp6XjtcJPRpRCFbTynEF8FoABUaveEAcAPADwSxuHLERyCD+2xOLRRKbVFKbVF23Rr+1zyGKJQlQ3B9a14A/PYrV+Yi4oGL1q7+owuhSgs4zmFWABgszYqUbSh849rH6NxDtu+6Jhd7Z6yNq3XNeoxWk+tQkQqWlo4o4CVVTb6MHVKIqY5k4wuxXTWL8iDUuBgDjKN8QTYegDfEpF07XRiCYC9Sqlvh3GsD8F7ykZTqpT6UrjHaD03j1LK43K5wnh5ilVVDZzAd7yKpqZhRkYSXjvEACNzGM81sDql1EalVIe2/VsA7WEO5NiHCz0qN4Btw3cQkVKl1CPa58XhHEMEAE3tvTjp6+H9X+MkIli/IA9vHm1Fd5/f6HKIRhWReWOUUo8DGPV+MW1whlsbiOEMGZixTXssAbBJRCpFpBJA5kjHEA1Xpd3AzB7Y+K1fmIt+fwA7ObkvmcCYJ/MdSbg3PA/1rgCUhzy3TnssR/Aa26jHEA1X2eBFgsOGBVPTjS7FtDyzMpCRHIfXDp/BRy+fanQ5RJc06lRS47lxWUQu41RSpLfKBi8Wz3Ai3sEJacfLYbdhbVEuth85g4HBgNHlEF3SqFNJAVgnIj8IJ8hEJF1Efgjgdk4lRXrqHRjEoVO8gTkS1i/IRUevH3uPtRldCtEljXoKUSn1uIhcBuB+EVmKC0up1CI4uCJLeyzQnntkPPMnEk3EuyfbMTCoUJzvNLoU07tmrguJcTa8dqgJH5mTbXQ5RCMK6xqYFkjfBoKnB3FhQct2BAdv1GlD6okMMbQCM3tgE5cUb8fquS68dvgMvvfxhVxTjaLWmAdxaGF2DMD2yJdDND6VDV7MykpGdmqC0aXEhPUL8/Da4TM4eLIDl8+YYnQ5RBc1rqvdInKfdl3sPhHhkC8ylFIKVQ1eTh8VQWsLc2ATcG5EimrjmQvxMQBzAAiCk+8eC2ciX6LJUn/2HM5298MzK5xJXigcGSnxWHFZJmfloKg2nh7YNqXUt7WP9QgO3pgrIrdFuDaisFTUB0fLeWazBxZJ6xfk4b0znVwjjKLWhG+YUUr5tHkQLzoxL9Fkq2r0Ij3RgTmuVKNLiSnrFnCNMIpu4wmwOhHZJyK3Drv+dTZSRRGNRUV9cAJfm42j5SKJa4RRtBtPgH0SwAsA7gJQr4XZ8wgOqwcAjGWFZqKJ8J3rx9+au+DhAI5JwTXCKJqNJ8BqAbyolLpTKZUJoAxABYKrMp8VkX0ANkWySKKR7G/0AeD9X5OFa4RRNBvPciqPA8gYmlpKKbVfKfUjpdR6pVQWgC8B8Ea2TKKLq2hog90mWDLTaXQpMWlojbBXORqRotC4BnFooVU/QlsVgG9NpCiicFXUe7FgajqS4yO2sAKFEBHcdPlU7Hy/Bc2dvUaXQ/QBkzJtN6eVIj0MDAZQfcLHG5gn2V0r8uEPKLyw77jRpRB9ANedINM6fKoDvQMB3v81yS7LTsHVc7Lx3N7jGAwoo8shOo8BRqZVoU3gyx7Y5PvMynyc9PXg9Zpmo0shOo8BRqZV1eDFdGcSpk5JMrqUmLe2KBc5aQl4ek+D0aUQnad7gIlIqYiUiEjZJdq3DXvOKyLbROSb+lRJ0U4phYqGNva+dBJnt+FTK/LxxvstON52zuhyiADoHGAiUgoASqlybbtk+D5KqZcucugdSql1SqlHJrlEMokT3h6c6ehjgOnorhUzYRPBs3sbjS6FCID+PbDlCK7oDO2xOMzjnCLiHn03soqqRl7/0tvUKUlYW5iDF/YdR59/0OhyiHQPMOew7XAnAM4E0CYimy/WKCJlIlIhIhUtLS0TqY9MoqLei5R4Owrz0owuxVI+s3IWznb345WDnB+RjKd3gPkQDKMxUUptUUr5APiGTkNepN2jlPK4XK6JV0lRr7LBiyX5TjjsHIekp6vnZGNWVjKeeZunEcl4ev/278OFXpgbwLaRdw3SelfhnmokC+jq86OmqQPLuICl7mw2wadX5GNvfRvea+o0uhyyOF0DTBug4dYGbzhDBnOcDzKtzRPS03pBe7405DXIwvY3ehFQ4Az0BrnDMxPxDhue4ZB6MpjuE8iFjCQsD3luXcjn5QAyQrZ9AKq0D4YXobLBCxFgSb7T6FIsKTMlHjdfPhW/qzqJb91YiJQEzkNJxuAFBDKdygYv5uemIT0xzuhSLOszK/PR1efHH6tPGV0KWRgDjExlMKCwv9HH+Q8NVpyfgcK8NDz9dgOU4vyIZAwGGJnKe02d6Orz8/4vg4kI7l45C4dOdeDAcZ/R5ZBFMcDIVCob2gAAHo5ANNytS6cjJd6O/3qr3uhSyKIYYGQqFQ1e5KQlYEYGJ/A1WmqCA59ZOQv//c4p1LV0GV0OWRADjEylssGLZbMyICJGl0IA7rvGjTi7DT/7S63RpZAFMcDINM509OKEt4fXv6KIKy0Bd63Ix+/3n+Qs9aQ7BhiZxt5jwetfDLDo8qVr3bCL4LE32AsjfTHAyDTKj5xBRnIcLp8+xehSKMTUKUko9czAixUn0NTea3Q5ZCEMMDKFPv8gdhxpxroFuZzANwptvLYAg0ph8072wkg//EtAprD76Fl09vnx0UVTjS6FLmJmZjJuXTodz+5pREtnn9HlkEUwwMgUXjnYhNQEB1bNCXcJOdLbA9cVYGAwgCd21Y2+M1EEMMAo6vkHA9h25AzWFOYgwWE3uhwagduVir+7Yhp+/dcGeLv7jS6HLIABRlFvX70Xbd39uHFRntGl0Ci+vGYOzvUP4pdvHTO6FLIABhhFvVcPNSHBYcO187jadrSbl5uGGxfm4Ze769HRO2B0ORTjGGAU1QIBhVcONuHaeS6uO2USX14zB529fjy1u97oUijGMcAoqlWf8KGpo5enD01k0fQpWFOYg1/sOobuPr/R5VAMY4BRVHvlUBMcNsHawlyjS6Ex+PKaOfCeG8BzexuNLoVimO4BJiKlIlIiImWXaN82lmMoNiml8OrBJlxVkIUpyVx92UyK8zOw0p2JJ948hn5/wOhyKEbpGmAiUgoASqlybbtk+D5KqZfGegzFppqmTtSfPcfThya18bo5aOroxdYDJ40uhWKU3j2w5QCG7nKsA1A8ScdQDHjlYBNEgPULGGBmtHpuNhZMTcdjb9QiEFBGl0MxSO8Acw7bDmdahVGPEZEyEakQkYqWlpZxlkbR5tVDTVg+KxOutASjS6FxEBFsvK4AdS3deO3wGaPLoRikd4D5AIx1LfhRj1FKbVFKeZRSHpeL9wrFgmOt3ahp6sQNPH1oah9dlIdZWcn4+Ru1UIq9MIosvQNsHy70qNwAto2864SOIZN79VATAOCGhRx9aGYOuw1lq92oPu7DX+vOGl0OxRhdA0wboOHWBmI4QwZmnA8lrc0TMnjjosdQbHv5YBOumDEFMzKSjS6FJuj24hnITk3Az//CpVYosnSf2kAp9Yj2aXnIc+tCPi8HkDHaMRS7Tvl6UH3ch2/cMN/oUigCEuPs+OLVl2HTKzU4eLIdi7ggKUUIb2SmqPOadvqQw+djx90r85GW4MDP32AvjCKHAUZR55VDTZibk4oCV6rRpVCEpCfG4TNXzcLL757GsdZuo8uhGMEAo6hy+FQH9h5rY+8rBt37kdlw2G3YspMLXlJkMMAoavT0D+Krv9mP7NQE3PuRy4wuhyIsJy0Rdyybgd9WnkBzR6/R5VAMYIBR1Hj4vw/jaHMXfnLnEmSmxBtdDk2CstVu+AMB/IILXlIEMMAoKrx2qAnP7GlE2Wo3rp6bbXQ5NElmZaXg5ium4Zm3G+Ht7je6HDI5BhgZ7kxHL77123ewaHo6HlzPofOx7svXz0FXnx9P7OK1MJoYBhgZKhBQ+PoLB9A7EMC/f2op4h38kYx18/PScPPlU/HkW/XshdGE8K8FGerxN+vw1tGz+OePLeCweQv5WslcnBsYxONvshdG48cAI8McPNmOH7/2Hm5cmIdPLZ9pdDmko3m5wV7Yr3bXo429MBonBhgZ4ly/H199bj+yUhLww9svh4gYXRLp7Gtrg70w3hdG48UAI92d8vXgK8/ux7Gz3fjJJxfDmcwh81Y0NzcNH7tiGp76az3OdvUZXQ6ZEAOMdNPRO4BNr9Tg+h//BW8ebcVDNy/AqgIOmbeyr66di172wmicdJ+Nnqyn3x/As3sa8B87jqKtux+3Lp2Of1g/j0ulEObkpOLji6fhqb82YMNqN7JTufo2hY8BRpNGKYVXDjZh0ys1qD97DqsKsvCdm4q4nAZ9wFfWzsUfq09hy846fOemIqPLIRNhgNGk6PMP4sEX38Gfqk9hXm4qfvn55bhuvouDNehDClyp+MSS6Xjqr/XYcI0brjT2wig8vAZGEdfeM4DP/mIv/lR9Cg+un4f/99VrcH1hDsOLRvSVNXPQ7w9gM9cLozFggFFEnfL14I7HdqOq0YuffnIJvrxmLhx2/pjRpbldqbhl6XQ8vacBzZ2cqZ7Co/tfFhEpFZESESkLt11EvCKyTUS+qV+lNFZHTnfgtp/txmlfL568dwVuWTrd6JLIRL66Zi4GBhUe3XHU6FLIJHQNMBEpBQClVLm2XRJm+x1KqXVKqUd0LJfGYPfRVtz52F8BAC/cfxU+MofD42lsZmen4K4VM/Hrtxvw7ol2o8shE9C7B7YcwNANH3UAisNsd4qIe/LLo/H4w4GT+Nwv92KqMxG/e2AViqamG10SmdQ3bihEVmoC/vH378A/GDC6HIpyegeYc9h2VpjtmQDaRGTzxV5URMpEpEJEKlpaWiZcJIXv5XdP42u/OYDi/Ay8eP8qTHMmGV0SmdiUpDh872MLcfBkB57cXW90ORTl9A4wH4JhNKZ2pdQWpZQPgG/oNONF2j1KKY/L5YpQqTSaw6c68PUXqrE034lffWEFpiTFGV0SxYCbLs/D9fNd+Mm293HS12N0ORTF9A6wfbjQy3ID2DZau9a7Gn6qkQzW2tWHDU9VYEpSHDZ/ZhkS4+xGl0QxQkTwvz6xCEoB/7z1IJRSRpdEUUrXAFNKvQTArQ3OcIYM1th2ifYXtH1KQ/YhA/X7A3jg6Sq0dvVhy2eXISc90eiSKMbMzEzG19fNw/aaZrx8sMnocihKSaz9d+PxeFRFRYXRZcQspRS+8/t38dze4/j3Ty3BJ5ZwqDxNDv9gAJ949C20dPah/B+uRXoiT1FPJhGpVEp5jK5jLHiHKY3Jr99uwHN7j+OB6woYXjSpHHYbfnDb5Wjt6sMjr9QYXQ5FIQYYhW330Vb8658Oo6QoBw+un290OWQBV8xw4nOrZuOZPY2obPAaXQ5FGQYYhaXhbDceeLYK7uwU/Nsnl8Bm47yGpI9/WD8feemJ+M7v3sUA7w2jEAwwGlVbdz+++KsKKAU88TkP0ngtgnSUmuDAv358Id4704l//sMhjkqk8xhgdEmdvQP4/C/34njbOWy+ZxlmZaUYXRJZ0PqFedh4XQGe29uIH736ntHlUJTgemA0ot6BQdz3qwocPtWBLZ9dhpXu4ROnEOnnmzfMh+/cAH72l1pkJMdjw2rOLmd1DDC6qH5/AA88U4W99W346SeXYE1hrtElkcWJCB6+ZRE6egfw/f93BFOS4nDn8plGl0UGYoDRhwwGFL7+wgHsqGnG929dxOHyFDXsNsG/3bkEHT0D+Pbv3kF6kgM3LppqdFlkEF4Dow9QSuGhrQfx53dO49sfLcTdV84yuiSiD4h32LD5nmVYPNOJrz53AG8dbTW6JDIIA4zOU0rhhy/X4Lm9jfj76wtw/7UFRpdEdFHJ8Q788vPLcVl2CsqeqkD1cZ/RJZEBGGAEIHja8Icv12Dzzjrcs3IWb1SmqOdMjsdTX1yBzNR43POLPfjDgZMcYm8xDDCCt7sfn//lXmzeWYe7r8zHv358IUR4ozJFv9z0RDx730q4Xan42m8OoOzXlWju6DW6LNIJA8ziDp5sx8f+cxf21LXhB7ddju/fejln2SBTmZmZjN9uXIXv3lSEne+3oOQnb+ClyhPsjVkAA8zCfr//BG7/+W74BxWe/9JK3LUi3+iSiMbFbhNsWO3Gy1+7BvPz0vDgi9W498l9ON3OBTFjGQPMggYGA/jeHw/hfz5fjcUznfjTV67G0vwMo8simjC3KxXPl12Ff/nYAuypa8P6n+zEE2/WobN3wOjSaBJwPTCLOXyqA9/74yHsrW/DFz5yGf7xpkLE2fl/DMWexrPn8J3fv4tdR1uREm/H7ctm4LNXzcacnFSjS4tKZlwPjAFmAUopvF3XhsfeqMUb77cgNcHBG5TJMt454cOTu+vx5+rT6B8M4Jq52fjsVbOxpjAHdl7vPY8BFgUYYBcEAgqvHT6Dx96oxYHjPmSnxuPej1yGz1w5C1OSOaM8WUtrVx+e33ccT7/dgNPtvZiZmYQbF+Zh1ZxsrJidiZQEa09MxAAL5wuKlALwAXArpbaE0z7aMaGsHGBKKTR39qG2pQtHTnfimT0NqGvpRn5mMjasduOOZTOQGGc3ukwiQ/kHA3jt8Bk8u6cRe4+1oX8wAIdNsGSmE6sKsrBqTjaW5juR4LDW7woDbLQvFgwiKKVeEpEyAHVKqfJLtQNwXuqY4YwIMKUU/AGFfn8A/f4Aev2D6O7zo7PXj+6+QXT1DaCrbxBdvQM4NzCIvoHgPn0DAfT5A+jzD6LPH4BNBPF2G+IdNsTbJfjosCHOboNdBHa7BB9tApv22Nk7gNqWbtS1dKG2pRtdff7zdS2Ymo77ryvATYvy4OB1LqIP6R0YREW9F2/VtmJ37Vm8e8KHgALi7IJpziRMH/rISMKMjGRMdybBlZaApHg7Eh027dEeE7eemDHA9O4zLwfwvPZ5HYBiAOWjtGeNcswHvNfUiWt/9PqYihopwxUUlIL2oRBQQEB7VEqhfzAYWP2DgRFfYyQJDlvwI85+/vOACs4C3+cPYCDktQcDl37xaVMSUZCTituLp6MgJxUFrlS4XSnIS0/kDclEl5AYZ8fVc7Nx9dxsAEB7zwD2HmtDVaMXJ7w9OOk9h51/a8GZjr5Lvk6Cw4bEODvi7AIRgU0AmwT/0RRB8AMj/y7y13R89A4w57Dt4QtMXax9tGOg9czKACB9mhtLZw4/ZHQj/aEXre38D6Qt+KxNgDh7MHiCPSbb+R5TgsOO1EQH0hIcSElwIDXBgbTE4GNSvB3xdtuY/mMLBBQGlcJgQPtQKvhcQCEp3o7keGufuyeKlClJcVi3IBfrFnxw+aA+/yBO+3px0teD1q4+9A0E0DMwiJ6BQfQOPfYPwh+48A9uIOSf3kv9gxst4xB2Gl3AOOj9l88HIHOM7aMdA+262BYgeArxp59aOu4Co5HNJrBBwMtXRMZIcNgxOzsFs7Njd0Xyf7/L6ArGTu8A24cLPSo3gG1htDtHOYaIiCxI1yv7SqmXALhFpASAc2gwhohsG6l9pGOIiMjaeB8YERGZchQix1YTEZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZlSzI1CFJEWAA0Gl5ENoNXgGqIF34sL+F5cwPfigmh5L2YppVxGFzEWMRdg0UBEKsw2HHWy8L24gO/FBXwvLuB7MX48hUhERKbEACMiIlNigE2OSy66aTF8Ly7ge3EB34sL+F6ME6+BERGRKbEHRkREpsQA04mIbDK6BiOJiFNEikWk1IrvhfZ9l2iLr1qW1X8ORsL3YnwYYDrQloJxG12Hwe4E4NGWx4GV/pCLSCkAhCwfVGJsRYay7M/BSPj3Yfy4Fv0kExE3gDqj6zCatmr2EKstTLocwPPa53UAigFYcl07i/8cfAj/PkwMe2CTz62U4g+oRvuFbbPYwqTOYdtZRhQRTSz6c3Ax/PswAeyBTZB2eihz2NN1SqlyESmx0i/opd6LkO1SpdSXdCwrGvjw4ffF6qz4c/ABVvv7MBkYYBM0dC5/BG3a+W0nALeIFCulqvSpTH+jvBcQkVKl1CPa5zH9XgyzDxd6YTxtZt2fg+Es9fdhMvAU4iRSSlVp/2Fl4sOnkSxF+0XdJCKVIlIJC/VItGB3D/2xsvJ/3Vb+ORiOfx8mjjcyExGRKbEHRkREpsQAIyIiU2KAERGRKTHAiIjIlBhgRERkSgwwIiIyJQYYERGZEgOMiIhMiQFGRESmxAAj0oGIuEWkVkS2advF2ozsRDRODDAifXwLwDoAVdrqux4uo0E0MZwLkUgHIuJUSvlExIlgeFl2Ql+iSGGAEelERIqB4CzkRtdCFAt4CpFIB9pin3VD4aVtE9EEMMCIJpmIlCG4kOXjIuLUroH5jK2KyPwYYESTSBtpWKetQFwH4BiAWl4DI5o4XgMjIiJTYg+MiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEzp/wNwQG8L6Hng6QAAAABJRU5ErkJggg==
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtJUlEQVR4nO3deXhb5Z0v8O9PkvdNXmQ7mx3sLHYWkthOCBACJCZlmXYoDUkppYUWTNP13g5Ne1vuTOdO55lCe9uZ3i4Q6EBZQgNpS6EzbE4ogaYk2E5Cs5hgO7YTJ443KV7iTdZ7/9BRopjYkh35HB3p+3keP9LZ5F8cW1+957znfUUpBSIiIrOxGF0AERHRZDDAiIjIlBhgRERkSgwwIiIyJZvRBRAR0dSorq7OttlsjwNYBPM2WDwADrrd7ntLS0vb/DcwwIiIIpTNZns8Nze32OFwOC0Wiym7nHs8Hmlvb1/Q2tr6OIBP+G8zayITEVFgixwOR7dZwwsALBaLcjgcZ+BtRV64zYB6iIhIHxYjw+uJJ55Iv+mmmwrG2r5p06YZDz74YE6g19H+DR/JKwYYERFNiXvuucc53vY777xz3O2BMMCIiMgQGRkZ7ks5np04iIiiwLe2H5h1tLUnMZSvOS835eyP1i85Hsy+CxcuLL7nnnvaH3jggY4HH3wwp6ys7GxVVdUF9fjW19XVxT3wwAMdgV6TLTAiIppSL774YsoLL7xQ/8ADD3T8+Mc/ziorKzt766239tx44409vn02bdo0w7e+vr4+LpjXZQuMiCgKBNtSCrXm5ua4Rx991PG9732vFcBQTU1N0s0339w9er/GxsY4p9Npe+eddxILCwsHg3lttsCIiGjKLFmy5OzTTz/dtHnz5hkAUFJS0nf06NGPtLBKS0v75s6dO7hq1aqzd999d1CdO9gCIyKiKfHiiy+mvP322yltbW3WtLS0kc985jP5W7dubfJ1na+qqkrcuXNnakdHR8cPfvCD0w8++GBOR0eHFQBuvfXWnvFfHRDOB0ZEFJkOHDjQuGTJkoCdIczgwIEDWUuWLJntv46nEImIyJQYYEREZEoMMCIiMiUGGBFR5PJ4PB4xuohLpf0bPKPXM8CIiCLXwfb29jQzh5g2nUoagIOjt7EbPRFRhHK73fe2trY+3traGhETWo7ewG70RERkSmZNZCIiinIMMCIiMiUGGBERmRIDjIiITIkBRkREpsQAIyIiU2KAERGRKekeYCKyXkTKRWRzgP02T/QYIiKKHroGmIiUAIBSqhKAy7d8kf3KASyfyDFERBRd9G6BbQTg0p43ACifomOIiCjC6R1gdgBdfsuZo3cQkRKttRX0MUREFH3CsRNHhtEFEBFR+NN7NHoXzgeUHUCn/8aLtL4CHjNaVlaWmj179qVVSUQUZaqrqzuUUg6j65gIvQNsG4Ay7XkBgEoAEBG7UsoFoEBECnzbtQ4bFz3Gn4hUAKgAgLy8PFRVVU3ZP4CIKBKJSJPRNUyUrqcQlVI1wLlehi7fMoAd2vbtSqnt8La47AGO8X/dLUqpMqVUmcNhqg8QREQ0SRE3H1hZWZliC4yIaGJEpFopVRZ4z/ARjp04iIiIAmKAERGRKTHAiIjIlBhgRERkSgwwIiIyJb3vAyMiAEoptHYPoLa1B0dbe1CSn47lszkIDdFEMMCIdNAzMIz/ev8UjpzqRm1rD2pbe3Cmf/jc9hir4NG7SrGmKMfAKonMhQFGNMWG3B584cn38F6jE0mxVszPTcEtl09DUW4KinJTMd0ejy89U40vPVODX3++DNfM5c34RMFggBFNsX/502G81+jE/719CT65bAYsFvnIPk9/4Qrc8di7uO+pKjx5zwqsLOCkC0SBsBMH0RTa9l4znn63CRWrC/Cp0pkXDS8ASE+KxTP3XoEZ9gR88cn3UN3k1LlSIvNhgBFNkZpmJ/73i4dwzdwsbP7Y/ID7ZyXHYet9K+FIicPd/7kX759wTX2RRCbGACOaAm09A9j0TDVy0uLw/+5YBps1uD+1nNR4PHvfSqQmxOCuX+/F4ZPdU1wpkXkxwIhCbMjtwaZnatDd78aWu8pgT4yd0PEz7Al47r6VSIix4q5f70FTZ98UVUpkbgwwohD7/suHUN3kxI9uvxzF01In9Rp5mYnYet8V6Bty49FdDSGukCgyMMCIQmjrnmZs3dOML11biL+7fPolvVaBIxm3LJ6OP+5rQd+gO0QVEkUOBhhRiNS19eCfXjqI1fMc+FYQnTaC8Zkr8tA3NIKXD5wMyesRRRIGGFGI/GxHHWKsFvx0wxJYx+guP1EleXbMz0nBc3ubQ/J6RJGEAUYUAnVtvXj5/ZO468p8ZCbHhex1RQR3rJiFAyfO4GDLmZC9LlEk0D3ARGS9iJSLyOYxtpdrXw/5rXtIe6zQq06iifjFm3WIt1lRcU1ByF/7k8tmIs5mYSuMaBRdA0xESgBAKVUJwOVbHrX9Bm17id/2ChGpB8DuWBR2Gtp78cf9LSFvffmkJcbglsun4Y/7T7IzB5EfvVtgGwG4tOcNAMr9NyqlapRS39YWC5RSNdrz25VShVqwEYWVX7xZj1ibBfdNQevL5zMr8tA76Maf3mdnDiIfvQPMDqDLb/miI5Zqpxfv91tVMt5pRyKjNHX24cX9Lbjzinw4UkLf+vIpzU/H3OxkbN17fMq+B5HZhGUnDqXUwwDuFxG7b1lrfWWKSPm4BxPp6Oc762CzCO5fPXWtL8DXmSMPB467cOgkO3MQAfoHmAuAb9pZO4BO/40i4n/dqwHea1/rRWS9tq4TwEfeKUSkQkSqRKSqvb19SgonGu1411n8fl8L7liRh+zU+Cn/freVzECczYLfshVGBED/ANuG8wFUAKASAHwtLXivifkHXIP25bv2VQigavSLKqW2KKXKlFJlDgcnAyR9/OLNOlgtgk3XFery/eyJsbhl8TS8uK8FZ4fYmYNI1wDzdcrQTgO6/Dpp7NAetwAo8LW4lFLbtX02aOvq/Y4hMszxrrPYXn0Cn14+Czk6tL587rgiDz2Dbvzp/VO6fU+icKX7jMxKqS0XWVeqPbrgDTEA2D7eMURG+tVb9bCIfq0vn7L8dMzJTsZze5uxoWyWrt+bKNyEZScOonDW4urHC1XHsWH5TExLS9D1e/s6c+xrduHIKc4VRtGNAUY0QY/8uR4AsOm6OYZ8/9uWzUCszYLfcmQOinIMMKIJOOnqx7b3jmN96SzMsOvb+vJJT4rFzYty8ft9LRgYHjGkBqJwwAAjmoBf/rkOCgpfuV7fa1+j3VYyEz0Dbuyu7zC0DiIjMcCIguRrfd1eNgsz0xMNreWKggwkx9nwxuE2Q+sgMhIDjChIv3izDgDwleuNufblL85mxep5WdhZexoejzK6HCJDMMCIgnDCeRbPVx3HhjLjrn2NtrYoB6e7B3GQQ0tRlGKAEQXhl1rPw3BofflcX5QNiwCVR3gakaITA4wogBPOs3ih6jg2Lp+F6WHS+gKAjKRYlOano/LwaaNLITIEA4wogF+8WQ+BhFXry6e8OAeHT3XjpKvf6FKIdMcAIxrH8S5v6+vTK2bpPupGMNYW5wAAdtTyNCJFHwYY0Th+8WadIWMeBqvQkYTZmYk8jUhRiQFGNAbfiPN3hGnrC/COjVhenIO/1neib5BTrFB0YYARjeHnO+tgsYhhYx4Ga21xDoZGPHj7Q07mStGFAUZ0Ec2dZ/G7mhP4zIo85KbpN9/XZJTNTkdaQgy701PUYYARXcSv3vK1vsLz2pe/GKsF1813YGdtG0Y4KgdFEQYY0ShtPQP4XXULbi+dqetsy5dibXEOuvqGsP+40+hSiHSje4CJyHoRKReRzWNsL9e+Hgr2GKJQemp3E4Y9Htx7TYHRpQTt2nkO2CzC04gUVXQNMBEpAQClVCUAl2951PYbtO0lIlIS6BiiUOobdOPpd5uwbkEOLstKMrqcoKUlxGDFZRnsTk9RRe8W2EYALu15A4By/41KqRql1Le1xQKlVE2gY4hC6YWq4zjTP4yK1eF/7Wu0tcU5+LCtF02dfUaXQqQLvQPMDqDLbznzYjtppwrvn8gxRJfKPeLB4+8cQ1l+Okrz040uZ8LKi7MBcHBfih5h2YlDKfUwgPtFxB7M/iJSISJVIlLV3s57YWhyXjnYihPOfty32jzXvvzlZyZhbnYydhzhaUSKDnoHmAtAhvbcDqDTf6P/NS94TxdWBDoGAJRSW5RSZUqpMofDEfKiKfIppbBlVwMKspJwgza+oBmVL8jB3mNdONM/bHQpRFNO7wDbBsD38bYAQCUA+LW0ynFhWDWMdQxRKL3b0IW/tZzBvdcUwGIRo8uZtPLibLg9Cm8d5ZkIiny6BpjWKQMiUg7A5VsGsEN73AKgQETWa/tvH+cYopDZsqsemUmxuK1khtGlXJKls9KRkRTL3ogUFWx6f0Ol1JaLrCvVHl3whhgAbB/vGKJQOXq6B29+0I5v3jAP8TFWo8u5JFaLYE1RNl4/1IrhEQ9irGF5mZsoJPjbTVHvsV0NiI+x4K6V+UaXEhLlxdnoHnCjqpGjclBkY4BRVDvdPYAX97dgQ9kspCfFGl1OSFwz14FYqwWV7I1IEY4BRlHtyd2NGPEofHHVZUaXEjJJcTZcWZiJyiOnoRQH96XIxQCjqNU76MYz7zbhxkW5yM80z7BRwShfkIOmzrOob+81uhSiKcMAo6j12sFW9Ay4I6r15bO2iKNyUORjgFHU2lnbhpzUOJTkmW/YqECm2xOwcHoqu9NTRGOAUVQacnuw62g71hRlQ8S8Ny6PZ21xDmqanejsHTS6FKIpwQCjqFTV2IWeQTfWFJl32KhAbijOgUcBb37AUTkoMjHAKCrtqG1DrM2Cq+dE7uQGi2akIic1joP7UsRigFFU2lnbhqsKM5EYq/tgNLoREawtzsGuo+0YdI8YXQ5RyDHAKOo0tPfiWEffuZ56kay8OBt9QyN4t6Er8M5EJsMAo6izs9bbtfz6KAiwqwqzkBBjZW9EikgMMIo6O460oSg3BTPTE40uZcrFx1ixam4WdnBUDopADDCKKmf6h/FeYxfWREHry+eG4hycPDOAw6e6jS6FKKQYYBRV3v6wHW6Pwtri6Amw64uyIeJteRJFEgYYRZWdR9qQnhiDpbMib/SNsThS4rB0lp2j01PEYYBR1BjxKPz5aDuum58NqyUyR98YS3lxDt4/cQanuweMLoUoZHQPMBFZLyLlIrJ5jO0V2tdDfuse8m3Tq06KPPuPu9DVNxRV1798you9I47wNCJFEl0DTERKAEApVQnA5Vv2214OoFIptQVAgbYMABUiUg+gQc96KbLsrD0Nq0Wwep7D6FJ0Ny8nGTPTEzgqB0UUvVtgGwG4tOcNAMpHbS/wW9egLQPA7UqpQi34iCZlx5E2LJ+djrSEGKNL0Z2IoLw4B+/UdaB/iKNyUGTQO8DsAPyHBLhgIDql1Bat9QUAJQCqfM/HO+1IFEiLqx+1rT1YG8GD9wZSXpyDQbcHb3/IwX0pMoRlJw7t1OIbSqkaAFBKPay1vjL9Tiv6718hIlUiUtXezj9O+ijf6Btroqj7/GgrLstASpzt3M+CyOz0DjAXgAztuR1A5xj7lSulHgbOdfpYr63vxPnTiudoLbcypVSZwxF91zcosJ1HTmN2ZiIKspKMLsUwsTYLVs9zYGdtGzwejspB5qd3gG3D+QAqAFAJACJi9+0gIhV+4VUO77Uw37WvQpw/rUgUlLNDbvylvhNrinIidvLKYK0pykZbzyAOneSoHGR+ugaY75SgFkwu3zKAHX7rHxKRehFx+h2zQWuF1fsdQxSU3XWdGHJ7omr0jbFcN9/hHZWjlr0Ryfx0nwzJr5OG/7pS7bESwEeGSLjYMUTB2lHbhuQ4G5bPzgi8c4TLTI7Dsll27Kxtw/8on2d0OUSXJCw7cRCFilIKb9a2YfW8LMTa+OsOAGu1UTnaOCoHmRz/oimiHe/qR2v3AK4qzDK6lLDhG4nkzQ/YG5HMjQFGEa262XvbYdns6Bm8N5Ci3BRMT4vnsFJkegwwimjVTU6kxNkwNzvF6FLChohgTXE23qnrwMAwR+Ug82KAUUSrbnJhaZ496kafD2RtUQ7ODo1gz7GuwDsThSkGGEWsnoFhfNDajZI8nj4c7crCTMTHWLCTg/uSiTHAKGIdOH4GHgWU5jPARouPsWLVnCzsqG2DUhyVg8yJAUYRq6bZCRFgaZ7d6FLC0pqiHJxw9uPDtl6jSyGaFAYYRazqJifm56QgNT76pk8Jhq87PXsjklkxwCgieTwKNc1OlPD04Zhy0+KxcHoqdnJYKTIpBhhFpLr2XvQMuNmBI4C1RdmobnLC2TdkdClEE8YAo4hU3eQEwA4cgawpzoFHAW8d5Tx6ZD4THsxXRGbDO1tyBrxzejXAO7L8zpBWRnQJqpucyEiKxezMRKNLCWuXz0hDVnIcdtS24dZlM4wuh2hCgg4wEfkWgBsAOOGdk8sF4Ay8c3Rlish3ANQDeFQptT/klRJNQE2zEyV56VE//1cgFotgTZEDrx5sxfCIBzFWnpQh8wgYYCJyGYD7AfxWKfWjAPumAagQkTKl1OMhqpFoQrr6htDQ3of1pTONLsUU1hTl4PmqE6hucmJlQabR5RAFbdyPW1p4rVVKfSeYVpVS6owWcjtE5N4Q1Ug0Ifuatetf7MARlFVzsxBrtWBnLbvTk7mMG2BKqWOTaUlN9jiiUKhucsJmEVw+0250KaaQHGfDFQUZ2MFhpchkJnzCW0RSL+Ubish6ESkXkc1jbK/Qvh4K9hgif9VNTiycnoqEWKvRpZjG2qJs1Lf3obGjz+hSiII2mSu2hSKy1LcgIpeJyJpgDhSREgBQSlUCcPmW/baXA6hUSm0BUKCF1rjHEPkbHvHg/RNneAPzBK0tzgEAvHGYrTAyjwkHmFJqH4DlWnd6KKWOAUgXkX8L4vCN8PZeBLzd78tHbS/wW9egLQc6huic2lM96B8e4Q3MEzQrIxELpqXi9cOtRpdCFLTJnELcBm93eaff6cRKABVBHG4H4D8B0QVdnpRSW7TWF+C916wq0DFE/qqbvL8qvIF54tYtzEFVkxMdvYNGl0IUlMmcQiwFUKWUOgNAtK7z5QB+GKqitNOEbyilaoLcv0JEqkSkqr2dIwpEs+pmF6alxWO6PcHoUkxn3YJcKAV25iDTmEyA3Q6ttaWFWAaA9ED3iGlc2v6At2XVOcZ+5Uqph4M9Rmu5lSmlyhwORxBlUKSqaeIAvpNVPC0FM9MT8PohBhiZw6SugSmlfuy3fAxAtX/HjnFsg/e6FrTHSgAQEbtvBxGp8IWX1qnjoscQjdZ6ZgAtrn7e/zVJIoJ1C3Lxdl0H+gbdRpdDFFBIxo3ROnYcC2K/GuBcMLn8ThHu8Fv/kIjUi4gzwDFEF6jRbmBmC2zy1i3MwZDbg10c3JdMYMKD+Y5FO50YzH5bLrKuVHusBPCRd5+LHUM0WnWTE3E2CxZMu6RbFaNaWX460hNj8Prh07hp8TSjyyEaV8ChpCYzJNRkjyO6FNVNTiyZaUesjQPSTpbNasHa4hzsOHIawyMeo8shGlfAoaTgHdfwkWBuVhaRVG3U+rUcSor0NDA8gkMneQNzKKxbkIPuATf2HusKvDORgQKeQtRC7Esicp82ZYoCUIPzvQEz4e0dWAjv/WEPa8cQ6eZvLWcwPKJQkmc3uhTTu2auA/ExFrx+qBVXz8kyuhyiMQV9DUwp9RiAx7T7vsrgDa0MeDtvNGgdOYgM4ZuBmS2wS5cQa8XquQ68fvg0vv+JhZxTjcLWhDtxaJ01dkxBLUSTVt3kRH5mIrKS44wuJSKsW5iL1w+fxsGWbiyemWZ0OUQXNamr3SJyr4j8Sntkly8ylFIKNU1ODh8VQmuLsmERcGxECmuTGQvxhwDmADgDYAOAYyLyxVAXRhSsxs6z6OwbQll+RuCdKSjpSbFYcVkGR+WgsDaZFth72gzN31FKrYO388ZcEbktxLURBaWq0dtbrmw2W2ChtG5BLj443cM5wihsXfINM0opl1LqO+Ao8WSQmmYnUuNtmONINrqUiHLDAs4RRuFtMgHWICLvicj1o65/jTUwL9GUqmr0DuBrsbC3XChxjjAKd5MJsI0AngewCUCjFmavwTuDcgoA8HQi6cV1dggftvWijB04pgTnCKNwNpkAqwfwglJqg1IqA96pVSoBrAPQJCIfAngohDUSjWlfswsA7/+aKpwjjMLZZKZTeQxAuojM1pb3KaV+pJRapwXaRgQxMj1RKFQ1dcFqESydZTe6lIjkmyPsNfZGpDA0qU4cWmg1jrGtBsC3L6UoomBVNTqxYFoqEmNDNrEC+RER3Lx4GnYdbUdbz4DR5RBdYEqG7eawUqSH4REPDpxw8QbmKXbHijy4PQrPv3fc6FKILsB5J8i0Dp/sxsCwh/d/TbHLspKwak4Wntt7HCMeZXQ5ROfoHmAisl5EykVk8zj7lIxafkh7rJjq+sg8qrQBfNkCm3qfXZmHFlc/3qxtM7oUonN0DTBfMGkzL7tGB5W2TzmAx0atrhCRegANU18lmUVNkxMz7AmYlpZgdCkRb21xDrJT4vDMniajSyE6R+8W2EYALu15A4Dy0Tto4TZ6Jr3blVKF2jYiKKVQ1dTF1pdOYqwWfHpFHt462o7jXWeNLocIgP4BZseF4RTs8FMlgU47UnQ54ezH6e5BBpiO7lgxCxYRbN3bbHQpRABM0olDKfWw1vrK1E4xUpSraeb1L71NS0vA2qJsPP/ecQy6R4wuh0j3AHPBO4sz4G2NBRw/Uev0sV5b7ARQcJF9KkSkSkSq2tvbQ1QqhbOqRieSYq0oyk0xupSo8tmV+ejsG8KrBzk+IhlP7wDbhvMBVADvEFQQEfs4xzT49oN36paq0TsopbYopcqUUmUOhyN01VLYqm5yYmmeHTarKU4iRIxVc7KQn5mIZ9/laUQynq5//dooHb6ehi7fMoAdvn201laZr9Wl7bNBW673O4aiVO+gG7Wt3SjlBJa6s1gEn1mRh72NXfigtcfocijK6f7xVWstVSqltvitK/V7vl0pla6U2j7qmO1KqYf1rpfCz75mJzwKHIHeILeXzUKszYJn2aWeDMbzL2Q61U1OiABL8+xGlxKVMpJiccviafh9TQv6Bt1Gl0NRjAFGplPd5MT8nBSkxscYXUrU+uzKPPQOuvHSgZNGl0JRjAFGpjLiUdjX7OL4hwYryUtHUW4Knnm3CUpxfEQyBgOMTOWD1h70Drp5/5fBRAR3rszHoZPd2H/cZXQ5FKUYYGQq1U3egVzK2APRcJ9cNgNJsVb8518ajS6FohQDjEylqsmJ7JQ4zEznAL5GS46z4bMr8/Ff759EQ3uv0eVQFGKAkalUNzlRmp8OETG6FAJw7zUFiLFa8Ms/1xtdCkUhBhiZxunuAZxw9vP6VxhxpMThjhV5+MO+Fo5ST7pjgJFp7D3mvf7FAAsv919bAKsIHnmLrTDSFwOMTKPyyGmkJ8Zg8Yw0o0shP9PSErC+bCZeqDqB1jMDRpdDUYQBRqYw6B7BziNtuGFBDgfwDUObri3EiFJ4dBdbYaQfvhOQKeyu60TPoBs3LZpmdCl0EbMyEvHJZTOwdU8z2nsGjS6HogQDjEzh1YOtSI6z4ao5wU7iTXr78nWFGB7x4PF3GowuhaIEA4zCnnvEgzeOnMaaomzE2axGl0NjKHAk4+8un46n/9oEZ9+Q0eVQFGCAUdh7r9GJrr4h3Lgo1+hSKICvrpmDs0MjeOIvx4wuhaIAA4zC3muHWhFns+DaeZxtO9zNy0nBjQtz8cTuRnQPDBtdDkU4BhiFNY9H4dWDrbh2ngNJcTajy6EgfHXNHPQMuPHU7kajS6EIp3uAich6ESkXkc3j7FMy0WMoMh044UJr9wBPH5rIohlpWFOUjV+/c4wTXtKU0jXAfMGklKoE4BodVNo+5QAem8gxFLlePdQKm0WwtijH6FJoAr66Zg6cZ4fx3N5mo0uhCKZ3C2wjAJf2vAFA+egdtKDqmsgxFJmUUnjtYCuuLMxEWiJnXzaTkrx0rCzIwONvH8OQ22N0ORSh9A4wOy4Mp2Bu6pnMMRQBalt70Nh5lqcPTWrTdXPQ2j2AF/e3GF0KRSh24qCw9erBVogA6xYwwMxo9dwsLJiWikfeqofHo4wuhyKQ3gHmAuCbStcOoDMUx4hIhYhUiUhVe3v7JRdJ4eG1Q61Ynp8BR0qc0aXQJIgINl1XiIb2Prx++LTR5VAE0jvAtgEo0J4XAKgEABGxT/QYf0qpLUqpMqVUmcPBe4UiwbGOPtS29uBjPH1oajctykV+ZiJ+9VY9lGIrjEJL1wBTStUA53oaunzLAHb49hGR9QDKtMfxjqEI9tqhVgDAxxay96GZ2awWVKwuwIHjLvy1IZgTLkTB0/3OUKXUlousK/V7vh3A9kDHUGR75WArLp+ZhpnpiUaXQpfoUyUz8dM3PsSv/lyPqwqzjC6HIgg7cVDYOenqx4HjLnxsIU8fRoL4GCu+uOoyvP1hBw62nDG6HIogDDAKO69rpw/ZfT5y3LkyDylxNvzqLU54SaHDAKOw8+qhVszNTkahI9noUihEUuNj8Nkr8/HK307hWEef0eVQhGCAUVg5fLIbe491sfUVge65ejZsVgu27OKElxQaDDAKG/1DI/j6b/chKzkO91x9mdHlUIhlp8Tj9tKZ+F31CbR1DxhdDkUABhiFjR/812HUtfXiJxuWIiMp1uhyaApUrC6A2+PBrznhJYUAA4zCwuuHWvHsnmZUrC7Aqrnsah2p8jOTcMvl0/Hsu81w9g0ZXQ6ZHAOMDHe6ewDf/t37WDQjFQ+sm290OTTFvnr9HPQOuvH4O7wWRpeGAUaG8ngUvvn8fgwMe/Afn16GWBt/JSPd/NwU3LJ4Gp78SyNbYXRJ+G5Bhnrs7Qb8pa4T//jxBew2H0W+UT4XZ4dH8NjbbIXR5DHAyDAHW87gx69/gBsX5uLTy2cZXQ7paF6OtxX2m92N6GIrjCaJAUaGODvkxtef24fMpDj88FOLISJGl0Q6+8ZabyuM94XRZDHASHcnXf342tZ9ONbZh59sXAJ7IrvMR6O5OSn4+OXT8dRfG9HZO2h0OWRCDDDSTffAMB56tRbX//jPeLuuAw/esoCjk0e5r6+diwG2wmiSdJ9OhaLPkNuDrXua8LOddejqG8Inl83AP6ybx6lSCHOyk/GJJdPx1F+bcN/qAmQlc/ZtCh4DjKaMUgqvHmzFQ6/WorHzLK4qzMR3by7GohlpRpdGYeRra+fipQMnsWVXA757c7HR5ZCJMMBoSgy6R/DAC+/j5QMnMS8nGU/cvRzXzXewswZ9RKEjGX+/dAae+msj7rumAI4UtsIoOLwGRiF3pn8Yn/v1Xrx84CQeWDcP//31a3B9UTbDi8b0tTVzMOT24FHOF0YToHuAich6ESkXkc3BbheRh7THCr3qpMk56erH7Y/sRk2zE/++cSm+umYubFZ+TqLxFTiSceuyGXhmTxPaejhSPQVH13cWESkBAKVUJQCXbzmI7RUiUg+AXZXC2JFT3bjtl7txyjWAJ+9ZgVuXzTC6JDKRr6+Zi+ERhV/srDO6FDIJvT8abwTg0p43ACgPcvvtSqlCLdgoDO2u68CGR/4KAHj+S1fi6jnsHk8TMzsrCXesmIWn323C306cMbocMgG9A8wOoMtvOTPI7SXjnXYkY/1xfws+/8ReTLPH4/dfvgrF01KNLolM6lsfK0Jmchz+1x/eh3vEY3Q5FOZMcXFCKfWw1vrKFJHRrTaISIWIVIlIVXt7uwEVRq9X/nYK3/jtfpTkpeOFL12F6fYEo0siE0tLiMH3P74QB1u68eTuRqPLoTCnd4C5AGRoz+0AOgNt1zp1rNfWdQIoGP2iSqktSqkypVSZw+EIcck0lsMnu/HN5w9gWZ4dv/nCCqQlxBhdEkWAmxfn4vr5DvzkjaNocfUbXQ6FMb0DbBvOB1ABgEoAEBH7ONsbfPsBKARQpUehNL6O3kHc91QV0hJi8OhnSxEfYzW6JIoQIoL/8/eLoBTwjy8ehFLK6JIoTOkaYEqpGgDQTgO6fMsAdoy1XVu3QWuF1fsdQwYZcnvw5Wdq0NE7iC2fK0V2arzRJVGEmZWRiG/eMA87atvwysFWo8uhMKX7SBxKqS0XWVcaYPtH1pExlFL4p5cOYm9jF/7j00tx+Uy70SVRhLrn6tl4cX8Lvv/SIayam4XUeJ6ipguZohMHhY+n323Cc3uP48vXFeLvl/I+L5o6NqsF/3bbYnT0DuLhV2uNLofCEAOMgra7rgP//PJhlBdn44F1840uh6LA5TPt+PxVs/HsnmZUNzmNLofCDAOMgtLU2Ycvb61BQVYSfrpxKSwWjmtI+viHdfORmxqP7/7+bxjmvWHkhwFGAXX1DeGLv6mCUsDjny9DCq9FkI6S42z4508sxAene/CPfzzEXol0DgOMxtUzMIy7n9iL411n8ehdpcjPTDK6JIpC6xbmYtN1hXhubzN+9NoHRpdDYYLzgdGYBoZHcO9vqnD4ZDe2fK4UKwtGj/xFpJ/NH5sP19lh/PLP9UhPjMV9qz8ypgFFGQYYXdSQ24MvP1uDvY1d+PeNS7GmKMfokijKiQh+cOsidA8M41//+wjSEmKwYfkso8siAzHA6CNGPArffH4/dta24V8/uYjd5SlsWC2Cn25Yiu7+YXzn9+8jNcGGGxdNM7osMgivgdEFlFJ48MWD+NP7p/Cdm4pw5xX5RpdEdIFYmwWP3lWKJbPs+Ppz+/GXug6jSyKDMMDoHKUUfvhKLZ7b24yvXF+IL11baHRJRBeVGGvDE3cvx2VZSah4qgoHjruMLokMwAAjAN7Thj98pRaP7mrAXSvzeaMyhT17Yiye+uIKZCTH4q5f78Ef97ewi32UYYARnH1DuPuJvXh0VwPuvCIP//yJhRDhjcoU/nJS47H13pUocCTjG7/dj4qnq9HWPWB0WaQTBliUO9hyBh//+TvY09CFf7ttMf71k4s5ygaZyqyMRPxu01X43s3F2HW0HeU/eQvbq0+wNRYFGGBR7A/7TuBTv9oN94jCtvtX4o4VeUaXRDQpVovgvtUFeOUb12B+bgoeeOEA7nnyPZw6wwkxIxkDLAoNj3jw/ZcO4X9uO4Als+x4+WursCwv3eiyiC5ZgSMZ2yquxD99fAH2NHRh3U924fG3G9AzMGx0aTQFJNKa2WVlZaqqipM2j+XwyW58/6VD2NvYhS9cfRn+181FiLHycwxFnubOs/juH/6Gd+o6kBRrxadKZ+JzV87GnOxko0sLSyJSrZQqM7qOiWCARQGlFN5t6MIjb9XjraPtSI6z8QZlihrvn3Dhyd2N+NOBUxga8eCauVn43JWzsaYoG1Ze7z2HARbMNxRZD8AFoEQp9XAw2wMd448Bdp7Ho/D64dN45K167D/uQlZyLO65+jJ89op8pCVyRHmKLh29g9j23nE8824TTp0ZwKyMBNy4MBdXzcnCitkZSIqL7oGJzBhguv6PiUgJACilKkWkQERKlFI14233bRvrGDpPKYW2nkHUt/fiyKkePLunCQ3tfcjLSMS/3LoIt5fORHyM1egyiQyRlRyHr1w/B/evLsDrh09j655m/GZ3Ex57+xhsFsHSWXZcVZiJq+ZkYVmeHXE2/q2EO70/cmwE8Ib2vAFAOYCaANszAxxjOKUU3B6FIbcHQ24PBtwj6Bt0o2fAjb7BEfQODqN3cAS9A8M4OzyCwWHvPoPDHgy6PRh0j2DQ7YFFBLFWC2JtFsRaxftosyDGaoFVBFareB8tAov22DMwjPr2PjS096K+vQ+9g+5zdS2Yloqf3bEMNy/KhY3XuYgAADarBTcvnoabF0/DwPAIqhqd+Et9B3bXd+Lnb9bhZzvrEGMVTLcnYIbvKz0BM9MTMcOeAEdKHBJirYi3WbRHK289MYjeAWYH0OW3PHp+jottD3TMBT5o7cG1P3pzQkWNdRZVQUEpaF8KHgV4tEelFIZGvIE1NOIZ8zXGEmezeL9irOeee5R3FPhBtwfDfq894hn/xaenxaMwOxmfKpmBwuxkFDqSUeBIQm5qPG9IJhpHfIwVq+ZmYdXcLADAmf5h7D3WhZpmJ044+9HiPItdH7bjdPfguK8TZ7MgPsaKGKtARGARwCLeD5oi8H5h7L9F/plOTkSc9BWRCgAVAJA6vQDLZtkn8xoXX69tO/cLafGutQgQY/UGj7fFZDnXYoqzWZEcb0NKnA1JcTYkx9mQEu99TIi1ItZqmdAnNo9HYUQpjHi0L6W86zwKCbFWJMZGxH8jkeHSEmJww4Ic3LDgwumDBt0jOOUaQIurHx29gxgc9qB/eAT9wyMY8D0OjcDtOf8B1+P3oXe8D7jh0pFul9EFTILe73wuABnaczuAziC3j3cMlFJbAGwBvJ04/v3Ty0JTbZiwWAQWCHj5isgYcTYrZmclYXZW5M5I/h93GF3BxOkdYNsA+Hq5FACoBAARsSulXGNtH2MdERFFMV2v7Pt6D4pIOQCXX2/CHWNtH+cYIiKKYrpfPNFO941eVxpg+0fWERFRdGPfaiIiMiUGGBERmRIDjIiITIkBRkREpsQAIyIiU4q46VREpB1Ak8FlZAHoMLiGcMGfxXn8WZzHn8V54fKzyFdKOYwuYiIiLsDCgYhUmW1agqnCn8V5/Fmcx5/FefxZTB5PIRIRkSkxwIiIyJQYYFODI4ecx5/FefxZnMefxXn8WUwSr4HpREQ2K6UeNroOIgo/fH+YHE4kpQNtIOLlRtdhNG3eNgAoVEp929BidCYi6+GdLqgk2t+oovn34GL4/jB5PIVIutD+SCu1gZkLtOWoICIlAKCUqgTg8i1Ho2j+PaDQY4BNMREp0d64ol0BAN+bVYO2HC02wtv6Arz/9mh+047m34OP4PvDpeEpxKmXEXiXyDdqSpwSeCcvjRZ2AF1+y5kG1WG4KP89uBi+P1wCBtgl8juf769BKVXJT1cfpZ0+e4MTk0Y3/h6w9RUKDLBLFGCyzQIRKfB7XhLJf7DjhbnfcnkUdmJw4fwnbTuATsMqCR/R+HswWlS9P0wFBtgUUkptB869sduNrWbqBZo5W0QqfG9aIlIeRZ8+twHwDRVUACBa/t0XFcW/BxeItveHqcD7wEgXWm+zF+C9FpQB4PZoeuPS3qQaABQECvpIFu2/BxRaDDAiIjIldqMnIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKbEACMiIlNigBHpQERKRKReRF7wW7YbXBaRqTHAiPRRDqAUwKO+UfuVUi5DKyIyOY6FSKQjrdWVoZRqMLoWIrNjgBHpxHfKkC0votDgKUQiHfgmLvSFl99EhkQ0SZzQkmiKiUgJvBNadolIJbzXw1zwzg9GRJPEFhjRFPI7bbgF3tmYjwFYzkkciS4dr4EREZEpsQVGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKb0/wEFZshz/FLIqwAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -15714,7 +15425,7 @@ Spline knots [[-5. -5. -5. -5. -3. -2. -1.  0.  1.  2.  3.  5.  5.  5.  5.]] [[ 
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAArS0lEQVR4nO3de3hT95kn8O8ryRcMtoWx8EVchIFwCeALhgRDOk3GJBCSYBInTTNNAk+z9DKbdp5nMunMdrvP7rRzCd3dJ21mnmlotiFpMmkSGhxCbrXbpg0YAgZjwiUXMAYjY2PjKxhfZP32Dx+DMJYt29I5OtL38zw81tE5R3rRI+vr39F7fkeUUiAiIjIbi9EFEBERjQUDjIiITIkBRkREpsQAIyIiU7IZXQAREY3OwYMHp9psthcALELkD0S8AI56PJ4nli5desF3BQOMiMhkbDbbC+np6QscDkeLxWKJ6FZyr9crjY2NC+vr618AcJ/vukhPbiKiSLTI4XC0R3p4AYDFYlEOh6MN/aPN69cZUA8REY2PJRrCa4D2f70hrxhgREQUEiUlJYkFBQVzAeD48eOxa9euzQrm4zPAiIgoJIqKijqSk5P7AGDhwoU977//fnUwH59NHEREJvZ326umf1HfkRDMx7wpPbHzp8XZtf7W7969O6Gpqcna0tJimzx5sgcAfvjDH077p3/6p3MnT56MmzNnTndRUVHH4H2efvppZ3l5+ZclJSWJW7ZsSX/66afrKyoqEtasWdMxf/787meffTY1Pz+/8+TJk3FPPfVU00h1cgRGRESj8uqrr04GgE2bNrXcdNNN3dpIy1NUVNTx1FNPNT355JMzB++zatWqzoHRWFFRUUdtbW1cUVFRxyOPPNLy6quvTv7Rj36UvmbNmo6ioqKOQ4cOTQykDo7AiIhMbLiRUqj8+Mc/rn/00UdnPvnkkzNfe+21agA9A+EEANOnT+8+fvx47MKFC3v8PcaiRYs6fZerqqoS7rrrrvbdu3cnfPe7320MpA6OwIiIaFTeeeedpPfff7+6srLyxAcffJAIAG1tbdaB9bW1tXHDhddQ7rjjjnagf6Q2f/787kD24QiMiIhGZf/+/QkAMHfu3O5HHnmkBQDa2tpsu3fvTti3b1/Cc889dwbo/97r6NGjCcePH49tbm62DXX7vffeS6qqqkrYuXNn9bPPPps68ByDv0MbivB6YERE5lJVVVWTnZ09YpODntauXZsV7C5DX1VVVanZ2dku3/t4CJGIiMalpKQkcWBEpefzMsCIiGhctK7Co6P93mu8GGBERGRKDDAiIvPxer1eMboIvWj/V+/g+xlgRETmc7SxsTE5GkJMu5xKMoCjg9exjZ6IyGQ8Hs8T9fX1L9TX10fVBS0Hr2AbPRERmVKkJzcREUUoBhgREZkSA4yIiEyJAUZERKbEACMiIlNigBERkSkxwIiIyJQYYEREZEoMMCIiMiUGGBERmRIDjIiITIkBRkREphRxs9GnpqYql8tldBlERKZy8ODBJqWUw+g6RiPiAszlcqGiosLoMoiITEVEzhhdw2jxECIREZkSA4yIiEyJAUZERKbEACMiIlPSPcBEpFhECkVk8wjbPTPafYiIKHroGmAiUgwASqkybbnQz3aFALJGsw8REUUXvUdgywBUa7erAeQN3kBEsny2CWgfIiKKPnoHmH3Q8pQhtslSSvkGWCD7EIW1sxc7sf3gOaPLIIooep/I3Aogxd9KESkcOFQY6D7afpsBbAaAGTNmjK9CohD48bvHUXq8AfPTE7HImWx0OUQRQe8R2AFcG1FlASgdtL5Za9YoBpAlInkB7AOl1FalVL5SKt/hMNVMKBQFaps7UXaiAQDwUnmNscUQRRBdA0wptR39wVQIwO7TmFGqrT+k3ZcCLbT87UNkFi+V18AqgtUL0/B2VR0uXuo2uiSiiKB7G71SaotSqkwptcXnvtWDttmqlJqtlDrkbx8iM7jc7cHrFbVYuzgDT981Dz0eL17bf9bosogiAk9kJgqhtyrd6OjyYGOBC3PTEnHb3FT8et8Z9PZ5jS6NyPQYYEQhopTCtj2nsWRaMvJm2AEAGwtcaGjvxgdH640tjigCMMCIQmT3ySacaryMjQUuiAgA4PZ5UzFzSgK2sZmDaNwYYEQh8uKeGqROisO6JRlX77NYBI+vcOHgmRYcOddqXHFEEYABRhQCp5su4w+fXcBf3TIDcTbrdeuK86dhYqwV2/bUGFMcUYRggBGFwMt7axBjFfzVLTeeWJ8UH4PipdPwzpE6XOjoMqA6osjAACMKskvdHrxZcQ7rFmdgalL8kNs8VuBCb5/Ca5/U6lwdUeRggBEF2W8PnsOlbg82rpzld5vZjkn4i5sceOWTM+jxsKWeaCwYYERB5PUqbCuvQe4MO3Km24fddtNKFxo7uvHep+f1KY4owjDAiILoT1824nRTf+v8SL4y14Gs1Il4kS31RGPCACMKom17ajA1MQ5rF2WMuK3FIni8wIWq2lZUnm3RoTqiyMIAIwqSU42X8KcvGvGNW2ci1hbYr9YDS6dhUpyNJzYTjQEDjChIXi6vQazVgq8vD/yadJPibHgwfxrePXIeDe1sqScaDQYYURC0d/Vi+8FzuDc7E47EuFHt+/gKF/qUwqv7zoSoOqLIxAAjCoI3K87hck9fQM0bg7lSJ+KOeVPx6idn0e3pC35xRBGKAUY0Tn1ehZfKa5A/czIWT0se02NsXOnCxcs92FXFlnqiQDHAiMbpo88v4GxzJzaudI35MVbNScWcqZOwrbwGSqngFUcUwXQPMBEpFpFCEdnsZ32h9u8Zn/taRKRURJ7Wr1KiwGwrr0F6Ujzuujl9zI8hIthY4MKn7jYcYks9UUB0DTARKQYApVSZtlw4aH0egDxtfZ6IZGmrHlRKrVZKbdGzXqKRfNnQgY+/bMKjK2Yixjq+X6f785xIjLfhV5ylniggeo/AlgGo1m5XA8jzXamUOqSU2iIidgDVSqmBbe0+YUYUNraV1yDWNrrWeX8SYm14eNl0fHC0HufbrgShOqLIpneA2QctT/GzXT6AUz7LKQCaReT5oTYWkc0iUiEiFY2NjeOvkigAbZ29eOuQG0U5mUiZGBuUx3xshQtepfAKW+qJRqR3gLWiP4yGpR1CnO1zyHGrUqoVQOvAfYO236qUyldK5TscjiCXTDS0NypqcaW3D4+PoXXen+kpCShckIb//OQsunrZUk80HL0D7ACujcKyAJT6rhSRZ3yaO1oBpGijq+sONRIZrc+r8NLeGiyflYKbM8fWOu/PppUutHT2YmdVXVAflyjS6BpgSqntALK05g27TzPHQJA9D6DaZ/1WAG9o2xT7PAaRoX5/ogHnWq5gUxBHXwNWZE3BvLREbNvDlnqi4dj0fkKfTsIyn/tWaz+rca3Jo0y7rxXAIe0fw4vCwot7auC0T8DqhWlBf2wRwcaVLvzDW59i/+lm3JLl76tioujGE5mJRumz+nbsrb6IR1fMhG2crfP+FOU4kTwhhrPUEw2DAUY0Si+V1yA+xoKHl00P2XNMiLXi4eXT8eGxerhb2VJPNBQGGNEotFzuwY5KNzbkOmFPCE7rvD+PrXABAH69ly31RENhgBGNwusVtejq9Qa1dd4fp30C7ro5Hb85cBZXethSTzQYA4woQJ4+L14ur0HB7CmYn56ky3NuLHChtbMXJYfdujwfkZkwwIgCVHq8AXVtXWO65tdYLZ+VggUZSWypJxoCA4woQC+W12Da5An4ywXBb533R0SwqcCFzxs6sLf6om7PS2QGDDCiAByra8P+0814fIULVovo+tz3aXMtbuMs9UTXYYARBeCl8hpMiLHiofzQtc77Ex9jxdeXT0fZiQbUNnfq/vxE4YoBRjSCi5e6UXK4Dg8sdSI5IcaQGr5x60yICF7eW2PI8xOFIwYY0Qh+c6AWPR4vHtfOyzJCRvIErFmUjt8cqMXlbo9hdRCFEwYY0TB6+7z49d4zuG1uKuamJRpay6YCFzq6PNhRyZZ6IoABRjSsD4/Vo75d39Z5f5bOnIzFzmRsK2dLPRHAACMa1rY9NZg5JQG3z5tqdCn9s9QXuHDywiXsOcmWeiIGGJEfn55rQ8WZFjy+wgWLzq3z/tyTnYHUSbF4cc9po0shMhwDjMiPF8tPY2KsFcX504wu5ao4mxWPLJ+BP3x+ATVNl40uh8hQDDCiITR2dGNX1XkUL52GpHhjWuf9+catM2EVwcucpZ6inO4BJiLFIlIoIpv9rC/U/j0T6D5Ewfba/rPo6fPisTBo3hhsalI81i3JwJsVtbjElnqKYroGmIgUA4BSqkxbLhy0Pg9AnrY+T0SyRtqHKNh6PF68su8M/uImB2Y7JhldzpA2FrjQ0e3BW4fOGV0KkWH0HoEtA1Ct3a4GkOe7Uil1SCm1RUTsAKqVUtUj7UMUbO8fPY8LHd3YtNJldCl+5c6YjOzpdmzbUwOvly31FJ30DjD7oOUpfrbLB3Aq0H1EZLOIVIhIRWNj47gKJHpxTw2yUifiK3MdRpcyrE0FLlQ3Xcafv+R7nqKT3gHWCiBlpI20w4WztcOHI+6jlNqqlMpXSuU7HOH9oUPhrfJsCw7XtuLxgvBpnffn7sUZcCTGYVt5jdGlEBlC7wA7gGsjqiwApb4rReQZn0aNVvQH17D7EAXTS+U1mBRnwwNLw6d13p9YmwXfuGUmPvq8EdWNl4wuh0h3ugaYUmo7gCytEcPu05gxEErPA6j2Wb/V3z5EwXahvQvvfnoeD+ZPw6Q4m9HlBOSRW2YgxsqWeopOuv+WKqW2aDfLfO5brf2sxrWGjbLh9iEKtlc/OQuPVxk66/xoORLjcO+STLxZUYu/vfMmJIbZOWtEocQTmYkAdHv68OonZ3DHvKlwpU40upxR2bjShcs9fXizgi31FF0YYEQA3j1yHk2XerAxjFvn/VkyzY6lMyfjpb1sqafowgCjqKeUwot7ajBn6iSsmpNqdDljsrHAhTMXO/HRFxeMLoVINwwwinqHzrbiU3cbHi9wQSS8W+f9WbMoHWlJcXhxT43RpRDphgFGUW9beQ0S4224P9dpdCljFmO14NFbZ+LjL5tw8kKH0eUQ6YIBRlGtvq0L7396Hg8vm46JJmmd9+fry2cg1mbhic0UNRhgFNVe2XcGfUrhMRO1zvszZVIc1mdn4rcH3Wi70mt0OUQhxwCjqNXV24f/3H8WhQvSMD0lwehyguLxAheu9PbhzYpao0shCjkGGEWtd6rq0Hy5B5vC8JpfY7XImYzlrhS8tLcGfWyppwjHAKOopJTCtvIazEtLxIrZ/i6KYE4bV7pQ23wFf/iMLfUU2RhgFJUO1LTgWF07Nq40b+u8P3cuTENmcjxe3HPa6FKIQooBRlFpW/lpJE+IQVGOeVvn/bFZLXh0hQvlpy7i83q21FPkYoBR1HG3XsGHxxrw8PLpmBBrNbqckHh42XTEsaWeIhwDjKLOK/vOQCmFR2+daXQpITN5Yiw25Dqxo/IcWjt7jC6HKCQYYBRVunr78Nr+s7hzYTqmTY6M1nl/Hi9woavXi9cPsKWeIhMDjKJKSaUbrZ292GTCWedHa0FGEm7NSsHLe8/A0+c1uhyioGOAUdQYaJ1fkJGE5bNSjC5HF5tWzoK79QrKTjQYXQpR0OkeYCJSLCKFIrJ5iHV2EcnTtnnG5/4WESkVkaf1rZYiyb7qZnxW34FNJp51frQKF6TBaZ/AWeopIukaYCJSDABKqTJtuXDQJg8ByFdKbdfWD4Tcg0qp1UqpLboVSxFnW/lpTE6IwX05mUaXohurRfB4wUx8croZx+vajS6HKKj0HoEtA1Ct3a4GkOe7Uim1VSm1VVvM8tnWLiJZ+pRIkai2uROlxxvw9eUzEB8Tma3z/nwtfwYmxFjxElvqKcLoHWD2QctDzuGjhVXzwEgNQAqAZhF53s/2m0WkQkQqGhsbg1YsRY5X9p2BiODRFZHbOu9PckIM7s9zouSwG82X2VJPkUPvAGtFfxiNpFgp9a2BBW1k1gqgdeAwpC9tfb5SKt/hcAStWIoMnT0evLb/LNYsSkdG8gSjyzHExgIXuj1evLb/rNGlEAWN3gF2ANdGYVkASgdvICLFA991aQ0dm0Ukb/B2RIHaUelGe5cnomadH625aYlYNScVr+w7g1621FOE0DXAtOaMLK15w+7TzFGq/SwE8IyIHBSRg+gfrb2hrSv2eQyigCil8FJ5DRY5k7B05mSjyzHUxgIXzrd14XfH2FJPkUH3a6j7dBKW+dy3WvtZBmD2ELsd0v4xvGhUjpxrwxcNl/Cv9y+OmtZ5f26fPxWZyfHYfrAW65ZkGF0O0bjxRGaKaDsq3Yi1WbB2MT+wrRbB+lwn/vxlE5oudRtdDtG4McAoYvX2efFOVR0KF0xF8oQYo8sJCxtynejzKuyqqjO6FKJxY4BRxNp9sgkXL/dE5DW/xuqmtEQszEjCjsMMMDI/BhhFrJJKN+wJMfjqvKlGlxJWNuQ6UVXbiurGS0aXQjQuDDCKSJe6PfjwWD3WLc5ArI1vc1/35WRCBCjhKIxMjr/ZFJF+d6weXb1ebMjl4cPB0pLisXJ2Kkoq3VBKGV0O0ZiNOsBEJEdE7heRp0TkCe12TghqIxqzHZVuTJs8IerP/fKnKNeJs82dOHS21ehSiMYsoAATEZeI/EJEPgTwLfSfq9UGQLTb3xaR34nIf4iIK2TVEgXgQnsX9pxswoZcZ9Sf++XPXTenIT7GgpJKt9GlEI3ZiCcyi8jfoX9GjB8opdpG2DYZwGYRaVFKvRCkGolGZWdVHbyqf5RBQ0uMj8HqhenYdaQOP7pnIb8nJFMa9l2rhdd2pdQ/jBReAKCUalNK/RTA70XkqWAVSTQaJYfdyJ6WjNmOSUaXEtY25GaipbMXf/6CV3Agcxo2wJRSP1VKnR7tgyqlTiul/vfYyyIamy8bOnDU3c7RVwBum+tAysRY7DjMw4hkTmNp4nCFoA6ioCg57IbVIrhnSfRcdXmsYqwW3LskA2XHG9De1Wt0OUSjNpYD35NF5ImBBRF5QETuCGJNRGPi9SqUVNbhtrmpcCTGGV2OKRTlOtHt8eKDo/VGl0I0aqMOMKVUJYA5A6GllPotgDtF5JvBLo5oNCrOtMDdeoXnfo1CznQ7XFMS2I1IpjSWQ4gfAlAADvqc//UvALb43YlIBzsq3UiItWL1wjSjSzENEUFRrhN7qy/ifNsVo8shGpWxHEKcDeB5rStRtNb5X2r/iAzR7enDu0fqsObmdCTE6n6ZO1MrynFCKWAnp5YikxlLgN0J4AcikqQdTiwEsF8p9ffBLY0ocH/8rBHtXR52H46BK3UicmfYsYOHEclkxvIdWLVS6jtKqXZt+bcA2gJt5BCRYhEpFJHNQ6yzi0iets0zgexDBPTPPO9IjEPB7ClGl2JK9+c68Vl9B06cbze6FKKABeX0e6XULwGMeL6YiBRr25dpy4WDNnkIQL5Saru2fnMA+1CUa+vsxR8+u4D7sjNhs3JGibFYtyQTNoughOeEkYkE7bc9wBOelwGo1m5XA8gb9BhblVJbtcUsbZth9yF67+h59PRx5vnxSJkYi6/Oc+Dtyjp4vZyhnsxhxKmkxnLisojM8jOVlH3Q8pDHe0QkC0CzNuoacR9tpFYhIhWNjZwWJ9rsqHRjztRJuDkzyehSTK0o14n69i7sO33R6FKIAjLiVFIAVovIvwQSZCKSJCL/CuABP1NJtaJ/YuCRFCulvhXoPtrILV8ple9wOAJ4eIoU51o6sf90M2eeD4LCBWmYFGfjOWFkGiP2Gyulfikis9B/yZRc9B/GawVwCv2joynaz9nafVuGOZx4ANdGVFkASgdvICLFSqkt2u28QPah6PW21vp9Xzanjhqv+Bgr1i5Kx/uf1uMf1y9CfIzV6JKIhhXQd2Da5Lx/r5S6C/0nLJeh/1pgbQAqAGxVSt2pdSf6/S5Ma87I0hox7D6NGaXaz0IAz4jIQRE5CCDF3z5ESinsqHRjuSsF01MSjC4nImzIdaKj24Pfn7hgdClEIxr1GZ9aQJ0G8PuxPOHA6Ar9IThw32rtZxn6R3Ij7kN0rK4dJy9cwj9vWGx0KRHjlqwpSE+Kx45KN9YtyTC6HKJhjakLUUSe0L4Xe0JE+M05GWJHpRuxVgvWLeYHbbBYLYL1OZn46PMLaL7cY3Q5RMMay1yIvwAwB/2HEB8CcJoT+ZLePH1e7Kyqw+3zHUhOiDG6nIhSlOuEx6vw7hFOLUXhbSwjsFLt+7C/V0rdif5DfnNF5P4g10bkV/mpi2js6Oa5XyGwICMJ89MTObUUhb1xn8islGrV5kHkHD6km5JKN5LibfjqvKlGlxKRinKdOHS2FWcuXja6FCK/xhJg1SJyQEQ2DPr+i2c/ki46ezz44Fg91i3JYKt3iNyXnQkRoKSShxEpfI0lwL4G4A0AXwdQo4XZ6+g/RwsAwCs0UyiVHm9AZ08finJ4+DBUMu0TcOusKSg57IZSnFqKwtNYAuwUgDeVUg8ppVIAbEb/uWB3ishFETkA4JlhH4FoHHZUuuG0T8AyVyCTutBYbch14nTTZVSdazO6FKIhjeVyKr8EMHlgaimlVKVS6qfaicxTAHwLQEtwyyTq19jRjY+/bML6nExYLJw6KpTWLE5HrM3CqaUobI2piUMLrRo/6w4B+MF4iiLyZ9eROvR5FbsPdZAUH4PVC9LwTlUdevu8RpdDdIOQXDxJu1IzUdCVVLpxc2YS5qYlGl1KVCjKdeLi5R7s/rLJ6FKIbsCr/5FpnGq8hKpzbRx96egvbnLAnhDDc8IoLDHAyDTernTDIsC9nHleN7E2C+5ZkoHfHa/HpW6P0eUQXYcBRqaglMKOw26snJOKtKR4o8uJKhtynejq9eLDo/VGl0J0HQYYmcKhsy2obb7Cc78MkDdjMqanTEDJYR5GpPDCACNT2FHpRnyMBXctSje6lKgjItiQ48Sek01oaO8yuhyiqxhgFPZ6PF7sOnIedy5Mx6S4UV/CjoJgfa4TXgW8U8WppSh86B5gIlIsIoUisnmY9aWD7msRkVIReVqfKimc/OmLRrR29rL70ECzHZOQPS2Z3YgUVnQNMBEpBq5eeRkiUjh4G6XU9iF2fVAptdrnyswURUoq3ZgyMRar5qYaXUpUK8p14lhdO75o6DC6FCIA+o/AlgGo1m5XA8gLcD+7iGSNvBlFmvauXpSeaMC92ZmIsfKIt5HuWZIJq0U4tRSFDb0/EeyDlgO9hlgKgGYReT645VC4++DTevR4vCji4UPDORLjcNvcVLx9uA5eL2eoJ+PpHWCt6A+jUVFKbVVKtQJoHTgM6UtENotIhYhUNDY2jr9KChs7Kt2YlToR2dOSjS6F0H9OmLv1Cg7UNBtdCpHuAXYA10ZhWQBK/W/aTwunYQ81agGXr5TKdzgc46+SwkJd6xXsO30RRTlOiHDm+XCwemEaEmKtPCeMwoKuAaY1aGRpzRt2n2aOq0Gmrcv3GWm9od1f7PMYFAV2VtVBKaAol1NHhYuEWBvW3JyOXUfOo6u3z+hyKMrpflKNTydhmc99q31ulwGY7LPcCuCQ9o/hFUVKKt3Im2HHzCkTjS6FfBTlOvFWpRsffX4BaxZlGF0ORTG2dVFYOnG+HZ/Vd/DcrzBUMHsKHIlxPCeMDMcAo7BUUumGzSJYt4SHD8ONzWrBfdmZ+ONnjWjt7DG6HIpiDDAKO31ehbcP1+Gr8xxImRhrdDk0hA25TvT0efHep5yhnozDAKOw80n1RdS3d/HcrzB2c2YS5kydxJOayVAMMAo7OyrdmBRnQ+GCNKNLIT9EBBtyndhf04za5k6jy6EoxQCjsNLV24f3j9Zj7aJ0xMdYjS6HhnGfdmXsnZyhngzCAKOwUnaiAZe6Pew+NIHpKQlY7krBW4fOQSlOLUX6Y4BRWCmpdCM9KR63ZAU6TSYZqSjXiVONl3Gsrt3oUigKMcAobDRf7sFHnzdifU7/rOcU/tYtzkCs1cJzwsgQDDAKG+8eqYPHq7Ahj4cPzSI5IQa3z3dgZ1UdPH1eo8uhKMMAo7Cxo9KN+emJmJ+eZHQpNAobcp1o7OhG+amLRpdCUYYBRmHhzMXLOHS2lc0bJvTVeVORFG/jOWGkOwYYhYWSyjqIAPflcOoos4mPsWLdkgx8cKwenT0eo8uhKMIAI8MppVBy2I0VWVOQkTzB6HJoDIpynOjs6UPp8QajS6EowgAjw1Wda8PppsucOsrElrlS4LRPYDci6YoBRoYrqXQjzmbBmkXpRpdCY2SxCNbnZOLjL5vQ2NFtdDkUJRhgZKjePi/eqapD4cI0JMXHGF0OjcOGXCf6vAq7jnBqKdKH7gEmIsUiUigim4dZXzqafci8dn/ZhIuXe7Ahh4cPzW5uWiJuzkxiNyLpRtcAE5FiAFBKlWnLhYO3UUptH+0+ZF47Kt2YnBCDr9zkMLoUCoINuU5UnWvDqcZLRpdCUUDvEdgyANXa7WoAeSHah0zgUrcHvztej3uWZCLWxqPZkeDe7ExYBHibozDSgd6fGvZBy4HM2DriPiKyWUQqRKSisbFxjKWR3j48Wo+uXi+7DyNIWlI8Vs5JxY7Dbs5QTyGnd4C1AkgJ9j5Kqa1KqXylVL7DwUNRZlFy2I0ZKQnIm2E3uhQKoqIcJ2qbr+DQ2RajS6EIp3eAHcC1EVUWgFL/m45rHwpzDe1d2HOyCUW5Tohw5vlIcteidMTHcIZ6Cj1dA0xr0MjSGjHsPo0ZV0NJW5fv07wx5D5kbu9U1cGrgCJOHRVxJsXZcOfCdOw6ch49Hs5QT6Fj0/sJlVJbtJtlPvet9rldBmDySPuQue2odCN7uh1ZjklGl0IhsCHXiZ1VdfjTF41YvTDN6HIoQrH1i3T3RUMHjtW1YwNHXxFr1dxUTJkYy3PCKKQYYKS7kko3rBbBPdkMsEgVY7Xg3uxMlJ5oQHtXr9HlUIRigJGuvF6Ftw/X4StzU5E6Kc7ociiEinKd6PF48cGn9UaXQhGKAUa6OlDTDHfrFZ77FQWypyVjVupEdiNSyDDASFclh92YGGvFnQs583ykExEU5Tix7/RF1LVeMbocikAMMNJNV28fdh05j7sWpWNCrNXockgHRbmZUArYWcUZ6in4GGCkm48+v4COLg828PBh1Jg5ZSLyZtjZjUghwQAj3bx1yA1HYhwKZqcaXQrpaEOuE5/Vd+B4XbvRpVCEYYCRLlo7e/DHzy9gfXYmrBZOHRVN1i3JhM0iKDnMURgFFwOMdPHup+fR26fYfRiFUibG4qvzHHj7sBt9Xs5QT8HDACNdlFS6MXfqJNycmWR0KWSAolwnGtq7sa/6otGlUARhgFHI1TZ34kBNC2eej2KFC9IwKc7Gc8IoqBhgFHJva999rOfch1ErPsaKtYvS8cHRelzp6TO6HIoQDDAKKaUUdlS6sXxWCqZNTjC6HDLQhlwnLnV7UHaiwehSKEIwwCikjrrbcarxMs/9ItySNQXpSfE8J4yChgFGIbWj0o1YqwV3L8owuhQymNUiWJ+TiT990YiLl7qNLociAAOMQsbT58XOqjrcMX8qkhNijC6HwkBRrhMer8K7n543uhSKALoHmIgUi0ihiGwOdL2ItIhIqYg8rV+lNF4fHmtA06VunvtFVy3ISML89ES8fqAWXb1s5qDx0TXARKQYAJRSZdpyYYDrH1RKrVZKbdGxXBqjPq/Cv//xJL73m0pkOSbi9vkOo0uiMPLNVbNwrK4dRf++BycvXDK6HDIxvUdgywBUa7erAeQFuN4uIlmhL4/G60J7Fx79f5/gpx9+jrsXZ+Dtv16JOBtnnqdrHsyfjhc3LsOFjm7c+9xuvFFRC6U4QweNnt4BZh+0PCXA9SkAmkXk+aEeVEQ2i0iFiFQ0NjaOu0gamz9+fgFrf/YxDp1twZYHluDnD+cgMZ7ffdGNbp8/Fe9//zbkTLfj6e1H8DevH0ZHV6/RZZHJ6B1gregPo1GtV0ptVUq1AmgdOMw4xPp8pVS+w8HDVXrr8Xjxz++dwKYXD8CRGIddT67CQ8umc9YNGlZaUjxeeeIW/O3qm/BOVR3ueW43jpxrNbosMhG9A+wAro2ysgCUjrReG10NPtRIYeLsxU48+ItybP1zNR69dSZK/nol5kxNNLosMgmrRfDkX87F699agV6PFw/8Rzle+LgaXk76SwHQNcCUUtsBZGnNGXafZo3SYda/oW1T7LMNhYGdVXW4++cf43TTZfziG3n4cdEixMfw+y4avWWuFLz3/dtw+7yp+Mm7J/DNlw7wXDEakUTal6f5+fmqoqLC6DIiWmePB/9z5zG8UXEOS2dOxs8ezuE0URQUSin8et8Z/OTdE7BPiMGzD+fwAqg6EZGDSql8o+sYDZ7ITKNy4nw77n1uN948eA7/9fY5eH3zrQwvChoRwWMrXCj57kpMirfhr174BP/nd5/D0+c1ujQKQwwwCohSCr/eW4P1/74H7V0evPrNW/DUXfNgs/ItRMG3MDMJu55chQeXTsNzfziJh7fug7v1itFlUZjhpw+NqK2zF99+5SB+9PYxFMyegve/fxsK5vCwDoVWQqwNW4qz8bOHc/BZfQfu/tnH+OBovdFlURhhgNGwKmqacffPP8bvT1zAD+9egF89vgypk+KMLouiyPocJ3Y9uQozUhLw7VcO4n+8fZTTUBEABhj5MTAd1Ne27oPVIvjtdwrwX76SBYuF53aR/lypE/vfg7fNwst7z3AaKgLAAKMhDJ4O6t3vrUL2dLvRZVGUi7VZ8MN1CzkNFV3FAKPrcDooCnechooGMMAIAKeDInPhNFQEMMAInA6KzInTUBEDLMpxOigyO05DFb0YYFGqs8eDH2w/gu+9Vol56Yl47/u3Yc2iDKPLIhoTe0Isnn90Kf5x/c3Yc+oi1v7sY5SfajK6LAoxBlgU+qy+Hff92x68cbCW00FRxBhqGqr/y2moIhoDLIoMTJR637/tQduVXrzC6aAoAg1MQ1WcNw0//8NJfP2XnIYqUvGTK0pcnQ6q5ChWZPVPB7WS00FRhEqIteGnD2bj2a/l4HhdO6ehilAMsCjgOx3Uf7t7Pl7cyOmgKDoU5Trx7vdu4zRUEYoBFsEGTwe1/TsF2PyV2ZwOiqLKwDRUT6ziNFSRhgEWgTx9Xrhbr+CxX/VPB7V2UTp2fW8VcjgdFEWpWJsF//2ehfjVxvzrpqHq6u3jVFQmpvsVmUWkGEArgCyl1NZA1o+0j69wuSKzUgrdHm//v94+7XYfunqv/9nd60XXwM+r2127Pex9Pj+7fJY92omc8TEW/K/7bsZD+ZxRg2hAQ3sX/uY3h7G3+uLV++JsFsTZLIiPsSIuxoI4mxXxg35eXe/zM85mQdzA7Rgr4gf99LfPwO1waqAy4xWZbXo+mRZEUEqVichmESlUSpUNtx6Afbh9RuLp8w4bAF1DBMANAXFdkAQeQuNhs8gNb/hYnzd+8oQYxCfG+fyy3PhLV7ggDVmOSeOqgyjSDExDtbPKjbrWrqu/193D/F63XenV1t/4OTIeNovcEH5xAYbfDffFWBBvGz6A43z2iYQ/anUNMADLALyu3a4GkAegbIT1U0bY5zqf1Xdg6Y9Lr765POOcVmbIN4z2RomPscA+IeaGN8xQb8ChH8fPmyzM/jIjijRWi2BD7rRxP45SCj193utCb3AIDn1Exd8fwtf/Qd1+pRddvX3oGeJoTDA+23zDz4z0DjD7oOUpAawfaR+IyGYAmwEgOTMLaxenjzz09/PXiu9yrDUy/kohotAQEe0zxgpA36s2ePq814XndUEYyFcQgwJ3t67VB4feAdYKIGWU60faB9r3YluB/u/AflK0eMwFEhGZgc3af6QmITY4j/fsw8F5HD3pHWAHcG1ElQWgNID19hH2ISKiKKTrgU+l1HYAWQPNGQPNGCJS6m+9v32IiCi66d5GH2rh0kZPRGQmZmyjN2frCRERRT0GGBERmRIDjIiITIkBRkREpsQAIyIiU4q4LkQRaQRwxuAyUgE0GVxDuOBrcQ1fi2v4WlwTLq/FTKWUw+giRiPiAiwciEiF2dpRQ4WvxTV8La7ha3ENX4ux4yFEIiIyJQYYERGZEgMsNIa96GaU4WtxDV+La/haXMPXYoz4HRgREZkSR2BERGRKDDCdiMgzRtdgJBGxi0ieiBRH42uh/b8LtYuvRq1ofx/4w9dibBhgOtAuBZNldB0GewhAvnZ5HETTB7mIFAOAz+WDCo2tyFBR+z7wh58PY6f3BS2jjohkAag2ug6jaVfNHhBtFyZdBuB17XY1gDwAUXlduyh/H9yAnw/jwxFY6GUppfgG1Wi/sM1RdmFS+6DlKUYUEU6i9H0wFH4+jANHYOOkHR5KGXR3tVKqTEQKo+kXdLjXwme5WCn1LR3LCgetuPF1iXbR+D64TrR9PoQCA2ycBo7l+9GsHd+2A8gSkTyl1CF9KtPfCK8FRKRYKbVFux3Rr8UgB3BtFMbDZtH7Phgsqj4fQoGHEENIKXVI+wsrBTceRooq2i/qMyJyUEQOIopGJFqwZw18WEXzX93R/D4YjJ8P48cTmYmIyJQ4AiMiIlNigBERkSkxwIiIyJQYYEREZEoMMCIiMiUGGBERmRIDjIiITIkBRkREpsQAIyIiU2KAEelARLJE5JSIlGrLedqM7EQ0RgwwIn38AMBqAIe0q+/m8zIaROPDuRCJdCAidqVUq4jY0R9eUTuhL1GwMMCIdCIieUD/LORG10IUCXgIkUgH2sU+qwfCS1smonFggBGFmIhsRv+FLH8pInbtO7BWY6siMj8GGFEIaZ2G1doViKsBnAZwit+BEY0fvwMjIiJT4giMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEzp/wN1r5d5/Oh29AAAAABJRU5ErkJggg==
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAsAUlEQVR4nO3deXhT95kv8O8rywsG28K2sLFYHANhxyskGNJpOs5CSIJJSUgzTQJPM3Ry56ad55kM7b1t595n2s5MaO99usw8ndLcQrZJaZjiENKQxLRpAw5JDMaELQk2BiNj8CbbYLzI+t0/fATCeJFl6Rwd6ft5Hh6fVX7xI+vrc857fkeUUiAiIjIbi9EFEBERBYIBRkREpsQAIyIiU2KAERGRKVmNLoCIiMbm0KFDU6xW6/MAFiHyD0Q8AI653e6nCgsLL/muYIAREZmM1Wp9PjMzc77dbm+zWCwR3Uru8XikqalpQWNj4/MAHvRdF+nJTUQUiRbZ7faOSA8vALBYLMput7dj4GjzxnUG1ENERONjMUN4lZWVJRUXF88BgBMnTsStWrUqJ5DX0f6vN+UVA4yIiEKitLS0MyUlpR8AFixY0PvSSy+dDebrM8CIiCjkTpw4EXfq1Kn4YL4mmziIiEzsH3ZWT/+ssTMxmK95a2ZS14/W5dYPt37//v2Jzc3NMd75trY2649//OPMH/7wh+dPnz4dP3v27J7S0tLOwftt3rzZUVFR8XlZWVnSli1bMjdv3txYWVmZeO+993auXLmy67vf/W5GUVFR1+nTp+OfffbZ5tHq5BEYERGNySuvvDIZGDhFeOutt/Zs3LixbcaMGT2lpaWdzz77bPMzzzwzc/A+CxYs6PWeTiwtLe1sb2+3lpaWdj722GNtr7zyyuSnn37aUVRU1FVaWtpZU1Pj15Eaj8CIiExspCOlUPn+97/f+L3vfS/zO9/5zrRf/vKXZwH0+q6fPn16z4kTJ+IWLFjQO8xLICUlxe07X1dXF9/W1mbdv39/4qxZs3r8qYNHYERENCZvvPFG8i9+8Qvn8ePHT+7duzcJANrb26+dUmxvb7eOFF4A4D0a8yosLLwyZ86cnpUrV3Zt2LChzZ86eARGRERjUlNTE7dt27bJAPDYY4+1AQOhtX///sSDBw8m/vCHPzwPDFwrO3bsWOL+/fsTAeDYsWOJJ06ciPvss8/ivcv37t2bVF1dnbh79+7an/zkJ+nea2tDXUMbTPg8MCIic6murq7Lzc0dtclBT6tWrcp56623akP1+tXV1em5ubnZvst4CpGIiMalrKwsyXt0pef3ZYAREdG4lJaWdtbX1x8b7bpXsDHAiIjIlBhgRETm4/F4PGJ0EXrR/q+ewcsZYERE5nOsqakpJRpCTHucSgqAY4PXsY2eiMhk3G73U42Njc83NjZG1QMtB69gGz0REZlSpCc3ERFFKAYYERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKYUcaPRp6enq+zsbKPLICIylUOHDjUrpexG1zEWERdg2dnZqKysNLoMIiJTEZGzRtcwVjyFSEREpsQAIyIiU9I9wERknYiUiMjmUbbbPNZ9iIgoeugaYCJSAABKqXIALu/8ENuVAFg6ln2IiCi66H0Eth6AS5uuBVASon2IiCjC6R1gNgCtPvNpgzcQkQLtaMvvfYiIKPqEYxNHqtEFEBFR+NM7wFy4HlA2AC2+K4c4+hp1HyIzONfShZ2HzhtdBlFE0ftG5h0AirTpHADlACAiNqWUC0COiOR412sNG0Pu40tENgHYBAAzZswIWfFEgfr+myfw7omLmJeZhEWOFKPLIYoIuh6BKaUOA9e6DF3eeQD7tPU7lVI7MXDEZRtlH9/X3aqUKlJKFdntphoJhaJAfWsXyk9eBAC8UFFnbDFEEUT3oaSUUluHWFY4xDZbR9qHyCxeqKhDjAjunD8Fr1c34Nur5iFtUrzRZRGZXjg2cRBFjCs9buyorMeqxVOx+Z656HV78OpH54wuiygiMMCIQuh3VU50druxoTgbczKScMecdLx08Cz6+j1Gl0ZkegwwohBRSmH7gTNYMi0FBTNsAIANxdm42NGDvccajS2OKAIwwIhCZP/pZtQ0XcGG4myICADgzrlTMDMtEdvZzEE0bgwwohDZdqAO6ZPisXrJ1GvLLBbBk8uzcehsG46edxlXHFEEYIARhcCZ5iv4w6lL+KvbZiDeGnPDunVF0zAxLgbbD9QZUxxRhGCAEYXAix/UITZG8Fe33XxjfXJCLNYVTsMbRxtwqbPbgOqIIgMDjCjILve48VrleaxePBVTkhOG3OaJ4mz09Su8+mG9ztURRQ4GGFGQ/deh87jc48aGFbcMu80s+yT8xa12vPzhWfS62VJPFAgGGFEQeTwK2yvqkD/DhrzpthG33bgiG02dPfj9Jxf0KY4owjDAiILoT5834UzzQOv8aL4wx46c9InYxpZ6ooAwwIiCaPuBOkxJiseqRVNH3dZiETxZnI3qeheqzrXpUB1RZGGAEQVJTdNl/OmzJnz19pmIs/r3q/XlwmmYFG/ljc1EAWCAEQXJixV1iIux4CvL/H8m3aR4Kx4umoY3j17AxQ621BONBQOMKAg6uvuw89B5PJCbBXvS2B6V8uTybPQrhVcOng1RdUSRiQFGFASvVZ7Hld5+v5o3BstOn4gvzZ2CVz48hx53f/CLI4pQDDCicer3KLxQUYeimZOxeFpKQK+xYUU2Wq70Yk81W+qJ/KV7gInIOhEpEZHNw6wv0f4957PsOe3rJr3qJPLXe59ewrnWLmxYkR3wa6ycnY7ZUyZhe0UdlFLBK44ogukaYCJSAABKqXIALu/8oPV3aesLfNZvEpEaALV61kvkj+0VdchMTsA9CzMDfg0RwYbibHzibMdhttQT+UXvI7D1AFzadC2AEt+VSqnDSqlvabM5SqnD2vTDSqlZWrARhY3PL3bi/c+b8fjymYiNGd+v00MFDiQlWPFrjlJP5Be9A8wGoNVnPm2ojbTTi1/3WVQw0mlHIqNsr6hDnHVsrfPDSYyz4tGl07H3WCMutF8NQnVEkS0smziUUlsAfF1EbN557egrTURKBm8vIptEpFJEKpuamnSulqJVe1cffnfYidK8LKROjAvKaz6xPBsepfAyW+qJRqV3gLkApGrTNgAtvitFxPe6Vy0Grn2tE5F12rIWADmDX1QptVUpVaSUKrLb7SEpnGiw31bW42pfP54MoHV+ONNTE1EyPwP/+eE5dPexpZ5oJHoH2A5cD6AcAOUA4D3SwsA1Md+Aq9X+ea99zQJQqUOdRCPq9yi88EEdlt2SioVZgbXOD2fjimy0dfVhd3VDUF+XKNLoGmDepgztNKDLp0ljn/Z1K4Ac7xGXUmqnts0j2rIan32IDLPv5EWcb7uKjUE8+vJanpOGuRlJ2H6ALfVEI7Hq/Q2VUluHWFaofXVhIMQAYOdI+xAZaduBOjhsE3DXgoygv7aIYMOKbPyP332Cj8604racIXudiKJeWDZxEIWzU40d+KC2BY8vnwnrOFvnh1Oa50DKhFiOUk80AgYY0Ri9UFGHhFgLHl06PWTfY0JcDB5dNh1vH2+E08WWeqKhMMCIxqDtSi92VTmxNt8BW2JwWueH88TybADASx+wpZ5oKAwwojHYUVmP7j5PUFvnh+OwTcA9CzPxm4/P4WovW+qJBmOAEfnJ3e/BixV1KJ6VhnmZybp8zw3F2XB19aHsiFOX70dkJgwwIj+9e+IiGtq7A3rmV6CW3ZKK+VOT2VJPNAQGGJGftlXUYdrkCfjL+cFvnR+OiGBjcTY+vdiJD2pbRt+BKIowwIj8cLyhHR+dacWTy7MRYxFdv/eD2liL2zlKPdENGGBEfnihog4TYmPwSFHoWueHkxAbg68sm47ykxdR39ql+/cnClcMMKJRtFzuQdmRBny50IGUxFhDavjq7TMhInjxgzpDvj9ROGKAEY3iNx/Xo9ftwZPafVlGmJoyAfcuysRvPq7HlR63YXUQhRMGGNEI+vo9eOmDs7hjTjrmZCQZWsvG4mx0druxq4ot9UQAA4xoRG8fb0Rjh76t88MpnDkZix0p2F7BlnoigAFGNKLtB+owMy0Rd86dYnQpA6PUF2fj9KXLOHCaLfVEDDCiYXxyvh2VZ9vw5PJsWHRunR/O/blTkT4pDtsOnDG6FCLDMcCIhrGt4gwmxsVgXdE0o0u5Jt4ag8eWzcAfPr2EuuYrRpdDZCjdA0xE1olIiYhsHmZ9ifbvOX/3IQq2ps4e7Km+gHWF05CcYEzr/HC+evtMxIjgRY5ST1FO1wATkQIAUEqVA3B55wetv0tbXyAiBaPtQxQKr350Dr39HjwRBs0bg01JTsDqJVPxWmU9LrOlnqKY3kdg6wG4tOlaACW+K5VSh5VS39Jmc5RSh0fbhyjYet0evHzwLP7iVjtm2ScZXc6QNhRno7PHjd8dPm90KUSG0TvAbABafebThtpIO1X49bHsQxQsbx27gEudPdi4ItvoUoaVP2MycqfbsP1AHTwettRTdArLJg6l1BYAXxcRmz/bi8gmEakUkcqmpqbQFkcRb9uBOuSkT8QX5tiNLmVEG4uzUdt8BX/+nO95ik56B5gLQKo2bQNww80svte8MHC6cNNo+wCAUmqrUqpIKVVkt4f3hw6Ft6pzbThS78KTxeHTOj+c+xZPhT0pHtsr6owuhcgQegfYDgA52nQOgHIA8DnSKsGNYVU73D5EofBCRR0mxVvx5cLwaZ0fTpzVgq/eNhPvfdqE2qbLRpdDpDtdA0xryoCIlABweecB7NO+bgWQIyLrtO13jrAPUVBd6ujGm59cwMNF0zAp3mp0OX557LYZiI1hSz1FJ91/S5VSW4dYVqh9dWEgxABg50j7EAXbKx+eg9ujDB11fqzsSfF4YEkWXqusx9/ffSuSwuyeNaJQCssmDiK99bj78cqHZ/GluVOQnT7R6HLGZMOKbFzp7cdrlWypp+jCACMC8ObRC2i+3IsNYdw6P5wl02wonDkZL3zAlnqKLgwwinpKKWw7UIfZUyZh5ex0o8sJyIbibJxt6cJ7n10yuhQi3TDAKOodPufCJ852PFmcDZHwbp0fzr2LMpGRHI9tB+qMLoVINwwwinrbK+qQlGDFQ/kOo0sJWGyMBY/fPhPvf96M05c6jS6HSBcMMIpqje3deOuTC3h06XRMNEnr/HC+smwG4qwW3thMUYMBRlHt5YNn0a8UnjBR6/xw0ibFY01uFv7rkBPtV/uMLoco5BhgFLW6+/rxnx+dQ8n8DExPTTS6nKB4sjgbV/v68VplvdGlEIUcA4yi1hvVDWi90ouNYfjMr0AtcqRgWXYqXvigDv1sqacIxwCjqKSUwvaKOszNSMLyWZH1hJ4NK7JR33oVfzjFlnqKbAwwikof17XheEMHNqwwb+v8cO5ekIGslARsO3DG6FKIQooBRlFpe8UZpEyIRWmeeVvnh2ONseDx5dmoqGnBp41sqafIxQCjqON0XcXbxy/i0WXTMSEuxuhyQuLRpdMRz5Z6inAMMIo6Lx88C6UUHr99ptGlhMzkiXFYm+/ArqrzcHX1Gl0OUUgwwCiqdPf149WPzuHuBZmYNjkyWueH82RxNrr7PNjxMVvqKTIxwCiqlFU54erqw0YTjjo/VvOnJuP2nFS8+MFZuPs9RpdDFHS6B5iIrBOREhHZPMz6Tdq/53yWPeddp1edFHm8rfPzpyZj2S2pRpeji40rboHTdRXlJy8aXQpR0OkaYCJSAABKqXIALu+8z/oSAOXaE5hztHkA2CQiNQBq9ayXIsvB2lacauzERhOPOj9WJfMz4LBN4Cj1FJH0PgJbD8ClTdcCKBm0PsdnWa02DwAPK6VmacFHFJDtFWcwOTEWD+ZlGV2KbmIsgieLZ+LDM6040dBhdDlEQaV3gNkAtPrM3zAEglJqq3b0BQAFACq90yOddiQaTX1rF949cRFfWTYDCbGR2To/nPVFMzAhNgYvsKWeIkxYNnFopxbfVUodBgCl1Bbt6CvN57Si7/abRKRSRCqbmpr0LpdM4OWDZyEieHx55LbODyclMRYPFThQdsSJ1itsqafIoXeAuQB4r57bALQMs12JUmoLcK3pY522vAXXTyteox25FSmliux2e3ArJtPr6nXj1Y/O4d5FmZiaMsHocgyxoTgbPW4PXv3onNGlEAWN3gG2A9cDKAdAOQCIiM27gYhs8gmvEgxcC/Ne+5qF66cVifyyq8qJjm53RI06P1ZzMpKwcnY6Xj54Fn1sqacIoWuAeU8JasHk8s4D2Oez/DkRqRGRNp99HtGOwmp89iEalVIKL1TUYZEjGYUzJxtdjqE2FGfjQns33jnOlnqKDLo/Q92nScN3WaH2tRzATZ8yQ+1D5I+j59vx2cXL+NeHFkdN6/xw7pw3BVkpCdh5qB6rl0w1uhyicQvLJg6iYNlV5USc1YJVi/mBHWMRrMl34M+fN6P5co/R5RCNGwOMIlZfvwdvVDegZP4UpEyINbqcsLA234F+j8Ke6gajSyEaNwYYRaz9p5vRcqU3Ip/5FahbM5KwYGoydh1hgJH5McAoYpVVOWFLjMUX504xupSwsjbfgep6F2qbLhtdCtG4MMAoIl3ucePt441YvXgq4qx8m/t6MC8LIkAZj8LI5PibTRHpneON6O7zYG0+Tx8OlpGcgBWz0lFW5YRSyuhyiAI25gATkWwReUhEnhKRZ7XpL4WiOKJA7apyYtrkCVF/79dwSvMdONfahcPnXEaXQhQwvwNMRP5BRN4B8BwGRsQQAO3a9N0i8o6I/EJE8kJSKZGfLnV048DpZqzNd0T9vV/DuWdhBhJiLSirchpdClHARr2RWURuAfB1AL9RSv1olG1TMPDsriKl1PNBqpFoTHZXN8CjBo4yaGhJCbG4a0Em9hxtwPfuX8DrhGRKI75rtfD6S6XUt5VSR0Z7MaVUuxZy+0TkqSDVSDQmZUecyJ2Wgln2SUaXEtbW5mehrasPf/6MT3AgcxoxwJRSZwI5kgp0P6Lx+vxiJ445O3j05Yc75tiROjEOu47wNCKZUyBNHMmhKIQoGMqOOBFjEdy/JHqeuhyo2BgLHlgyFeUnLqKju8/ocojGLJAT37N8GzVE5BZ2IVI48HgUyqoacMecdNiT4o0uxxRK8x3ocXuw91ij0aUQjdmYA0wpVQVgqYhka/NnAEwWkX8Jcm1EY1J5tg1O11Xe+zUGedNtyE5LZDcimVIgpxB3AKgB0OZzOrEcwKZgFkY0VruqnEiMi8FdCzKMLsU0RASl+Q58UNuCC+1XjS6HaEwCOYVYCKBSKdUOQLTW+RIA/xrUyojGoMfdjzePNuDehZlIjNP9MXemVprngFLAbg4tRSYTSIA9DO1oSwuxVACTR7tHzEtE1olIiYhsHmb9Ju3fc/7uQ/THU03o6Haz+zAA2ekTkT/Dhl08jUgmE9A1MKXUj33mzwA45M8IHCJSoO1TDsDlnfdZXwKgXHsCc44WWiPuQwQMjDxvT4pH8aw0o0sxpYfyHTjV2ImTFzqMLoXIb0G5/V5r7Djjx6brAbi06VoMnHr0leOzrFabH20finLtXX34w6lLeDA3C9YYjigRiNVLsmC1CMp4TxiZSNB+27XTiaOxAWj1mb/hz2Wl1Fbt6AsACgBUjrYP0e+PXUBvP0eeH4/UiXH44lw7Xq9qgMfDEerJHEYdSiqQIaEC3c9n/wIA7yqlDvu5/SYRqRSRyqYmDosTbXZVOTF7yiQszOI99uNRmu9AY0c3Dp5pMboUIr+MOpQUBsY1/A9/blYWkWQR+QcMjJ841FBSLgw0fQADR1bD/aaUKKW2+LuPduRWpJQqstvto5VJEeR8Wxc+OtPKkeeDoGR+BibFW3lPGJnGqP3GWoj9jYj8tYh8G4ACcBjXgyQNA8EyCwP3h23R9hnKDgBF2nQOBu4fg4jYlFIubXqTN7y0po4h9yECgNe11u8Hczl01HglxMZg1aJMvPVJI/5pzSIkxMYYXRLRiPy+BqaU+pVS6m4Aj2AgRM5g4HlglQC2KqXuVko9PUJ4wXtKUAsml88pwn0+y58TkRoRaRtlH4pySinsqnJiWXYqpqcmGl1ORFib70Bnjxv7Tl4yuhSiUY35jk+tWWNfoN/Qp0nDd1mh9rUcwE2P0B1qH6LjDR04feky/nntYqNLiRi35aQhMzkBu6qcWL1kqtHlEI0ooC5EEXlKe/ryUxydnoyyq8qJuBgLVi/mB22wxFgEa/Ky8N6nl9B6pdfocohGFMhYiP8KYDYGTh8+AuCMiHwt2IURjcTd78Hu6gbcOc+OlMRYo8uJKKX5Drg9Cm8e5dBSFN4COQL7WHtC87e1a2KzAMwRkYeCXBvRsCpqWtDU2cN7v0Jg/tRkzMtM4tBSFPbGfSOzUsqllPo2eIMx6aisyonkBCu+OHeK0aVEpNJ8Bw6fc+FsyxWjSyEaViABVisiH4vInYOuf/HuR9JFV68be483YvWSqWz1DpEHc7MgApRV8TQiha9AAmw9gN8CeBpAnRZmb2Ng8N0kAODpRAqld09cRFdvP0rzePowVLJsE3D7LWkoO+KEUhxaisJTIAFWA+A1pdQjSqlUDDxapRzA3QDOisjnAJ4b6QWIxmNXlRMO2wQszU4dfWMK2Np8B840X0H1eX+GOSXSXyCPU/kVgMkikq3NVymlfqTdyJyKgSM0f0amJxqzps4evP95M9bkZcFi4dBRoXTv4kzEWS0cWorCVkBNHFpo1Q2z7jCAb42nKKLh7DnagH6PYvehDpITYnHX/Ay8Ud2Avn6P0eUQ3SQkD0/Sng9GFHRlVU4szErGnIwko0uJCqX5DrRc6cX+z5uNLoXoJnz6H5lGTdNlVJ9v59GXjv7iVjtsibG8J4zCEgOMTOP1KicsAjzAked1E2e14P4lU/HOiUZc7nEbXQ7RDRhgZApKKew64sSK2enISE4wupyosjbfge4+D94+1mh0KUQ3YICRKRw+14b61qu898sABTMmY3rqBJQd4WlECi+6B5iIrBOREhHZPMI2BYPmn9O+bgp1fRSedlU5kRBrwT2LMo0uJeqICNbmOXDgdDMudnQbXQ7RNboGmDeYtOd+uQYHlbZNCYBfDVq8SURqANSGvkoKN71uD/YcvYC7F2RiUvyYH2FHQbAm3wGPAt6o5tBSFD70PgJbD8ClTdcCKBm8gRZurYMWP6yUmqWtoyjzp8+a4OrqY/ehgWbZJyF3Wgq7ESms6B1gNtwYTv6OYF8w2mlHilxlVU6kTYzDyjnpRpcS1UrzHTje0IHPLnYaXQoRAJM0cSiltmhHX2naKUaKEh3dfXj35EU8kJuF2BhTvF0j1v1LshBjEQ4tRWFD708EFwDvCKw2+PEIFq3pY5022wIgJySVUVja+0kjet0elPL0oeHsSfG4Y046Xj/SAI+HI9ST8fQOsB24HkA5GBjFHiJiG2GfWu92GHj6c+XgDURkk4hUikhlU1NT8Kolw+2qcuKW9InInZZidCmEgXvCnK6r+Lhu8GVqIv3pGmDaQL/eTkOXdx7APu822tFWkfeoS9vmEW2+xmcf39fdqpQqUkoV2e32kP8/SB8Nrqs4eKYFpXkOiHDk+XBw14IMJMbF8J4wCgu69yQrpbYOsazQZ3ongJ2j7UORb3d1A5QCSvM5dFS4SIyz4t6Fmdhz9AL+1wML+URsMhSvilPYKqtyomCGDTPTJhpdCvkozXegs9uN9z69ZHQpFOUYYBSWTl7owKnGTt77FYaKZ6XBnhTPe8LIcAwwCktlVU5YLYLVS3j6MNxYYyx4MDcLfzzVBFdXr9HlUBRjgFHY6fcovH6kAV+ca0fqxDijy6EhrM13oLffg99/whHqyTgMMAo7H9a2oLGjm/d+hbGFWcmYPWUSb2omQzHAKOzsqnJiUrwVJfMzjC6FhiEiWJvvwEd1rahv7TK6HIpSDDAKK919/XjrWCNWLcpki3aYe1B7MvZujlBPBmGAUVgpP3kRl3vc7D40gempiViWnYrfHT4PpTi0FOmPAUZhpazKiczkBNyW4++DCshIpfkO1DRdwfGGDqNLoSjEAKOw0XqlF+992oQ1eQOjnlP4W714KuJiLLwnjAzBAKOw8ebRBrg9CmsLePrQLFISY3HnPDt2VzfA3e8xuhyKMgwwChu7qpyYl5mEeZnJRpdCY7A234Gmzh5U1Iz6dCSioGKAUVg423IFh8+52LxhQl+cOwXJCVbeE0a6Y4BRWCiraoAI8GAeh44ym4TYGKxeMhV7jzeiq9dtdDkURRhgZDilFMqOOLE8Jw1TUyYYXQ4FoDTPga7efrx74qLRpVAUYYCR4arPt+NM8xUOHWViS7NT4bBNYDci6Ur3ABORdSJSIiKbR9imYKz7kHmVVTkRb7Xg3kWZRpdCAbJYBGvysvD+581o6uwxuhyKEroGmDeYlFLlAFyDg0rbpgTAr8ayD5lXX78Hb1Q3oGRBBpITYo0uh8Zhbb4D/R6FPUc5tBTpQ+8jsPUAXNp0LYCSwRtoQdU6ln3IvPZ/3oyWK71Ym8fTh2Y3JyMJC7OS2Y1IutE7wGy4MZz8GS8okH3IJHZVOTE5MRZfuNVudCkUBGvzHag+346apstGl0JRgE0cZJjLPW68c6IR9y/JQpyVb8VI8EBuFiwCvM6jMNKB3p8aLgCp2rQNgD+37o+6j4hsEpFKEalsamoad5Gkj7ePNaK7z8PuwwiSkZyAFbPTseuIkyPUU8jpHWA7AORo0zkAygFARGxj3ceXUmqrUqpIKVVkt/NUlFmUHXFiRmoiCmbYjC6Fgqg0z4H61qs4fK7N6FIowukaYEqpw8C1TkOXdx7APu82IrIOQJH2daR9yMQudnTjwOlmlOY7IMKR5yPJPYsykRDLEeop9Kx6f0Ol1NYhlhX6TO8EsHO0fcjc3qhugEcBpRw6KuJMirfi7gWZ2HP0Av7x/oW8vkkhw3cWGWJXlRO5023IsU8yuhQKgbX5Dri6+vCnz3hNmkKHAUa6++xiJ443dGAtj74i1so56UibGMd7wiikGGCku7IqJ2IsgvtzGWCRKjbGggdys/DuyYvo6O4zuhyKUAww0pXHo/D6kQZ8YU460ifFG10OhVBpvgO9bg/2ftJodCkUoRhgpKuP61rhdF3lvV9RIHdaCm5Jn8huRAoZBhjpquyIExPjYnD3Ao48H+lEBKV5Dhw804IG11Wjy6EIxAAj3XT39WPP0Qu4Z1EmJsTFGF0O6aA0PwtKAburOUI9BR8DjHTz3qeX0NntxlqePowaM9MmomCGjd2IFBIMMNLN7w47YU+KR/GsdKNLIR2tzXfgVGMnTjR0GF0KRRgGGOnC1dWLP356CWtysxBj4dBR0WT1kixYLYKyIzwKo+BigJEu3vzkAvr6FbsPo1DqxDh8ca4drx9xot/DEeopeBhgpIuyKifmTJmEhVnJRpdCBijNd+BiRw8O1vrzBCUi/zDAKOTqW7vwcV0bR56PYiXzMzAp3sp7wiioGGAUcq9r1z7WcOzDqJUQG4NVizKx91gjrvb2G10ORQgGGIWUUgq7qpxYdksqpk1ONLocMtDafAcu97hRfvKi0aVQhGCAUUgdc3agpukK7/0i3JaThszkBN4TRkHDAKOQ2lXlRFyMBfctmmp0KWSwGItgTV4W/vRZE1ou9xhdDkUA3QNMRNaJSImIbPZ3vYg8p33dpFedNH7ufg92VzfgS/OmICUx1uhyKAyU5jvg9ii8+ckFo0uhCKBrgIlIAQAopcoBuLzzfqzfJCI1AGr1rJfG5+3jF9F8uYf3ftE186cmY15mEnZ8XI/uPjZz0PjofQS2HoBLm64FUOLn+oeVUrO0YKMw1+9R+Pc/nsY3flOFHPtE3DnPbnRJFEa+tvIWHG/oQOm/H8DpS5eNLodMTO8AswFo9ZlP83N9wUinHSl8XOroxuP/70P86O1Pcd/iqXj9b1cg3sqR5+m6h4umY9uGpbjU2YMHfr4fv62sh1IcoYPGzhRNHEqpLdrRV5qIDD5qg4hsEpFKEalsamoyoEICgD9+egmrfvo+Dp9rw5YvL8HPHs1DUgKvfdHN7pw3BW998w7kTbdh886j+LsdR9DZ3Wd0WWQyegeYC0CqNm0DMHhcmZvWa00d67RlLQByBr+oUmqrUqpIKVVkt/N0ld563R788+9PYuO2j2FPiseeZ1bikaXTOeoGjSgjOQEvP3Ub/v6uW/FGdQPu//l+HD3vMrosMhG9A2wHrgdQDoByABAR2wjra73bAZgFoFKPQsk/51q68PB/VGDrn2vx+O0zUfa3KzB7SpLRZZFJxFgEz/zlHOz4+nL0uT348i8q8Pz7tfBw0F/yg64BppQ6DADaaUCXdx7AvuHWa8se0Y7Canz2IYPtrm7AfT97H2ear+A/vlqA75cuQkIsr3fR2C3NTsXvv3kH7pw7BT948yS+9sLHvFeMRiWRdvG0qKhIVVbyIC2Uunrd+N+7j+O3ledROHMyfvpoHoeJoqBQSuGlg2fxgzdPwjYhFj95NI8PQNWJiBxSShUZXcdYmKKJg8LHyQsdeODn+/HaofP473fOxo5NtzO8KGhEBE8sz0bZf1uBSQlW/NXzH+L/vPMp3P0eo0ujMMQAI78opfDSB3VY8+8H0NHtxitfuw3P3jMX1hi+hSj4FmQlY88zK/Fw4TT8/A+n8ejWg3C6rhpdFoUZfvrQqNq7+vA3Lx/C914/juJZaXjrm3egeDZP61BoJcZZsWVdLn76aB5ONXbivp++j73HGo0ui8IIA4xGVFnXivt+9j72nbyE79w3H79+cinSJ8UbXRZFkTV5Dux5ZiVmpCbib14+hH98/RiHoSIADDAahnc4qPVbDyLGIvivp4vx11/IgcXCe7tIf9npEwfeg3fcghc/OMthqAgAA4yGMHg4qDe/sRK5021Gl0VRLs5qwXdWL+AwVHQNA4xuwOGgKNxxGCryYoARAA4HRebCYagIYIAROBwUmROHoSIGWJTjcFBkdhyGKnoxwKJUV68b39p5FN94tQpzM5Pw+2/egXsXTTW6LKKA2BLj8MvHC/FPaxbiQE0LVv30fVTUNBtdFoUYAywKnWrswIP/dgC/PVTP4aAoYgw1DNX/5TBUEY0BFkW8A6U++G8H0H61Dy9zOCiKQN5hqNYVTMPP/nAaX/kVh6GKVPzkihLXhoMqO4blOQPDQa3gcFAUoRLjrPjRw7n4yfo8nGjo4DBUEYoBFgV8h4P6n/fNw7YNHA6KokNpvgNvfuMODkMVoRhgEWzwcFA7ny7Gpi/M4nBQFFW8w1A9tZLDUEUa3QNMRNaJSImIbPZ3/Wj70I3c/R44XVfxxK8HhoNatSgTe76xEnkcDoqiVJzVgu/evwC/3lB0wzBU3X39HIrKxKx6fjMRKQAApVS5iOSISIFS6vBI673rhtsnXCml0OP2DPzr69em+9Hdd+PXnj4Pur1fr213fXrEZT5fu33m3dqNnAmxFjz35cV4pIgjahABwJfmZeCtb96Bv/vNEWzeeRSbdx4FAMRbLYi3WpAQG4P4WAvirTFIGPT12nqfr/FWC+K907ExSBj0dbh9vNNsoBofXQMMwHoA72rTtQBKABweZX3aKPuMyN3vGTEAuocIgJsC4oYg8T+ExsNqkZve8HE+b/yUCbFISIr3+WW5+ZeuZH4GcuyTxlUHUaTxDkO1u9qJBlf3td/rnhF+r9uv9mnrb/4cGQ+rRW4Kv3g/w++mZbEWJFhHDuB4n30i4Y9avQPMBqDVZz7Nj/Wj7XODU42dKPz+u9feXO5xDisz5BtGe6MkxFpgmxB70xtmqDfg0K8zzJuMf5kRhVSMRbA2f9q4X0cphd5+zw2hNzgEhz6jMtwfwjf+Qd1xtQ/dff3oHeJsTDA+23zDz4z0DrCQEJFNADYBQEpWDlYtzhz90H+Yv1Z85+NiIuOvFCIKDRHRPmNiAOj71AZ3v+eG8LwhCP25BDEocPfrWn1w6B1gLgCp2rQNQIuf60faB0qprQC2AkBRUZH6Qeni4FRLRBSmrDEDZ2oS44Lzej95NDivoye9A2wHgCJtOgdAOQCIiE0p5Rpu/TDLiIgoiul64tPbPSgiJQBcPt2E+4ZbP8I+REQUxXS/Bqad7hu8rHCU9TctIyKi6GbO1hMiIop6DDAiIjIlBhgREZkSA4yIiEyJAUZERKYkkTYSs4g0AThrcBnpAJoNriFc8GdxHX8W1/FncV24/CxmKqXsRhcxFhEXYOFARCqVUkWjbxn5+LO4jj+L6/izuI4/i8DxFCIREZkSA4yIiEyJARYaHDnkOv4sruPP4jr+LK7jzyJAvAamExHZrJTaYnQdRBR++PkQmIh4Hli40wYiXmp0HUbTntsGALOUUt8ytBidicg6DDwuqCDaP6ii+X0wFH4+BI6nEEkX2i9puTYwc442HxVEpAAAlFLlAFze+WgUze8DCj4GWIiJSIH2wRXtcgB4P6xqtflosR4DR1/AwP89mj+0o/l9cBN+PowPTyGGXurom0S+QY/EKcDAw0ujhQ1Aq898mkF1GC7K3wdD4efDODDAxsnnfL6vWqVUOf+6upl2+uxdPpg0uvF9wKOvYGCAjdMoD9vMEZEcn+mCSP6FHSnMfeZLorCJwYXrf2nbALQYVkn4iMb3wWBR9fkQCgywEFJK7QSufbDbjK0m9EZ7craIbPJ+aIlISRT99bkDgHeooBwA0fL/HlIUvw9uEG2fD6HA+8BIF1q32WsYuBaUCuDhaPrg0j6kagHkjBb0kSza3wcUXAwwIiIyJbbRExGRKTHAiIjIlBhgRERkSgwwIiIyJQYYERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIdCAiBSJSIyKv+czbDC6LyNQYYET6KAFQCOCX3lH7lVIuQysiMjmOhUikI+2oK1UpVWt0LURmxwAj0on3lCGPvIiCg6cQiXTgfXChN7x8HmRIRAHiAy2JQkxECjDwQMtWESnHwPUwFwaeD0ZEAeIRGFEI+Zw23IqBpzGfAbCUD3EkGj9eAyMiIlPiERgREZkSA4yIiEyJAUZERKbEACMiIlNigBERkSkxwIiIyJQYYEREZEoMMCIiMiUGGBERmdL/B5xvzATa8jwpAAAAAElFTkSuQmCC
 "
 >
 </div>
@@ -15765,7 +15476,7 @@ Spline knots [[-5. -5. -5. -5. -3. -2. -1.  0.  1.  2.  3.  5.  5.  5.  5.]] [[ 
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABTf0lEQVR4nO3deXzU1bn48c+ZLSvZw76GHZElBEQEFwiKa1GDWG2tVoXaXq+9t1baXnt77+/aa6Haa3vbKmivra1aBS2tomiCikZQCVE0LLKEHYFskz2znt8f35kwCdkzmUkyz/v18kXmu82ZMZlnzvk+5zlKa40QQgjR15jC3QAhhBCiKySACSGE6JMkgAkhhOiTJIAJIYTokyzhboAQonfbuXPnQIvF8gwwFfnSK0LPCxS53e57Zs2adTZwhwQwIUSbLBbLM4MHD56cnp5eYTKZJG1ZhJTX61UlJSVTTp8+/QxwQ+A++TYlhGjP1PT09CoJXiIcTCaTTk9Pr8QYAWi6LwztEUL0LSYJXiKcfL9/58UrCWBCCCH6JAlgQggh+iRJ4hBCdNgPN+wasf90dWwwrzlh8IC6X+ZMP97a/o0bNw5Ys2bN4Iceeuh0QUFB7JIlS6rnz59fB/DYY4+lzZ07t+6jjz6KffDBB0v9x957772lhw4dsmVlZdUFnjt27FhncnKy++WXX075zW9+cyItLc0TzNciQkt6YEKIXm3p0qXVx48fj1q6dGn1bbfdVvH8888nAzz88MOD5s6dWzd//vy6cePGOR577LE0/7F33XVXxSOPPHKm+blPP/102tKlS6szMzNr8/PzgxqIRehJD0wI0WFt9ZR60tSpU+uab3vnnXcSbrvttgqACRMmONauXZv+4IMPljY/NvDx9OnT6wBSU1Ol59UPSA9MCNEnTZ8+vW7//v1RAPv374+aNWtWbbjbJEJLApgQolfLz8+PLSoqit2zZ4/tjTfeSNi1a1dsaWmp+cknnzxZUFAQu3HjxgEFBQWxjzzyyJmNGzcOKCoqivUPD7Z07p49e2y5ubkJb731VkK4X5voHiXrgQkh2rJr164j06dPLw13O0Rk27VrV9r06dNHB26THpgQQog+SQKYEEKIPkkCmBBCiD5JApgQQog+SQKYEEKIPkkCmBBCiD5JApgQotcrLS01P/bYY2kbN24csHHjxgGPPfZYWrCu/eyzzyb7f96zZ4/t6quvzgCjBuO8efPGB+t5RPBJABNC9Ho33HBDxp133lmxdOnS6qVLl1aPGzfOcd999w3r7nVLS0vNubm5jROap0yZ4nzzzTeLwajBmJiYKCWnejGphSiE6JRfTj0+q7V9l/0g8eicuxJKAT55tipt6+OVo1o79odFI3Z25Pk2btw4IDEx0RNYOX7p0qXVd9xxx9gnn3zypL8C/bZt2w48/PDDg8rKyixPPvnkSf+5Bw8ejBo3bpxj6dKl1c0r2w8dOtS1a9eu2I0bNw5YunRpdX5+fuxDDz00bNu2bQcC21BaWmp+4okn0rKysuoOHjwYNXfu3LrS0lJzRUWFJTk52b106dLqjrwWEVzSAxNC9GoHDx6MSk5OPq8nlJiY6C4tLTUH9pT8xX3BGA48ePBg1IMPPli6Zs2awXB+ZfsvvvgiZuTIkQ5/AJo/f35dS72un/70p4OXLFlSvXTp0urCwsI4f0X8u+66q2LChAmOnnrtom3SAxNCdEpHe05z7koo9ffGumPu3Ll1r776anLz7ZWVlZa21vOaMmWKc8qUKaWlpaXmwO0tVbZvz65du2Kvuuqqqvz8/Njvfve7JZMmTXJ885vfHHX//fePevHFF4sBZ2evKbpPApgQolfz94r27Nlj81efP3jwYNSvf/3ro82P9e8Ho5Dv5s2bB3z/+9/vUBDNz8+P9S+U2dzChQur/G0pLS01v/baawlvvvlmsX9osbXzRM+SACaE6PXefPPNYn/m4aFDh6LGjh3ruOuuuxqHC2fNmlWbn58fe/Dgwaj3338/obS09PSBAweikpKSPPv27YsaPXq089lnn00eP368o3l1+okTJzZs3LhxwPz58+sCq9eXl5db/D8/8sgjZx5++OFB/uf75JNPYgHGjx/vCBy2FKEl1eiFEG3qbdXoS0tLzT/96U8Hz5kzp+7666+vamsYUfQfUo1eCNHnpaWleXbt2hX79NNPp0nwimwyhCiE6HOap7mLyCQ9MCGEEH2SBDAhhBB9kgQwIYQQfVK/uweWlpamR48eHe5mCNFvrFmzhj179rRaEkr0Dw6Hwz1z5sxd4W5HZ/S7ADZ69GgKCgrC3Qwh+o29e/cyefLksD1/cXExq1atYv369a0es2HDBnJyckLYqv6nqKioz1UTkSFEIUSvlpGR0Wbwstvt5ObmhrBForfodz0wIUQPevNHcPqL4F5z8IVw9S9a3V1YWMiqVavIzc0lLy+P1atXs2rVKgoLC8nOzgagoKCAvLw8srOzsdvtrFu3jszMTIqLi8nIyGD16tWsXLmS4uJiMjMzWbVqFatXr27c77+O6FskgAkherXMzEySkpIAyM7OZuXKlWRnZ5ORkcHatWtZvXp1kyD06KOPsnz5cjIzM1m5ciUrVqxg5cqVTYYYU1JSGo8fO3Yshw4dCvnrEt0nAUwI0XFt9JRCJTMzs839hYWFLF68mMLCQlauXNniOf6ACMYQpb8nJvoWCWBCiH7DH7zACFp2u73F4wK3S/Dqu0IewJRSOYAdyNBar2vjuNVa61WdOUcI0f8UFhZSWFhIcXExdru98ee8vDwKCwux2+1kZGSQl5dHVlYWDz30EGvWrGnxGv6eWHl5OYWFhRQUFLB27dpwvCwRBCGtRu8LRGitNyilVgDFWuu8Fo7LBlZqrZd19By/rKwsLWn0QgRPuNPoe8KyZcvazGyMREVFRXVTp07dG+52tKY3VKOfDRT7fi4GzhvMVkplBBzToXOE6O2014vbLYXTewN/z624uLj9g0WvFuohxKRmj1NbOCZDa52nlOrwOb6e2QqAkSNHdq+FQgSJ2+Nlx5EKcvecIfHzp7nV+Tf+feSfuHTqaBZPHsTAhOhwNzEiZWdnS9ZhPxHqAGYHUlrbqZTKbmF4sM1zAHz3xdaBMYTYvSYK0X0nKuq489kdHDxbQ7QFPox6jVRVwdgzm/m3A/N5eGMRP7xqIvddNpaAL2tCiE4I9RDiDs71qDKA5tPny5VS2b77XhlKqcwOnCNEr7L/TDU3P7mNs1UN/PrWGXx2q5dUTwlYY/lhSj5vf38B11w4hDWbv+SRTXvxeuU7lxBdEdIAprXegBGYsoEkf29LKZXr21/o25aCL2i1do4QvdHOoxUse2o7WsPL37mYr80YRvRnf4QBQyH7P1CnP2eCez//e+tM7pw3mj/kH+bB9btwebzhbroQfU7I0+i11v781ryAbYubHdM4JNjaOUL0NvtOV/GNZz5mUEIUf777IkakxEJ5MRzMg8t/DDNugy3/D3Y8g+nGLH52/RTS4m089vZ+AH61fEZ4X0BHPR7kIc8fSA9UdI0U8xWik87sc7Jvc13jf4fz63F5vPzg5V3ERZn55cRMaj+BfZvrKFv/NBozB6uWse9dMw1jcqDoVagrp+qUh2znMO5PmcTnm2r469Mnm1zX65YPdjDmcM2aNYtVq1Zht9vJy8tj7NixrFu3juLiYpYtW9bquRs2bAhhS1vWvP2t6am25uXlNU7u7u5z33fffcMefvjhQc235+fnx15wwQWTH3744UHPPvtssv/flvY99thjaY899lha83Pvu+++Yf798+bNG9+R9kglDiE6obbMw19uPYPXfW5baoaFmgdq2H2qiqe+MYv8O6txN2jMJgffufYF9pcs5B8bbEAZ13z/Ni7w/BE+e54Tpd/mjZ+UAzauYhTHC70cp6zxut/fMQyTRRI8MjMzycjIYPny5SQlJZGdnU1SUhK33HILSUlJrc7n8lepD/cyK83b35KebGt2dnabk7X9zz1p0qR2r3X77bdXbN68eUDz7fPnz68bOXKkY8mSJdXz58+vA0hISJhx/fXXV7W0zx/EHnzwwVL//ttvv73Cvz81NbVDc04kgAnRCfbjbrxuiEkyMfKiKACccR4efecAN0wfypKpg3EvKsPr1gy3vEVslJ2ylG8y8aoYAKLHTwM1Fwr+j4SL727cXlXvJv9gCYMToskclQyAMkvwak9gpfrCwkLKy8ux2+0kJSWRkpLSpEo9wLp168jKyqKgoIAVK1Y0bktJSWksKZWUlNSkev1DDz1EXl5ek8r1zavi+89bv349q1evbjVQAT1eUb+l19j8+QPPKS4upqCggG3btpmmTp1KaWmp+YknnkjLysqqO3jwYNSDDz5Y+vDDDw/KysqqKygoiA3G/7c777yzYubMmZMffPDB0ub78vPzYy+66KLajlxHApgQnVBXbiRbDJ1u44bH03B5vCz93YckVtn4zxsuAOC61b6pin94GerGMe9nN0Bgqnzy3fDqvYxI+YgRjy9s3Gx/p5rH3t7PRbdncvWFQ6g86eat/ygnOsHEDY+nEeny8vIoLy8HztUyDKxU/9JLL7F48WJycnIaP6ADP9jXrFlDdnY2mZmZlJeXs27dOjIyMkhJSSEnJ4dly5bx0EMPATSpXl9cXExxcTErVqxg8eLFZGdnn1cVf+XKleTm5jYGg7aWZ+nJivotvcbAINbSa/H3EOfNm+cF+OlPfzrY3xu67bbbUh577DGysrLqli5dWp2WluZpqQfm99FHH8WWlpaaDx48GPXrX//6aFpaWos9qbS0NM+JEyeiArdt3rx5wEcffRQL0FJga4ncAxOiE+rKjb/H2BQzAM98cJjdp6r4+Y1TSY6znTvw9Bdw/GPI+nbT4AUw5WsQmwo7/tBk83cuG8uFwxJ5eGMR1Q0ulAmObndwotDRo6+pr/AHDv8QYnM//vGPWbt2LWPHjm3xXlNubm7jeRkZGeTm5pKVlcWOHTuaFAGGptXrMzIyWLFixXnXDDzG/3NKSptTVls8tyX+3mRnK+q39BoDtfZaAu3atSu2tLTUnJ+fH/vd7363ZMuWLQkTJkzo0C/h3Llz65YuXVr94IMPlt51110VrR1XWlpqHj58eJNrLlmypPrOO++s6OjwIUgAE6JTpt0cx/0fDuPSf02kxuFm7fuHWDhpIFddMLjpgTv+AJZomP718y9iiYKZ34Av34DKk+c2m038/MaplNU6eW77UWJTjSBZX+FFy1yxduXl5bF+/Xp27txJXl7ThGV/IV9/+aji4mJmz55NeXk5ixcvbvxgb0lhYeF5xYF7UvOK+q1Vym+pon5Lr7H5tdt6Lfn5+bELFy6sAuO+1qRJkxyzZs2q/fjjj+PACDzdeGmN/vjHPyY/8MADp5tvT0tL87QV+JqTIUQhOkEpRXSi0aN68r1D2Otc/POiZglTDVXw+cswNQdiW/lGPusu+PA3UPgnuOInjZunDU/iionpPPNBMXfOG03UAIWjWtNQ5SUmKSifHd0X4rR3f93Cl156iYyMDAoKCiguLubll18mKyurcf+OHTsAo5fhH2oLrFK/evXqxg/vwsJCHnroIYqLi1m7di3r16+nvLycH//4x409n8Cgl5SU1BgkNmzYQEZGxnlV8QN7QIFDiM3bX1xc3GMV9Vt6jYHV/Ft6LTk5OWRkZLBt2zbTTTfd5Jg/f35dYKbhI488cubhhx8elJ+fH1tQUBD7zjvvJJSWlpYGDg/m5+fHHjt2LOr5559PnjRpkqOlfZs3bx7gH16Ec8OEgeempKS4p0yZ4uzo70ZIq9GHglSjF6FQ53Qzf/W7XDgskT99e07TnZ88DW88CPe+A8NmtX6Rv+QYQ43/UgRma+PmwmMV3PT7bfzkmkmY1sRSccTNt/8+mNSx1tav1YP6YzV6P38iRGuPe7NgV9SXavRC9HNv/ayc9StKeO5vxyivdZ7f+9IaCv4PhsxoO3gBzL4bak4bQ4kBMkcms2B8GuveLyY6yfgTrS2TSvY9Yfny5WzYsIHCwkI2bNjA8uXLw92kDpGK+gYZQhSiE04UOig/7GZzwgnmT0pjli/lvdGxj+DsHrjhf9u/2PgrIXGEcb9sytea7Hpg0XhyntpOqWoATI3ZjyK4MjMzG4fk2kus6E2kor5BemBCdEJdmRFITnrquH/huPMP2PEMRCXC1Jvbv5jJDLO+BYe3QumBJruyRqdwcUYqH5lLmPy1GAYM6iX3v4ToRSSACdFBHpeRTKGVZtrERC7KaLY0XU0J7Pk7zPg62OI6dtGZd4DJagw7NvPPi8bz0eAzVN5Qy7CZUS2cLERkkwAmRAf554DV29zcvWDM+Qd8+mfwuiDr7o5fdMAgmHw9fPY8OOua7JqbkcLkIQm8+Mmx7jRbiH5LApgQHeQfPnTGeFg4aWDTnV4P7HwWRi+A9Amdu/Dsu6GhEna/2mSzUoqvzxjBqb0Otr1f3p2mh9673zf+E6IHSQATooOOH6sHIGmgFau52Z/OwS1gP2YEo84adQmkTzqvMgfA3Kh0vv7+RLb+d2VXmtwv9Jdq9GvWrGHDhg2sW7euca5We+1v61p5eXls2LCBWbPayXYNsGrVqpBOyu5pkoUoRAd98NVZ9o6o4+uLhp+/c8czED8IJl3X+QsrZZScevMhOFkIw85lw6UPMcpT1Zd7qXG4iY+KvD/Z/lCNPisrq7HuIBi1C1esWEFGRkan5nL534vAa2VkZDQWMG7P8uXLz6tS0pdJD0yIDvB4NS+fPoZ7mYPF32uWvFFxFA68DZl3NJmQ3CnTbwVrLBQ07YX5y0lFOyy8tutU167djwWWXSosLGzslfgrrvsrvPutW7eOwsJC1q1b12Tbhg0bGntI/vWz/NvAmHe1bt26xmv5j8nLy2ty3sqVK9usMwhGr9AfhAPb3/yahYWF7b7+DRs2NBY0but8f48t8L1o/n71RRLAhOiArfvP8lVlA7fNGXH+zp1/NHpRs+7s+hNEJ8KFy+CLV6D+XCk4W5zCEgVWj4mXPjze9ev3A/4P4Ly8vFar0QONpZECeytgfIhnZWU1bvcHJH81+h07dpCTk9O4xEhOTk5juSl/BXd/lQ7/MdnZ2eTk5LB27Vqys7OZNWsWrVUCKigooLCwkKSkpMZhv8D2N7+m//W09l6sW7eusTp/W+f7l2XxF0L2a/5+9UUhD2BKqRylVLZSqsXKmb592Uqp1QHbKpRSuUqph0LXUiHOeeHj42R4BjDdkoKrPmBSsdtpZB9OuBoSWxha7IzZd4O7Hnb9tXGTUqqx8n1xcR1FJyP3Xlhfr0bvD57Z2dnk5ua2eH+uo5Ops7OzWbFiRWNA8ve2Wjo/Nze3xQDV3vvVF4Q0gCmlcgC01nm+x9nN9mcCmb79mUop/7u+TGu9WGvdf+4+ij7jdGUD7+w7w5JDI/hLzlmOFwSsArH3H1BbArO/3f0nGjIdhmUZyRwBNUr9w4iJHquk1LehL1WjD1bA8N//CuyJNTd79uzGABd4XFvvV18R6h7YbMBfvKsYaPJ1QWtdqLVeo5RKAoq11v5jkwKCmRAh9frnp/BqSPIYk4n9PSLACDbJYyBjYStnd9Lsu6HsABx+v3FTXKrxZzpvUDqbvvgKpzuyykoFVnP3ZyH6q9EHVlrfsWMHGzZsaBz+g3PV6P0rGvvv+/grtQOsXbuWVatWsWzZsib7/R/6LVVwD3ze5tXom6/B5a8Y7x/+9C+kmZOT0+Q6LV2zeaDzH+O/1oYNG1i0aFFjdfyWzvcPg/r35+bmYrfbW3y/+pqQVqNXSq0F1mqtC329r8Va61UtHJeN0RNb43u8AngZWK21XtnC8SuAFQAjR46cdfTo0Z58GSLCfO23+Xg1XP3qGGpLvHwnbwgDBlvgzB548mJY/P/gkgeC82SuevjVZBhzKdzyHABlxS60Fwqry1jx0k6evXM2VzSfh9aDulSN3j8H7Iongt2coOrL1eiDTarRt88OtLtkqW8IcWzAkOM6rbUdsPu3NTt+ndY6S2udlZ6eHuQmi0h2tKyWXScquXbqkMaCujH+HljB/4E5CmZ8I3hPaI2BGbfDvk1Qbaz3l5phJW2clcsvHEhCtGQjBlNfrUYvDKGeVLIDSPL9nAE06Wv7EjcOaa3X4Qt2vt5Vgda6/ZxSIYLs9c+/AmDxmEG86qkgKkFhsSlw1BjJFhfcCHGp7Vylk7K+Ddt/C4XPwWXn8pZsFhNLpg7mjS9O0+DyEG3txQV+e3nPy6+vVqMXhpD2wLTWG4AM3xBhUkAyhz+QrQWKA/avwxg6DEwACf/UehExXtt1isyRSSQ2v//1xXpwVnet8kZ7UsdCxhVGer7Hzdl9Tt58uIyPn6niumlDqXG4ee/LkuA/rxB9TMjT6LXWa7TWeYEZhVrrxb5/i3378vz3urTWdl9yx4aW7pcJ0VMOnq1m3+lqrp8+lDrfgpJxqWbfopV/gEEXwvDZPfPks++GqpNw4C3qK70UbazjcH4D88amkhJn47XPZRhRiMirSyMi0+Oq06e8Vnsbilu59sNZJOs67lw6CrSCXx6EujiIqodf9dB3QA2oeFh/C7GO4UAetQeKsDyxiGs89/HK54uoOzWPWOVo70rn+0HoEreE6ElSiUOIFmgNrzkWcJG1iIHmCqwWB+nJ+0lP+RKcVkCD1dVzDVCA1QkeC/HRxnBhXb2RoHRd1AfUE02e46Kee/5ueucXFbzzi4r2DxSiGySACdGCPZ4xFHtGcH3U+013aAVuqxG8Ot+p6xyrC9BEq3qU8tDgTMLjsTLbuodBpjJecyzo4Qb0Hna7vbH0k38uVbAEVsQIrA7vry0oei8JYEK04PWGSzHj4eqobQAU7rmTN/N/SWXFKEAZvaOeZtJgcaPcFuJjjWzIuoYUzMrLNVH5bHVmUeWN7fl29ALLli3jlltuaSwllZGRwapV3b8l7q9Y7xdYHb61klWi95AAJkQL3nbO5SJrESmmKgCOnFpA0YFlxJhqwewGc4iqYVidoE1MGfk6cG4Y8ZqoD3FiZauz42tB9VV5eXkkJSU1CSbZ2dmNvbDAntKaNWuaBLb2qsi//vrrTSrWN6+J6Ge32xsruvsr2vf1Su79gQQwIZopdg/lkGcEi20fNW6rq09j9KDt2MyO0PS+/MweMHmYNuZVRg/dijK5Aci07CNFVZLr7L33wYKluLi4xSK5KSkp2O32Jj2lwJJIHaki/8UXXzSpWB9YHT7Qo48+2tj727lzZ7+o5N4fSAATopk8X1BYHBUQwBpSmZHxEl6twOIOXWMUYHWRFHuKZdnfYmDKPgDMystC2ye868zCpXvxhOYgyMrKaizCG6i8vLzNIb6OVJHvqMLCQsrLyyksLGTlypX9opJ7fyABTIhmch1zmWwuZrjZyP7TGhQexg59D23x9HzyRnNWJ6DBZWuyeXHUx1TreD5xTQ1xg0LL3yvyF6n1D+M9/fTT5x0bGOg6W0W+rQUk/cOK/rXE+kMl9/5A5oEJEaDMm8BO9yT+KfbcYoIudywXjNyEQqOiakPfKAXa4gKXjXodQ2yMkZ6+wPYpUTjIdV7EJbZdoW9XCK1fv77xntehQ4cYO3Zsk+FC/5Ih/iBnt9tbrCLvr9oeWLF9ypQp5OXlkZWV1aSiu91ub/z5oYceahIMd+zYAdBYVV6ER0ir0YdCVlaWbm1FVBHBOjiReX3DIn5Y/S+8nvQAU62HAKioGom1wUJZdQajxobn2/ahw4sZm/YxRcevZeqUFxu331P5U/a6R5Ofcjeqoz3DTk5k7ko1ev8csIU/Su7UeR1ht9t59NFHmT17tmQKBpFUoxeij8t1zGWIqYQLLIcat1lxER9Tytnq8WFrl7K6+Kr8Akak7jSqdPhk2z7mpHcQez1jwta2UEtKSqKwsJC1a9dK8IpwMoQohE+DtvGBcyY50XlNejPxlkrwmpg9/cmwtS02uoxPv7ibq7P+HTxmsBi1GRdFfYKq8ZLruIgplsNha19zPdHzCtR80UgRmSSAiYhSZh/HkVNGBYtBqUUMH2Tcy6iqGcKm4hWMbxjGhdHp7LTcBUCUpYqpQ3JxmcEa6uSNAHExJew7fjVXTPsldbXDKXWMYMKot0g32clUB9iz9zZ2xsa0eG7GsHdJTjzSrefXWqM6PEYpRHB5vV4FnDf5UgKYiCj/eO93lFYY93NmT32qMYBVVI3hxM67WQAc5V78a3pfMf0XeLwWar3xJFEVnkZj9MC82kzR0a8xc+xf+WDP/UwY9RYAi8yfUfvFMt5hRovnxl9+tlsBLDo6mrKyMlJTUyWIiZDzer2qpKQkEShqvk8CmIgo/koW0ya8yLCB55J94mJPs3/MCQabyrjcZqRTm5SL6RnrKakax4C0Qy1eL1TMZhfXXfbPlJePw2xykzXhT437FkZv5+ejS5lr/ZxJlqPnnZuUcKRbzz18+HBOnDhBSYmsQdafnT592uLxeNLC3Y4WeIEit9t9T/MdEsBERHH7Fqa8fPZ/EWWradz+VZwi94JyfjXgVyyKftfY6LSCI4bBQ3Y23nMKp4mj34DRQF0sw5KKfEuuwMTogxydthOb5TjfS/x/QX9eq9XKmDGRkyQSqaZMmfKF1jor3O3oDMlCFBHF7Y4GwGJuuo7We07j7/ZSW8BkVpcNTB6jnFNv4quPiMf4/qkUXG7byTbnNBq0tcmh9uqRFJ+4nPJKKXck+h8JYCJieL1mvNqKUh5MpqZreb3nnMU0y37STJXGBo8JvGYjWPS22z4WNyivb10yw+W2AuqJZofrgiaH7jm0lFdyn2P3wZtC3UohelzIhxCVUjmAHcjQWp+3qI9SKtv342Kt9aqOnCNER2gUF134O7za3CRN3u6N51P3RP4p9uVzG502enzRyq7y1UfEaQOvApPmYtsX2HDynjOLBbbPGg/19zT9Q6dC9Cch7YH5AhFa6zzf4+xm+zOBTN/+TKVURnvnCNFRZpObS7NWc/ns/26y/X1nJl7MXGbbaWzQhG7Ryq7yV8T31UeMUQ4ushbxbrPlVfwBzCMBTPRDoR5CnA34q20WA03KQmutC7XWa5RSSUCx1rq4vXOE6K73nLNIUlXMsOw3NrhshGzRyq7yLXaJy9pYmeMKWwHFnhEc9wxqPMxiaQDA7YkORyuF6FGhDmBJzR6ntnJcFuDPW273HKXUCqVUgVKqQFJ9RWucrliOnFzAVyXTGrd5teJ9ZyaX2goxK68RDJxWMIVw0cqu8idzuI07AZfbjGkB7wX0wswyhCj6sVAHMDtw/sp0zfiGC8cG3Ptq8xyt9TqtdZbWOis9PT0Y7RT9UGX1CNa//Tyb8x9v3LbbnUGpTuZy//ChxwzaDLZeeO+rObPHSObwDSOOMZ9ipOmrxoxKAIvZ3wOTACb6n1AHsB2c61FlAE0KmimlViulVvge2jECV5vnCNFR/mE0/7AatJA+77IZQcHSBwKYAmxOI53eY2oxnb4xicMtQ4ii/wlpANNabwAyfIkYSQGJGf6gtBYoDti/rrVzhOgsfy/EHDAH7F1n1rn0ea8yhuMsvTh5ozmri8DFLv3p9P5FLkcO2cbKZXO57rIHwthIIXpGyNPotdb+VeHyArYt9v1bzLmEjby2zhGis/wBzD+sZvfG85l7wrn0eZcVUEavpq9Q2gi4LitENQSk08/iUtunWC0NWONPhbuVQvQImcgsIkbzKhwfOGeeS5/XGL0Ys9vI8OtLbC5AgcvamE6/tVk6vRD9kQQwETE8nmYBzDWTBFXDdMt+Y+hQm3p36nxrTB7jP5cNNFxmK+SQZwQnPelU1w5i45a1vPXhL8LdSiGCTgKYiBiBQ4haGz2wS6y7sPgz+ZTXmFvV1yiMwOs1g9fMAtunAOQ7Z+Dx2jhw7OrGNdCE6E+kGr2IGBNGv8HwwZ9gMTs45BnOV9507rf9Fby+wri2hr6TvNGc1QWOaHBamRB9lIGmMt53zeRayy5A0uhF/yQBTEQMm7UOm/UYAO/X3QBg1A10Wum1dQ87yl8f0WVFaQcLrJ+yxTkH5UtIkTR60R/JEKKISB+4ZjLGfJIRpjPG8KGlDyZvNGd14k/muNT2KXadwJcMBaQWouifpAcmIsaeQ1/j4LGrGDfmdT6Ku5Bl0XlG0d7eXvewo8xeI4vSZeOSGOM+2IduYz6YxxuF1gql+niQFiKA9MBExDhbfgFfHrmOooqLqCeaBbZCX93DXrhoZVf56iOm6VousBzkA/dMKScl+i0JYCJi+IfRDjMQC27mmb4Ar6V3L5vSWf7FLl02Flg/pdA1mRHD3mfciLfRWv7cRf8iv9EiYvh7IAcZQqZ1H3EejZG80Q+GD/38yRxuC9nWHbixkDR/HTdm34PNWhfu1gkRVBLARMTwF/M9RhqLLJ8Y5Zf6U+/LzxeQZ+jDRNPAB86ZYW6QED1DApiIGP4emMekudb8Mf0meaM5kwazG4vbzCW2XWyvm0117WDcHlu4WyZEUEkAExHDPxfKZq5hmKfSl7zRyxet7CqbC7SJ2825TP9wPk+9/AmlFZPC3SohgkoCmIgY6Sl7OJtWztWJb6K0qW9Vne8ss5HMMVftx+Ob3yZZiKK/kQAmIsbQ6S+yfu4Jrk9+DdB9Y9HKrvLVR4z1uhk84EtAqnGI/kcCmIgYH7pmkI6dUbrMuPfV35I3mvMtdnnZ8PUAuKQHJvoZCWAiYmyrvoiVpk1G3LL1496Xn0mDxc2MgXlYzXUcdY0Id4uECCoJYCIiuLWJwe/msMxViEtbwNRPkzeaszqJstQzacQb7G2YEO7WCBFUIQ9gSqkcpVS2UmpFC/uSlFKZvmNWB2yvUErlKqUeCm1rRX+xyz2BiWnbSYz7Crcpgr63mT1U16czY+zLHHSODndrhAiqkP4lK6VyALTWeb7H2c0OuQXI0lpv8O33B7llWuvFWus1IWus6FfynTOYPWo91fUDwdKPsw+bU6CtLgYn76F84BkatDXcLRIiaEL9VXQ2UOz7uRjIDNyptV6ntV7ne5gRcGySUiojNE0U/dEB1yjGDdzG54dvxhJJAQxISDqGG8UNsXkUuiaHuzlCBE2oA1hSs8epLR3kC1bl/p4akAKUK6XWtnL8CqVUgVKqoKSkJGiNFf1DjcPNhd5jaG3i8+IcLGZHuJsUWgq0xc315u3scFwQ7tYIETShDmB2jGDUnhyt9Ur/A1/PzA7Y/cOQgXz7s7TWWenp6UFrrOgfdhz8ihzL+xz86nLqnUkRtybWybOZfFGcQ7RyEe+JgOxLETFCHcB2cK4XlgHkNj9AKZXjv9flS+hYoZTKbH6cEB1VsWM9qaqazw4txxxpvS/gq5KZbPnkvzhZm8FC9TkVNQ3hbpIQQRHSAOZLzsjwJW8kBSRz5Pr+zQZWK6V2KqV2YvTWXvbtywm4hhAdNuH4y5zWScyc+geuXvCDcDcn5PxDpkdKZzPGdJovP9oU5hYJERyWUD9hQCZhXsC2xb5/84CxLZxW6PtPgpfolNKje5nq2ct203guHnVehz8i+FdkrqwYT+XIWKKKXoLsm8PcKiG6L4ImxIhIdGb7CwCk2ErD3JLw8ffA3O54djGGifat4KoPc6uE6D4JYKJfSz78Op8yicFOB9s++2eKDkZez8Ps64G5PVHUm03E0kBJ4ethbpUQ3dfpAKaUmqGUukkp9aBS6h7fzzN6oG1CdIs+s4ehjmIOpF9JTe0wPvz0QT7b941wNyvkLBZfD8wTxVjbEUp0AnWfvhzmVgnRfR0KYEqp0Uqpp5RSbwErMe5TVWLU8x4LfEcp9bZS6kml1Ogea60QnVD+yV/xaIVt2o24PcZSIlZz5GXg2Sy1xMacJdpWxVjLSd4zX8KQM1vBUR3upgnRLe0mcSilfoiRDbhKa13ZzrGJwAqlVIXW+pkgtVGIztMay96/sd07haypk3C8YiwlEolp9MMG7eR7t2Y1Pj4z8lpsR97Eu+9NTNNvCWPLhOieNntgvuC1QWv94/aCF4DWulJr/Utgi1LqwWA1UohO+2oXiXXH2B5zOcOTYxtXI464KhwtGD7tck7pFGp2vhTupgjRLW0GMK31L7XWhzt7Ua31Ya31Y11vlhDd4/liAy5txjnhWoDGIUSLJfKGEJu7ZPxAXvdcTNzx96C+ItzNEaLLupLEMboH2iFE8GiN+/NXeN87jVmTjBrQngjugdXUDeTJlz7h2b8Z8+DSB0TxRdIizNoN+2RSs+i7upJGn6yUusf/QCl1s1JqYRDbJET3nNhBVO0pNnnncnFGGgAm5SYmqowoW1WYGxd6JpOLmrrB1NQPbNw2cOJcjumBeL6Q2gCi7+p0ANNafwqM8wctrfUrwJVKqbuD3TghuqToFZxYOTV4EYmxxvpXU8dv4J9um8kVcx4Jc+NCz9/r9PdCAeZPSOcfnosxHX4famQFB9E3dWUI8S1AAzsD5n89CshikyL8vB68Ra/yjncmsyaMCHdregV/AHO5o9G+QvwXjUnhTT0PpT2w9+9hbJ0QXdeVIcSxwFpfVqLypc4/7ftPiPA6+iGm2rP8wz2XS8alhbs1vYLJ5MGkXIAJr9fokcbaLMSPmMZR00goejW8DRSii7oSwK4EVimlEnzDidnAJ1rrHwW3aUJ0QdErOEwxbDdnMWtUcuPm/E//lade3s4X+yNz3pN//ps7YBhxwYR0NjjmoI9ug6pT4WqaEF3WlXtgxVrr+7TWVb7HrwCVksghws7jgj3/4APTbGZkDCHKYm7cVVefSnXtsCYf4JHEavHXQ4xu3LZgfDqvey9GoWH3xjC1TIiuC8pyKlrrp5VSY4JxLSG6rHgr1JfzV+dsFoxvujJ3JKfRA8ye+hRer7VxaRWAqcMSqYgZyQnbeIYXvQIXfzeMLRSi84JWjb4rE56FCKqiV3BaBvC+dxqXTmh6/8vf84rEUlIAcy5cx9zpvyPKVtO4zWxSXDI2jb+55sLJAqg4Er4GCtEF7ZaS6srEZaXUGCklJULK1QD7Xqcg9hJSEgYwNj2+yW6pxNGyBePTeKnOVydRkjlEH9NuKSlgsVLq0Y4EMqVUglLqF8DNUkpKhNTBPHBU8VxVFgvGp6GUarI70mshnjiTxZdHrqauIaXJ9vnj0zih0zmTOE0CmOhz2r0HFnB/6ztKqZlAMWAHDgFJQKrv37G+bWvaGk5USuX4zs/QWq9rti8JyPD9N1trvaq9c4QAoOgV3NEp5Non8j8T0s/bfe4eWGT2wPILf8jx0xezfMlyRgZsH54cS0Z6HLmm+XzjzO+hZD+kTwhbO4XojA7dA/MV5/2R1voqjAnLeRhrgVUCBcA6rfWVvuzE9oIXWus83+PsZofcAmRprTf49q/owDki0jlrYf9m9iQvxKvMzG9h/teUsa9y0bTfkhh/IgwNDL+W0uj9FoxLY23phWgU7JZemOg7Op2F6AtQh4EtXXi+2YB/DYdiIBMjGPqvHdi7ygBygcVtnSME+zeDq45XHBcxdWgiKXG28w6ZNiGylw7x9zzd7ujz9i0Yn86ftidSNfQiEotegctWQbMhWCF6oy5lISql7vHdF7tHKZXQiVOTmj1ObeX6GUC5r9fV7jm+nlqBUqqgpETqukWcolfxxg/mhdNDWTBeqm+0xNJGD2zu2FQsJsX22MugdD+cKQp184Tokq7UQnwKGIcxhHgLcLgThXztGKs7tydHa72yo+dorddprbO01lnp6eff/xD9WEMlHHib40OW4PIq5rcSwA6fvJTDJy/F7Y7MicwtFfT1i4+ykDkqmefs00CZoeiVUDdPiC7pSg8s13c/7Eda6ysxkjfGK6Vu6sC5OzjXo/IPETahlMrRWq/x/ZzZkXNEBNu3CTxO3lLziLGam5SPCrRp66/Z8PZfcLjiW9zf3/mnD7g85w8hgnEfbNtXCueoy4wA5q/6K0Qv1u2JzFpru68OYovDgc2O3QBk+BIxkgISM3J9/2YDq5VSO5VSO4GU1s4RAjA+bJNG8sKJdOZmpDQpHxUo0tPozW30wAAu9WVuFqVkg/0YnNwZsrYJ0VVdKSVVrJTaAfw3sMVfExEo68jJ/t4VTZM3Fvv+zcPo0bV7jhDUlkHxe9hnfIcj2+q5a35Gq4dGeimpS2Y8wdxpv8NmrQHOn4ly4TAj+WV9zXQyzTZjTtjwrNA3VIhO6EoPbDnwMvB14IhSaodS6iWM4T0ApLCvCIm9/wCvm/ejLgXgshbmfwF43RqvtqKUB5PJFcoW9hpRtmpio8uxmJ0t7jeZFJeOT+PtQ/XocYuNdHqvN8StFKJzuhLADgHrtda3aK1TgBUYc8GuVEqV+Xpnq4PZSCFaVPQKpI5n46lkRqfGMjotrsXD3E7jfo7F7JDs8DZcNjGdslonx4Yugeqv4Nj2cDdJiDZ1ZTmVp4Fkf2kprfWnWutf+iYypwIrgYrgNlOIZqpPw5F83FNuZHtxeau9LwC3wx/AIrMKB0Dx8StY//ZzFOxuPWHYX8H/DccMsMZKNqLo9bqUxOELWkda2VcIrOpOo4Ro1+6NgOazxIXUuzxcNrGNANZgBLBIrUQPUFM/iCMnL6e0YmKrx6TFRzFteCJbDtXAhCWwZyN43KFrpBCdFLTlVAL5VmoWoucUvQKDLmTz6URsFhNzM1pPgo0faOa+5Vncfu3S0LWvl2msxNFKGr3fZRPSKTxWQe2EpVBXBoe3hqB1QnRNjwQwIXqU/Ric+ASm3sTW/SVcNCaFWFvrCbUmsyI+9iwJ8V+FsJG9S2MtxHYmcl82IR2vhve90yEqQWojil5NApjoe3b/DYDTI6/hwNmaNu9/CUNbpaQCzRiRREK0hXcOVsKk62Dva+CO3KFX0btJABN9T9ErMGwW75yOBVpPn/c7u8/JK7nPkl/4g1C0rlfq6BCixWxiwfh0tu4vQV9wo1Gq69A7oWiiEJ0mAUz0LaUH4atdMPVmtu4/y7CkGMYNbLs8VG2Zh+ITizhVMjNEjex9OtoDA+MLwdlqB/tiZ0FMsmQjil5LApjoW3a/CiicE7/GhwfLuHRC+nmrLzfnHwGL1CocALExpYwb+RYjBn/c7rH+jM73Dtphytdg3xvgrOvhFgrReRLARN9S9AqMmseO8mhqHG4ubyN93s+fRh/J88CSE45y46J7uSzrF+0eOyghmilDEnhn3xmYejO4auHAWyFopRCdIwFM9B1n9kDJPph6E1v2nsVmMXVo/S9PQCUO0TGLJg9k59EKKtJmQ/wgozaiEL2MBDDRdxS9AsqMnnwDW/adYd7Y1DbT5/0aK3FYIrcHprWiqmYI9uqRHTp+0eRBeDVsPVgOF9wIB96Ghqr2TxQihCSAib5BayOAjbmU4vpYjpbVsWjSwA6deq6UVOT2wBzOAaxd/zF/+vsbHTp+2rBE0uJtbNl3Fi64CdwN8OWbPdxKITpHApjoG059ChWHYerNbNl7BoArOhjAEoaYyRi+hbTkL3uyhb2av/fZXhq9n8mkuGLiQN778iyuobMgcYRkI4peRwKY6BuKXgGTFSZfx5a9Z5k0eADDk2M7dOqExbHcvPgupk34aw83svcym4xlVLxeG15Px1ZbXjR5ENUNbgqOVhrDiIe2QF15TzZTiE6RACZ6P6/XqL4xLptKHU/B0QoWTe5Y70sYlDqXhelPamnP/PFp2Mymc9mIXrdRmUOIXkICmOj9TnwCVSeNycsHSvB4NQsnDerw6fV2DzV1A9utA9jfNVbjcHQsgMVHWbgoI8W4DzZkOqSMldqIolcJeQBTSuUopbKVUiva2J/bbFuFUipXKfVQaFopepWiV8ASAxOvZsveM6TG2ZgxIqnDp7//P5U8+VIBuw/d3HNt7AMaC/p2MIABZE8eRHFJLYfL6oxe2OH3oeZsTzVRiE4JaQBTSuUAaK3zfI+zmx+jtd7QwqnLtNaLtdZreriJorfxuI3hwwlX4rbE8t6XJVw+cSBmU8eXVvZ/YEfyemAQkMjRiQC20Jcos2XvGZh6E2gv7Pl7j7RPiM4KdQ9sNlDs+7kYyOzgeUlKqYyeaZLo1Y7mQ20JTL2ZwmN2Kutdnb7/5f/AtkZwJQ6Aq+c/yC1X3Up8urnD54xIiWXCoHi27D0LAyfDwCmSjSh6jVAHsKRmj1tfhbCpFKBcKbW2pZ1KqRVKqQKlVEFJSUl32id6m6JXwBYP46/k7d2nsZk7Vn0jkPTADCMGf8yooduwxnTuzz578iA+OVKOvc5p9MKObYfKEz3USiE6LtQBzI4RjDpFa71Oa20H7P5hyBb2Z2mts9LTZW2ofsPthD3/gEnXoi3RbN59mvnj0xgQbe3cZaQSR7csmToYj1eTt9c3qRka12QTIpxCHcB2cK4XlgHktn6owde76uhQo+hPit+FBjtMvZndp6o4UVHPVRd0PPvQTypxGIoO5PDejp9QVuzq1HkXDktkaGI0m4tOQ+pYGDpThhFFrxDSAOZL0MjwJW8kBSRzNAYy376sgJ7Wy77tOQHXEJGg6FWIToKMK3h792lMyhjO6iwp5mvYf/QadhR9h4qj7k6dp5TiygsG88GBEmodbiMb8dSnUF7c/slC9KCQp9FrrddorfMCMwq11osDfs7TWif7A5XW2q61LtRab9Barwp1e0WYuOph3yaYfD1YbGzefZo5Y1JIje/8XK6FP0pm6cK7SRpwJPjt7EO6kkbvt2TqYBxuL1v3lxhVOUAq1Iuwk4nMonc6kAvOaph6M8UlNew/U8OSCwZ36VLDM6MYPyqX6KjIrqZu6UYAmz06hdQ4mzGMmDgcRsyVACbCTgKY6J2KXoG4dBi9gLd2G8V7r+xiABOGzlbiCGQ2KbInD+LdfWdxuD3GMOLZ3XB2b7CbKUSHtb+YkhDd8XjHJxw30kDNALC64AkrmyseZ7pFMfQP13WpCds+ewB4gDlTn8Jiidz7YP4emGfzA3D8/zp9/hJHFi85/oNtay7iCmshEA/PzISoLrynP+h8EBWiOemBid7HbQEUWFyc8qSxyz2Rq6K2dflyH3/+PT789AdouhBM+5HGHlgHl1Rpbp7tM+JVHW8554FJg9kDLovxhUOIMJAAJnoftxWUF8we3nbOBWCJrWsBTOtzH9iRnoUYG1NK4oCjWC21XTo/SrlZaPuEXMdFeLQJLC7QZvDKx4gID/nNE72LxuiBWVyg4E3HJYw3HyXDcqpLl/N4jKxFs8mBUpHdVZg99WlW5Cwgc8qfunyNJVHbKdNJfOy6wBjiRRtfOIQIAwlgondxWwEFVhenPal84rqA66I+6Prl/L0vqcIRFFfYCoilntccl4ICzG5wWWUYUYSFBDDRu7h8w4cmL6875qMxcUPU+12+nNvfA4vw4cNgiVEOFkd9zJuOS3BpM1jdoE3g7XiBYCGCRQKY6D28CjxmY2hKwWuOy7jQcoAxXRw+hHMBLNLvfwHsK76e3zz/BZvzV3frOtdHvY9dJ5DvnGkM9aKNZA4hQkwCmOg9ArIPj3iGsMs9geu70fsC0NpEQtwJ4mPPBKeNfZzDmYjTNaBb17jUVkiiquYf/mFEi9sY+pVhRBFi8rVJdNunf63B627502t46VQGpRUBUF6ZweGTl7V6ncxRL6NMHjB52bj/e0yrTGVc7DB2mu5qclxKQjFjhm8FoMGRyO5DN7V6zQmj3mTlLfM6+5L6JbMvjb7MPo6de4z3NDXxIKOHGfcY6xqS2Vu8tNXzJ47eRHzsWWzKzfWVx9lXtpSP4qpJjz3C2LSP+bL4Omoc6cREVTBl7MbG8wr3fAvd/LvyX6oBGJEVxcBJNgBKD7k4ur3pvcr4gWYmLI5BqcieAiFaJgFMdNqJQgdDp9kwWYwPla2/suOqazmAXZY1rzGAnSmbyjsf/2eLx8VHnyFzxAawOUDBmS+vYUFZGjt56LxjJ435e2MAq2tIafWaAOnJexkQd7pTr6+/io6qBKDUPqnxPbtg3PrGAFZbN7DN93Jw2i7iY88CMPF0PIn7R/MBP8Virud7119KffUg3vn0Z6Ql7WsSwN7d8VO8XlvTi31sB2DRT5IaA9jpL5y88wv7ec+b81QaY+bHdOUli35OApjolLJiFy/ecZbk0Rbu/sdglEkx45b4xorvzQ0q2934c3LCYTInP9vicSNSdqJQYHWzzz2K3YMdXJXyDpMsR8+/ZuoXjT9H2apavSbAgFgJXn7DBhZw6axHqak7V5JrcPpnjT/HRNvbfC/jYs4tFps19A3+xzWDdFM5C207Ka8ZxZRRr1HeMIzY2LIm582c9BxaN0vymHk/AOkTzqXgp2RYyLwtvvFxWbGLox852P2POglgokVK6/41cJ2VlaULCgrC3Yx+K/9/K9m+tooLb4xjyX91YG3SjpaSqo0FFMTVsqbmDtbW38wnqd8k1RTZBXh7s/+oWcEL9UsoSP0GCV4n1MdCTC1YPO2f3IFSUpWn3Ky78its8YrvbR2GJUqGEXuSUmqn1jor3O3oDEniEB2mvZo9rxtVHKZcHxu8C3sVeI3Jy1rDa45LucT6mQSvXu6GqK04sRnVUsxujGzE4E1qThxq4YbHU7n3jSESvESLJICJDjv5mZPKkx4GDDIzIqvz63K1yv+hZ3VR4J7Cce9gvha9NXjXFz1ipuVLRpq+4m8NC33ZiK6gZyNOvCqW2BSZYyZaJgFMdNie14ze1+RrY1GmIH4jdlvB5AaT5uWGxcSrOq6O+jB41xc9QinIid7Ch64ZHPcM9JWWUr7pEMGlvbpLy8CI/k0CmOgQt1Pz5Vv1AEy5LojDhx5fFQermxpvDJsa5nN91PvEKpl43BfcHL0FhZcNDdlGdXrlDXptxN2v1fLU4q8ofKE6qNcVfV/IA5hSKkcpla2UWtHG/tzOnCN6XuUJN1EJivSJVtIn2No/oaPcFkCDxcUbjvnUEUNOdF7wri961DBzCfOtn7GhIRsvyjepObhLrFhjFDVnPOx5vS54FxX9QkgDmFIqB0Brned7nN38GK31hs6eI3peaoaVe98cQs7a9OBdVGN8Wzd7fMOH2Yw1HyfTsi94zyF63C3RuZz0DmSba5qvtFRwhxEzLo0hOsFEyZcuSvY7g3Zd0feFugc2Gyj2/VwMZPbQOaIHKKWITwviDXWvb/jQ4uKQexgF7gu4JToXKbrQtyyO+ogEVcPLDYt7ZBjRYlNMvMqYB7Zvc33Qriv6vlAHsKRmj1ODcY5SaoVSqkApVVBSUtJ8t+gmr1vjrPMS9DmDbivG8KGb9Q3ZmPFwY/Q7wX0O0eOilYulUe+x2TGPSh3ny0YM7jDisJlG1mvlSXfwLir6vFAHMDvQgdmvnTtHa71Oa52ltc5KTw/iEJcA4MxeJ7+ec5Lnbz8bvItqjPR5swe3UrzqWMgVtgIGmuzBew4RMrdE5+LEZhT4tboxhhGD1wuLTjA+qhqqvEG7puj7Qh3AdnCuR5UB5LZ+aLfOEUHk/9CwxQZxbM9rMtaRsrrY6pzFWW8qy6Llf21fdYHlEJPNxbzUcBWYfMOIQVxiJcoXwBwSwESAkAYwX4JGhi8RIykgMaPxk8u3LysgeaPFc0ToOKqMsaDoxCD+urj8w4cunqu/loGmMhbadgTv+iKklIKvx7xFkXscn7onGHPCPBajykoQpGZYuPrnKSx4IDEo1xP9Q8jT6LXWa7TWeVrrNQHbFgf8nKe1Tg7MRmzpHBE6DdXGt96oAUH6dfFnH1rcFHuGstWVxe3Rb2JVHaihJ3qtm6LeIV7V8af664OejRiTZGbq1+IYOSc6KNcT/YNMZBbt8g/b+O9DdJvHbAwfWlw813AdVlx8PWZzcK4twibeVE9OdB6bHPM5ywBjKDHIk5qFCCQBTLQr6D0wX/ZhjcnKhoZsrov6QJI3+olvRb+OCysvNFxjTGr2mIM2jPjZSzVse7ISdytL94jIIwFMtKshmD0wjTGsZHHzinMRNTqWb8W83v3ril5hjOUUl9sKeL7hapwWL8EcRvzwd5V8+LsqGiolkUMYJICJdk27KY6rH0lh5JwgVKD3DR96LW7+VH8d0y1fMsO6v/vXFb3Gt6Jfo8SbwpuuecYwYpCWWPEnEUkmovCTACbaNeTCKKYujSNlTBA+iHzDh/neCyj2DOeumNe6f03Rq1xmK2SM+SR/9CdzeIOTjegfwpa5YMJPApgIHf/kZYuL/2tYSpqq4Jqo/HC3SgSZSWnuiH6dT92T2M1wY2MQkjn8Q9iOaglgwiABTLSr8MVqCl+sxlnbzQ8OjwVQHFFpvOfM4s6Y17ApKQ3UHy2LziNRVfNEw9eDNowoPTDRnAQw0a5tv69iy8/tuBq6mf3lsgJefum4jQGqhjskeaPfijfVc1fMP8h1XswZ8wCjaLO3ex830QnGMGSD9MCEjwQw0SatdXCyEH3Zh3ZzNJucl3JnzOskmGR9p/7szpjXiFd1/MZ5E6C7XVoqJtlMTJIpqEWCRd8mAUy0yVWv0R5jUUGztRs34t3G8OFf3IuJxfh2Lvq3JFMN34zexAuOJdSbLN2+Dzb/nxL5p/xhZN42IEgtFH2dBDDRJv+cm25PYnZbcaN4wnEL34h5gxRTVRBaJ3q7u2M3EoWTNzxzjGFEj3zkiOCR3ybRJn/Gl//+Q5f4hg8/ZiImNPfE/i04jRO9XpqpkttiNrPacbsx8ielpUQQSQATbfLf/+pWD8xtBRRPOJbx9ei3pGxUhFkR8zfsDOAAQ4xEni7ewzr1uYN1V53ib/fLorXCIAFMtMnjNJI3YpK68avislCu49mtR3Ff7Ib2jxf9ymBzGd+I2cQfXNcaRZy7mI1oMisqT3qo+kpWLRCG4K04J/ql0fOiuX/bMLTu4tdmDV6PlZc9l3NP7EYGm8uC20DRJ9wf+xLXNTyBW5uwdHFOmExkFs1JD0x0iFJduwemXVZMwAfeC1gZ+2pwGyX6jGRTNXfGvs673hk0uGLB2/kgFOWfByYTmYWPBDDRo8qcaRR7B3NdzFbiVEO4myPC6I6Y19imJxONB8+xjzt9flS8rwdWo9FemQwmJICJdnzwazvrlpxiz+u1nT7XaT9NsreO7Xoyy2LyeqB1oi+JUm6yoj+nQVspfu+5Tp9vMits8Qo0OKolgIkwBDClVI5SKlsptaKj+5VSFUqpXKXUQ6FrqQCoPuOh8oQHb2dLFroaOPrXf8WsNOOjDmFRMuwj4JroD9mpxzPoyN+pPfhhp8/33weTclICQhzAlFI5AFrrPN/j7A7uX6a1Xqy1XhPC5goC0+g7cQ+s4iiOpxcz/vQmXtdzmB1d1EOtE32NUpASfZZyHU/0X66H7b+HTiQIZd4+gPn3J2KLC84qz6JvC3UPbDZQ7Pu5GMjs4P4kpVRGzzdPNOcfqulwHcT9b6HXXoq75BD36x8yK+5Tupj/IfqpyVHFvDTjz+R5ZsJbP4b134KGjlVmmf2tAVy8MoHYZHMPt1L0BaEOYEnNHqd2cH8KUK6UWtvSRZVSK5RSBUqpgpISmeQYTB2eyOz1wJb/ghduwW4bzNUNjzDn6m8yRNLmRQvuv3YW/xX3E9bavoXe+zo8fQWc2R3uZok+JtQBzI4RjDq1X2u9TmttB+z+YcYW9mdprbPS09OD1FQB55Zv9y/n3qKas/DnpfDBY9Rf+A2uqnqYwaMmc/uckaFppOhzYm0W/vumaTxadRV/nfI7cFTD04vgsxfbPK+s2MWBLXWUH3GFqKWiNwt1ANvBuV5WBpDb3n5f76r5UKMIkXZ7YEe3w9pL4fgn6K/9jn+p+zZ2t4VHb74Qk0nGDkXrLp2QTs6s4Tz8aSJ7b9gEw7Ng43fgtQfA1fKUi10batj4QBkH360PcWtFbxTSAKa13gBk+JIzkgKSNXLb2P+y75icgGNECGitmXP3AGbdEX/+TXOtYdtv4Y/XgjUG7snjufr5bN59mh8snsDY9PjwNFr0KQ9fO5mBA6JYufEEVbesh/n/Ajv/CP93JVQcOe/4c9U4JI1ehKGUVEAmYV7AtsWt7fcNHRb6/pPgFUJKKeZ9J/H8HQ1V8Pfvwd5/wKTrYOnv2VWieWTTNhZNGsi9CyTfRnRMUqyN3942k+VrP+KhV/bw5Dd+hho+B/72HaNnf+M6mLik8fho30iAVOMQIBOZRWed2Q3rLod9m+DKR2D5X6j0xvLd5wsZOCCax2+ZLkOHolNmjUrhR1dPYvPu0zz74RGYdA2s3ApJo+DF5ZD3n+AxJiJGST1EEUACmGhVXbmHg+/Wc2av09jw2QvGjXZnLdz5Osy7H6+GH6zfxdnqBn5720ySYm3hbbTok+6eP4bFUwbx32/spfBYBaSMgbtzIfNbkP8rI0mo5uy5IUTpgQkkgIk2nNnr5G/3l/LB42fgH/fDxvuMG+0r34dR8wD4xeZ95O09w0+umczMkclhbrHoq5RSPJYznSFJ0ax4roCjZbVgjYYbfgNLn4QTBfDUAgY4PwFkCFEYJICJVjmqNIlxx8keshwKn4P5/wrf3AgDBgHwzAfFrHu/mDsuHsWd80aHta2i70uMtfLsnXPweDV3/N8nlFQ7jB0zboN78sAWR/q2G8ka/0cc1bImmJAAJtpgO7WZOxYtJ858HL7+EmT/DMxG3s/GT0/yyKa9XHPhYH52/QVdXm5FiEDjBsbzhztnc6aqgbv++Ak1Dl8RzsFTYcW7MOEarpj+GHfe+kNoqAxvY0XYSQAT5/O4Ie8/yDh+F/ba4RTGb2qSCfbOvjM8uH4XczNS+NUtMzBL0oYIosyRyfz+9kz2flXNyj8XUO/09baiE1G3/hmu/DmmA28ayUSnvwhrW0V4SQATTVWfMW6Y5/8Pp2y38cK7f0Ynjm7c/ffPTrLiuZ1MGjKAdXdkEW2VmnQi+BZOGsSam6ex7VAZ3/zDx1TW+SpvKAXz/gnu3ASuengmGz59PryNFWEjAUycc+RDY+7NiQJY+hRfuH6OxxvVmPn1xw8P88BfP2PWqGRevHcuCdFdWxpeiI64edZwfvv1THadsLN83XbOVBnVOd74tzJe/NlY6pa/CyPmwN+/ayQZuaQ6R6SRACaMqhof/hr+dD3Y4uDeLTDj642pytZ4xS/f2sd/vLaHK6cM4k/fnsMACV4iBK6dNoRn75zDsfI6bn5yGwfPVnNql5MTBQ7qHWlGUtGCHxhJRn9YDOXF7V5T9B8SwCJdvR1e+gbk/jtMvg5WvAeDLgBgyX+lsOzvqaw+upvfvXuIW2eP4Pe3Z8qwoQip+ePTePHeudQ7PVz/vx9SZzYSOxqqvGAyw6J/h9teBvtxWHu5McleRASlO7GYXF+QlZWlCwoKwt2M3uHxdpIrPCaojwWtIMoBVicEnPKRcyr/XP1DKr3x/Gf8WpZHvy1re4mwOeNJ4f7qHzIw/wZGlQzg+uy7mTQioB64Vxm/z14z2BzGf+39vv6gf33+dYdSaqfWOivc7egM6YFFKpcV6uKMn2PqwHYueFV7Y/jPmnu5rfLnxKt6Nib/gFtjJHiJ8BpkLueFxH9jVLQxTPhI+f186Jx+7gCThtha44uYM8oXzOSXtj+TABZpNNAQDQ0xYPYYf/AWI01Za3itYQGLKp7ij/XXc09hHN8ttDJWyyKhonewKC8z4nYBYHLZuL3y5/xz1YOc9SYZByggugGi68FjNr6kuWXIu78KeTV6EUatDLFoDe+7MvlN7a3sdE/hQssB1g14hLyv3uKwnoDZ5Ax3y4VoFGWrAuBey2ZmxJ7lqbplbHHO4VvRr3NP7EZSTFVgdYHJA/Uxxu+8zdFklEH0DxLAIoXLYvS6wBgytLhxaxNbHHP4fd0t7HJPYKjpLD+P/y23Rr+Nxx1NrrZgtdRhNsvqt6L3GJSym4mjX2Ng0n7+Ne4Nbox6j8frvsGT9Tk8W38D34zZxLdiXmeYuQTiao3fe2e08cUtul6CWD8iAay/04AjClxRxjfSmDoOe4fwcs1iXnEs5Kw3lRGm0zwa/7/cHL0FmzIyvGodxjpg/m+7QvQWE8dsYuKYc5mGYyyn+G3CGr7vfoHf1i3nmfqlPF1/I/Otn7E8+m0WR31ElNlj/B3Uxhtf4MxSDLg/6H8BrPp4eJ//3e8b/17xRDhbYbTDq4xvnx4LpeYYnvdewWb7PPZ6MjDhYaGtgFuif88VtgKsqmlxVIczAYBom9SbE33DOMsJnkh4nAc9z7G+YTHrG7L5p+ofEa/quMxWwC2Wd1jg/RJTXRxENYDNZfydhPNvtRd9XoxKZkR4G9F5/S+ARSqvF5zVUG+nprKUrw6fZVhtKmbt5T/d3+SFhsWY8JBl3cO/Rf+BG6K2Mshc3urlGpzSAxO9k8djpbpuCNprIjnxyHn7h5tL+Je4F/jn2L+S75rBZsc88pxz2OS4lFTsPG17nEzHIY45h2E5U8ngM/swxSZDTBJYokL+ekTXhTyAKaVyADuQobVe15H97Z3TbwQEIRrsxr/1Fed+9v2rG+x4aitw11ag6yswOSqxuqoxYQyLxAPjgUPeIfzc83XSrWX8KvZxrrAVkGyq7lBTHL4AFh0lPTDRu5RUTOLPr21iYEoR3/raNa0eZ1ZeLrMVcpmtkJ9rxefu8Wx1ZvI/rqVc7N7Pdy2vwb5Xjf98XKYo3LZEiE7CHJeCJS4ZU4wvuEUntf2vBL+QC2kA8wUitNZ5SqkVSqlsrXVeW/uBpLbOac7lsHLyU0eL+9LGWYkaYMwcqDzppuaMb6kGdJN/LTYYNNnW+PjU5w1oL6A1Gg1otAaFJn6QmbiBJrxaU1fmxr4/HWNy+D5MLjvKaUc5KzC5KolLrsLkqIR6O+6yClRDJRZ3JWZ3JVZ3FVZPFYrWx+bd2kwt8VR64qnyxlHtjafUPJxyNZFaUzxR5lTirOnED0gjqW4/KaXb+S/1GrjAYnaQnHYueJ06OxOtW55FkRB/gpjoMiaM3sTgVKn2LXoX/6hAbX06J8/MatyeOOA48bFnfftSsVeNbnJeOpDDAXI4wMD0z9jvGs7p1KsoqZ9Cvb0MT305Fk8VA1QNCaZaBphqiDefJsFSQwK1xNF2rUWPKRp3VCKeqERcKgE3SXisiXitSWhrIl5bEl5bIiouiYSxaaiYZFSdg5ITw1HRpcY8S6Uw/lEopUgcZiU+3YxSJmrLPdiP+4f6VdN/lWLoNBvKZPxNn93vwlWnaWnyZmyKieRRRik4Z52Xki9dxJztm4vRhrQSh1JqNfCS1rrQF5wytdZr2toPpLZ1TnNZQy36k3sSfBc0XpvyBSKlwj/r3qXNVBKHty4Jd0MSDa4EGpyJNDgTaHAl4HAmcCTOwvaRDVTpWKz1MVzy4UU0OBNxeWJonkI1Lfshpg/NZaCpnK07fkLB7pUtPm9yQjH33Hx54+Mn/rwHlzu+xWMvy3qEORf2346u6NsaHIn87wvnf7FadNFPyZzyJwC+OLCMzfmPt3qNf71jbGN27V9e/xtflcxq8Tg1uoCSrHcp8ybiqhjC7A/nE2WrIsZWSZS1imhbFdHWKqJtlRwbfQxLdCWJqpaRtS7SvPWNx0RZa4PwyrtPa+X7Cu57jMLk2zb2txVnj5TrQWFsXqeFOoCtBdYGBKPFWutVbe3H6IG1eo7vvBXACgCbmWlOD5+H6CWdZ1QyI6odxJTXsT9cbfC3A+BoBd3Oakm2Dh8BUOE6cTzw5460oTe9F1U1w4GOtb01nXn9gUbED51S46o1VzgqO9Wl7erztXadhPgTQHB+L7qqM78XXf3d62g7oO+8Fz3djtJaEmocOiac7eisUN8DswMpndzf3jn47ov1mi6DUqqgr9UU6ynyXpwj78U58l6cI+9F14U6gO3Ad08LyAByO7A/qZ1zhBBCRKCQ1kLUWm8AMvzJGf5kDKVUbmv7WztHCCFEZOt3y6n0BkqpFf063b8T5L04R96Lc+S9OEfei66TACaEEKJPkuVUhBBC9EkSwELEN8ctYimlkpRSmUqpnEh8L3yvO9s35SNiRfrvQWvkvegaCWAh4EtAyQh3O8LsFiDLl5RDJH2QB1aY8T3ODm+Lwipifw9aI58PXSfFfHuYUioDKA53O8Kt2U3qSJsOMRt4yfdzMUaFmYjMpo3w34PzyOdD90gPrOdlaK3lF9TH9wdbHmHTIZKaPU4NRyN6kwj9PWiJfD50g/TAusk3PNS8Ukixr/hwm4WH+5u23ouAxzla65YLNvZfdtqpJhOBIvH3oIlI+3zoCRLAusk/lt+K8oCK+hlKqUytdWFoWhZ67bwXKKVy/IWY+/t70Ux7FWgiSgT/HjQXUZ8PPUGGEHuQ1rrQ9w0rhfOHkSKK7w91tVJqp1JqJxHUI5FqMudE8u9Bc/L50H0ykVkIIUSfJD0wIYQQfZIEMCGEEH2SBDAhhBB9kgQwIYQQfZIEMCGEEH2SBDAhhBB9kgQwIYQQfZIEMCGEEH2SBDAhhBB9kgQwIUJAKZWhlDqklMr1Pc70VWQXQnSRBDAhQmMVsBgo9K2+myXLaAjRPVILUYgQUEolaa3tSqkkjOAVsQV9hQgWCWBChIhSKhOMKuThbosQ/YEMIQoRAr7FPov9wcv3WAjRDRLAhOhhSqkVGAtZPq2USvLdA7OHt1VC9H0SwIToQb5Mw2LfCsTFwGHgkNwDE6L75B6YEEKIPkl6YEIIIfokCWBCCCH6JAlgQggh+iQJYEIIIfokCWBCCCH6JAlgQggh+iQJYEIIIfokCWBCCCH6JAlgQggh+qT/D6Fw7s8CbRQWAAAAAElFTkSuQmCC
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABUHklEQVR4nO3deXzU9Z348ddnrkwOcof7DIdcCibBEzyDiifWAK22VmqLdXdtd1cLdWu32127LVS77q/duqBdbK20SLS0aEUJKhi1Qoii4RBIuBHINSHnnJ/fH9+ZZBJyM5nJJO/n48EjM/M95jNhMu/5fL7vz/ujtNYIIYQQ0cYU6QYIIYQQvSEBTAghRFSSACaEECIqSQATQggRlSyRboAQon/btWvXUIvF8jwwE/nSK8LPB5R4PJ5vZmdnnw3eIAFMCNEpi8Xy/PDhw6dlZGRUm0wmSVsWYeXz+VR5efn006dPPw/cGbxNvk0JIboyMyMj45wELxEJJpNJZ2Rk1GCMALTeFoH2CCGii0mCl4gk//vvvHglAUwIIURUkgAmhOjXNm7cOOSqq66avHHjxiFPPPHEsMLCwrjAtqeeeiq9sLAw7qmnnkoHWLt2bcqCBQsy165dm/LEE08Ma3vs2rVrUzZu3Djk3nvvHVdRUWGO3KsSoaCklJQQojO7d+8+MmvWrAqA7+XvHnPgdG1cV8f0xJThQxp+njfreGf7zJgxY9qePXv27d271/bLX/4y49lnnz35xBNPDMvJyWlYuHBh7caNG4ccOnQo5rHHHqsYM2bMzOPHj5e0d+yjjz46+o033ih76qmn0idNmuRcuHBhbShfi+g7u3fvTp81a9b44MekByaE6PeSkpI8bR/btWtX/JQpU5wAU6ZMcW7dujURYObMmQ0dHTt+/HgnQFpamrdvWyzCQdLohRDd1lVPqa8kJSWdF3Cys7PrDxw4EDN9+nTXgQMHYrKzs+u7e6wYGKQHJoTo1zZu3DikpKQkrrCwMG7dunUpu3fvjquoqDA/+eSTZ4qKiuI2btw4pKioKO7JJ588E7xvR8fu3bvX9vLLL6e8/PLLqZF+beLCyDUwIUSngq+BCREpcg1MCCHEgCEBTAghRFSSACaEECIqSQATQggRlSSACSGEiEoSwIQQQkQlCWBCiKgQqG24du3alLVr16b0xXPs3bvXtmDBgkxoqcHYF88jQkMCmBCi31uwYEHmLbfcUrtw4cLapUuXVldWVppDFcSCzzN9+nTXiy++eBRg4cKFtVLFo3+TACaE6Nf27t1rO3bsWMzcuXObaxw+9thjFf/6r/866kLPXVFRYd6yZUti8HPt378/5kLPK8JDaiEKIXrk5zOPZ3e07dpHk45etjSxAmDH2nPp256uGdfRvt8rGbOrO8/30UcfxY8dO9bZ9vGamhpLRUWFubCwMG7VqlXDP/jgg4MPP/zwKIBnn332JLT0riorK82PPfZYxcaNG4esWrVq+PLly08XFRXFJSQk+Hbv3h23du3alKVLl1YDLF++fNQHH3xwsO3zBarfHzp0KOaKK65oCF6ORaraR4b0wIQQ/V5KSsp5Q3mBKvPBweORRx4pD9wuLCyMKy0ttS1durR67dq1GYF9a2pqLAsXLqy99957q48ePWobO3asMxC8pk+f7mpv2PDhhx8eFVi6pbS0NOall15KCZwvUBFfhJ/0wIQQPdLdntNlSxMrAr2xC3H55ZfXP/fcc+ltH6+pqbGkp6d7of2K83Pnzm2oqKgwb9y4cUjwkirtLc3SlSNHjsRUV1dbCgsL4yZOnOh84IEHqn/4wx8O/8EPfjB69erVRwFXT88pLpz0wIQQ/dr06dNd48ePd4HRq9q7d69t7dq1Kd/5zne+aLvvgQMHmq9fPfXUU+mHDh2KCfTQAkN+HSVmBK/03FZ2dnb95MmTnXPnzm144IEHqjdt2pT47LPPntyzZ8++zZs3D7nQ1yh6R3pgQoh+b926dUcDqy47HA4zwJNPPnkmsD07O7t+48aNQ6qrqy3bt29P3Lt3b/mkSZOcRUVFcYWFhXGzZs1q2LRpU2JKSoonsLzK5s2bh+zevTvuoosualq7dm3KHXfcca6wsDCupKQkbu/evbaqqipLYN8nn3zyzBNPPDEsEARLS0ttgetr9957b3VkfitCllMRQnSqPy6ncu+9947Lysqqf+CBB6oDw4hiYJPlVIQQA0J1dbX51VdfTZHgNbjJEKIQIuq88cYbZZFug4g86YEJIYSIShLAhBBCRCUJYEIIIaLSgLsGlp6ersePHx/pZggxYKxatYq9e/d2WBKqrx0/fpxf/OIX/Nd//VekmjAoOJ1Oz6WXXro70u3oiQEXwMaPH09RUVGkmyHEgLFv3z6mTZsWseefPn06l19+OcnJyR3uk5+fT15eXvgaNQCVlJREXTURGUIUQvRrZWVllJV1nHTocDjYsmVLGFsk+osB1wMTQvShN74Ppz8L7TmHXwwLftbpLitWrGDLli0UFBSwcuVKVqxYQXFxMbm5uVRVVVFUVNSqF7Zq1SqysrIoKysjNTWV9evXs2TJEsrKysjMzOSnP/0pK1eubL6fm5sb2tckwkJ6YEKIfi0zM7N5+DAQsHJzc8nLy2P9+vXk5uaSmZnZHLxWrFhBVlYWubm5lJaWkpeXR3FxMXl5eSxfvpy8vLzmoLVs2TIeeuihCL46cSHC3gNTSuUBDiBLa72qk/2WB7Z39xghRB/roqcUDqmpqZ1uLysrw+FwUFxczMSJEwHIysrqcP/MzMzmnpiILmENYEqpLACtdYFSKlMplaW1Lm5nv1xgTk+OEUIMDp0lcxQXFzNnzhwyMzPJysrqMCg5HI7m21VVVRK8olS4e2BLgMDV1jIgF+gqGPXmGCHEAFFcXExxcXFzMkfgfkFBAcXFxTgcDjIzM8nPzyc3N5fly5ezatUqqqqqzjtHoCdWVVVFcXExRUVFrFy5MlIvTVygcAewZKAq6H5a2x38PawCpdRD3T1GCDFwZWVlUVpaChjDfYHbWVlZLF++HOC8IBR4PCBwTECgh9bZ0KLo//pjEkfnA9xCRCHt8+HxSOH0/iDQc+ssNV9Eh3D3wBy0BKhkoDJ4Y6D31ZNj/MctA5YBjB07NlRtFeKCeLw+dh6pZsveMyR9+hxfdv2Jfx37W66ZOZ7504YxNNEe6SYOSoHsRBH9wh3A1gM5/tuZQAGAUipZa+0AMpVSgaupmf4EjnaPCaa1XgOsAcjJyZEVOkXEnahu4IG1Ozl0tg67Bd6P2USaqmbimc384OBcnthYwvduvoiHr52IUirSzRUiKoV1CDGQPejPMnQEZRNu9W/P11rnY/S4krs4Roh+6cCZWu559gPOnmviv788m0++7CPNWw7WOL6XWshb/ziPWy8ewarNn/Pk6/vw+eQ7lxC9EfZ5YP7eUtvHstvZZ01nxwjRH+06Ws03XthJjMXEy9++kqnDE+H334EhI2HuP6LeWM4UzwF++eVsMhJi+E3hYarrXazMuwSruT9ekhai/5JSUkKEyP7T5/jq8x8xLDGGFx+8nDGpcVBVBocK4LrHYfa9sPXfYefzmO7O4Ud3TCc9wcZTbx0A4BdLZkf2BXTX0yEe8ny08x5ocXExixYtIjc3l5UrV1JUVMSiRYt4/PHHycvLY8WKFWzYsCG0bQqhQPvz8vJ4/PHHO53H1hcC5bdCUS/y4YcfHpWWluZ58sknzwQ/XlhYGPeVr3wl8/bbb6++7LLLGnbs2BF38803n1u4cGFt222VlZXmtLQ079KlS6vbO7a0tNT2pz/9KXXPnj37umqPBDAheujMfhfVRzxMuj4WS4zxYX54RyM/e+kgUxuTeTxrKvU7YD8NZBx9jlRlRmXdDzFD8E5fhNq9jkOWJ/BZU8llFM5UE2+8/gV/PHeS2xcOJyHDDED5QReOYx7GXWnHFjd4e2eBdPeHHnqI5OTk5tJRy5YtIzk5meeee67DY/tDlfpA+5csWRKRivq5ubmsXr26033y8/OZOnVql+e67777qjdv3jyk7eNz585tmDdvXu19991XPXfu3IalS5dWJyYmzj537twnbbeBEQhTUlI8CxcurJ07d27DzJkzG4K3d9fg/asQohfqK738/stn2PRYJc5aX/Pjr/78DDO2DuWqD0ax7Ye1bHqskr8uP0XskXWcasqFxJEANE1eikk7Ofl/a9n0WCWbHqvE9zsbNxeP4/h/+yj9uOXvd89fGtj43Ure+++asL/OaNFZpfpoqlIfybb25LlTU1M93T1vUlKSZ+/evbb2tj3yyCPlP/jBD0a3t62iosKck5PTrUAmPTAhesBx3IPP/ydsthm9r31fnONvlDNzWgqXjk1u3ne05U3iYhwcHfoAo/yPmUbNpNKTzZyLN1Cb+RCB75DnGj0UHirntyXV/OKmSwBoqDLmjVUd7vZnxqAUqFRfXFzcqvoGcF6V+jVr1pCTk0NRURHLli3D4XCwZs0asrKyKC4uJjk5+bzq9cuXLyc/Px8wKngsW7bsvKr4gYLDGzZsYOXKlZ32tPq6on7b19hW29dSVFREUVERmzdvNs+cOROAJ554YlhOTk7DoUOHYh577LGKwP2ioqK47vyfVFRUmBMTE73Tp09vd42x6dOnu44fPx7T3rZNmzYlBoYXuyI9MCF6oKHK6HVNvNaOPdGE2+vjsQ27OTyrhu+8MJY7n05v/pc15WVIm8S0hxc0Hx+bbCZt8bdJMB3lzr8rad73q78ezszv23n17HHe+OwLALLuHeJ/TpkADcYHf35+Pvn5+c21DIMr1a9fvx6geYixbZX6VatWtaqRuGbNGoqKipqHJXfu3MmyZcvOq14fmPScl5fXPBTXUVX87OzsLhfU7cuK+u29xmAdvZbMzExuueUWLxjDezk5OQ0LFy6sLS0tjXnqqafSA/dvueWW2s5e2+bNm4ds3LhxyAsvvJCybdu2A53tW1tba2577L333juusrLS3NExbUkAE6IHGiqNYBKXavyNPf/eYfacOsdP7p5JSnzQaMnpz+D4R5DzDWg7z2v6XRCXBjt/0+rhb187kYtHJfHExhJqm9zEpRp/nvWVEsCA5g/8vLy8dns4jz/+OFu2bCE7O7tVsd6AnTt3NhftzczMZMuWLc29lkCvKCC4xFTgGlZBQUGrSvjBtwPn7apSfnvHtqe3FfXbe43BOnotwY4cORJTXV1tKSwsjJs4caKzuLg4fsqUKc7uvK5AoHvssccq0tPTO3zjVlRUmKdPn95qmPCWW26pXbdu3dFJkyZ167lAApgQPRIIJnFpJuqcHlZvL+WGqUO5ecbw1jvu/A1Y7DDrK+efxBIDl34VPv8r1Jxsedhs4id3z6Sy3sXvPjxKXJoRJBurfWiZK9alQBDatWsXBQWt6x0EqtQHrpeVlZUxZ86c5iG8QC+kPWvWrKGsrKw52AWC44VkE/akov7ixYvb3a+9ivrtvcbuvJaAwsLCuOzs7PrJkyc7586d2/DAAw9UZ2Vl1R84cKDd4b7eeuaZZ9Ife+yx0+1tW7hwYae9vGByDUyIHggMIcanmXnxw6M4Gtx858bJrXdqOgefvgwz8yCug2/a2Uvh/f8Hxb+F6/+l+eFLRidz/UUZPP9eGQ9cNZ6YIQpnrabpnI/Y5G6PrPStLtLeQy1QSX79+vVkZmZSVFREWVkZa9asITc3t1Wl+sD1ncBQXHtV6gPnDBT8zc7OJjMzk8zMTB5//HGKiopaVa/PzMxsdb+goIDk5OTzquKXlZWxfv16UlNTW63w3F77+6qifnuvMXBc4Fpd29cSGI7cvHmz+YEHHnDOnTu34YknnhhWUVFhBghcAwMoKiqKe/vttxMrKipa9bAKCwvjdu/eHQdGRmLbbe+9996QpKQkz8GDB2NKS0ttycnJrdLoS0pK4l566aWU1NRUT0fXzdqjtB5Y3+xycnJ0V2PQQvTWB8/W8Plbjcz5dgL37/iQi0cl8dtvXNZ6px3PwV8fg2+9DaOy2z8RwO/zjKHGfyoBs7X54eJj1Xzp1x/wL7dOxf6reJx1msXPZZA0KjLfN/ft28e0adMi8tx9bdWqVc3p+GVlZaxevTpqlldZtGhRSOe/lZSUNMycObPLuVeRsnv37vRZs2aND35MemBC9MBVDydx1cNJPLe9jKp61/m9L62h6P9gxOzOgxfAnAfhD182hhKn39X8cNbYFOZNTmfN9jLe+/0NxNr6Sc9rAAruUTkcDpYsWRLpJnVLcK9vMC/GKQFMiB5qdHlZvb2MuZPSyR6X0nrjsb/B2b1w5y+7PtHkmyBpjHG9LCiAAXz3xsnk/e+HrNtxjAfnTghh60Ww4KG+aCIV9Q2SxCFED7jqfaz76BgVdU4euWHS+TvsfB5ikmDmPV2fzGSG7K/D4W1QcbDVppzxqVyZmcb/biulye1loA31CxEKEsCE6CavW/Pfl5/kzCMmLhufyuWZbRYHryuHvX+G2V8BW3z3Tnrp/WCyGsOObXznxskM/zSBX119ksJfngvBKxBiYJEAJkQ3BSYUu81eHpzXzrDexy+Czw05D3b/pEOGwbQ74JOXwNW6es4VmakMTbajG1Tz/DMhRAsJYEJ0U0OlkULvivVyw9ShrTf6vLBrLYyfBxlTenbiOQ9CUw3sebXVw0oprrgkGYDTJ7s9t7N/eOcfjX8hEJjM+9BDD+FwOCgoKCAlJYVVq1ZRVlbGokWLQvI8faW4uJjs7GxWrFhBfn4+K1asaK6Q0dP2B34XgXOtWbOmeaJzd6xYsaI5zX4gkCQOIbrp+LFGAJKHWs9fu+vQVnAcg/n/3vMTj7saMqYayRyXfrXVpmuzM/gzVZw60dTbZke9gVCNPicnhyVLlpCVlUVeXh4pKSksXryYzMzMTtvf3rkCle0D88G6W/0DYMmSJedN8o5m0gMTopu2F1cAMG5c7Pkbdz4PCcNg6u09P7FSRsmpU8VwsvWC4xkjjfJUjVU+6pxS1LetaK1GH6jh2Fn7u8PhcJCbm9vtc4R7LbK+JgFMiG7w+jSf7DOWNQkElWbVR+HgW5B1f6sJyT0y68tgjYOi1vURAzUX7U4Lm3af6t25B7gVK1YANFe2CPwLVFkPVOcAo5RScXFx8xCew+Fg1apVFBQUsGrVKtasWUN+fj6LFi0iPz+/ebgtUEQ4cFxBQQHz589vPi4/P5+CgoLmYc6uBE+WDrS/7TmLi4s7OrxZYA5bZmZmp8cHXmPw76Lt7ysahT2AKaXylFK5SqnlHWzP9f9bGfTYSv/P89cGECIMth04i8e/LFcgqDTb9YLRi8p+oPdPYE+CixfBZ69AY8tKErZ4hSUGrF4T698/3vvzDwDRXo2+qKiIgoICFi1a1By0gtvf3jk7+12sWLGiVc+ro+MDy8UEaj4GtP19RaOwBjClVBaA1roAcATut9k+3789K2j7MqVUKdD7vrYQF2DdR8c5O7me+T9OJnOevWWDx2VkH05ZAEntrs/XfXMeBE8j7P5j80NKKeZ9N5mEe32UnKqh5OTgXdwy2qvR5+TkkJuby4YNG0hNTT1vqZOujg+Wm5vLypUrm9sZCGTtHb9r1652A1RXv69oEO4e2BLA4b9dBrSaBq+1LtZar/DfzdRaB/rAi7TWE/2BTYiwOl3TxNv7zzB/fgaz7xlCxpSgIcR9f4H6cpjzjQt/ohGzYFSOkcwRNHE55/4h3PuPIzHHKP6w49iFP88AFW3V6NsLNj09Z25uLg6Ho/l1tXd8dnZ2u9fIOvt9RYtwZyEmA8FLpqa1t5N/ePGhoIeylLGmUpbWeuDkgIqo8Nqnp/BpWJwz5vyNO38DKRMg84bQPNmcB2Hjw3B4O2Re2/xwUpyVW2YO5/XPvuBHd8zAZhk8l68HQjX6wFBloJ2Boc3AOQKPt1elPjgoBf8uysrKqKqqYvXq1WzYsKH5mLbHL1u2rNXr3rJlC8uWLTvv99XQ0HoeYjQIazV6pdRqYLXWulgplYsxXLiig303AN/SWjuCHlsJbGnbE/NfG1sGMHbs2OyjR4/21UsQg9BdvyrEp+GHCZdgjTVx8d3xWGIUnNkLz15ppM5f/d3QPJm7EX4xDSZcA4t/B8DZz12c2eviSEwtj2wvZu0Dc7i+7Ty0PtSravSBOWDXPxPq5oRUNFejD7VorEYf7q9xDiDQb04GKoM3KqWCr3uVYVz7ylNKBSZyVALn9fO11mu01jla65yMjIw+abgYnI5W1rP7RA23zRzB9mdqKHiyGhX4qyn6PzDHwOyvdnqOHrHGwuz7YP/rUGus97f/jQY2/7CalKOxJNolGzGUAj2qQI8lWqrRC0O4hxDXAzn+25lAAYBSKtnf08oFAte9koGdGIEsMIA7EVgdprYKwWuffgHA/PHDeNVbTUyiwmxV4Kwzki1m3A3x7Y6E917ON+DDX0Hx7+Da5c0rMzdVa26ZOZy/fnaaJrcXu7UfL7PSz3teAdFajV4YwtoDCyRl+IcPHUFJGlv9P9cAmYEel9Y637/PYv9jpUHHCNHnNu0+RdbYZJJ8xorq8f5gwmcbwFVrXLMKtbSJkHm9kZ7v9RCfZvyZNlR6uf2SkdQ5Pbz7eXnon1eIKBP2UlJa6/NyR7XW2f6fDowgBpDf2TFC9LVDZ2vZf7qWH90xvbmYblyq2b9o5W9g2MUwek7fPPmcB2H9V+Hgm8Sl3QgYtRhvnZhOaryNTZ+e4paZw/vmuYWIElILUQwOT6seH7Kp/l4UX+a297OpOjoX+B/iKl+Fn/8DNMRDTCP8oo8GMTSgEmDDYuKco4EC6g+WYHnmRm71Pswrn95Iw6mriFO9KPL7qKwtJgaGwZOLK0QPaA2bnPO43FrCUHM19U3pAMTZK8BlBTRY3X3XAAVYXeC1kGA3hgsbGo0Epdtj3qMROwXOy/vu+S/Q2z+r5u2fVXe9Yw8El0MKLokUSsHV4QOlmUT/JQFMiHbs9U6gzDuGO2K2A6C1CbvNQVL8CfBYjeDV805dz1jdgMauGlHKi8drx+uzMMe6l2GmSjY55/VxA/qPRYsWNU84zsvLo6qqKmRBLPg8wdXhc3NzB1zx24FGhhCFaMdrTddgxsuCmA8AyJnxG3Jm/AbttIHLbvSO+ppJg8WD8lj4zr0zsVrrUf6geWtMIS813so5XxyJpuibgNoTgUm+weWdli1bxsSJEy94qZRAxfrAecrKynA4HK2eS/Rf0gMToh1vua7gcmsJqaZzLQ9qUG4bmD1g9oWnIVYXaBM25WoOXgC3xryPCyvbXNnhaUcEFRcXt1vmqaqqqnmBy8BQ34oVK5oL5ULXVeTXrVt3XsX64OODBYYwAxXto72S+0AgAUyINso8Iyn1jmG+7W+tN3jNoE3h6X0FmL1g8vqvu7XIsuwnVdWwxdV/r4OFUnt1AwOPBc/leuihlgp03akif/To0VYV64OrwwdbsWJFc0X30tLSAVHJfSCQACZEGwX+oDA/piWAvbBxM0eO3IgPwBLGhSUVxrUwn4U/b1nN54dvA8CsfNxg28E7rhzcuh9PaA6BrKysdovRVlVVNQeb9oJOd6rId1dgaLG4uJiJEycOiEruA4EEMCHa2OK8gmnmMkabWyYLezyxjB26A2329X3yRltWF16fhfFDd1BT17Jky/yYj6jVCexwzwxzg8IrUGgXWnpV+fn5PP744+ftGxzoelpFvrMFJOfMmdO8ltjixYsHRCX3gUCSOIQIUulLZJdnKv8Q17KYoMsdx/Qxr6PQqJj68DdKQWX9WKaNfY2/ld7f/PA828fE4GSL63Kutu0Of7vCaPXq1RQUFDT3hIDmavJgBJiCgoLma2KBiu/dqSI/ffr05or1wdXhAz2uQOX6VatWUVVlLKbRXuV7EX5hrUYfDjk5ObqjFVHFINbNicwbmm7ke7X/xGvJ32WmtRSA6nNjsTZZqKzNZNzEyHzbLj08n4npH1Fy/DZmTv9D8+PfrPkh+zzjKUx9sFWSR6d6OJG5N9XoA3PAbvh+So+O666HHnqI7OxsFi9eLKnuISLV6IWIclucVzDCVM4MS2nzYz6XnYTYCspOR27elbK6+aJqBmPSdhlVOvxybR9x0jeMfd4JEWtbJFRVVbFhwwYJXoOcDCEK4dekbbznupQ8e0Gr3kysqYGa+pFUN46KWNvi7JV8/NmDLMj5VyMb0mLUZrwxZgeqzscW5+VMtxyOWPva6queV8CGDRv69PwiOkgAE4OW1lC8b2nz/QOesUxuGsXF9gx2WZYydsT7ZCQeIs56ju37lxJnr+zkbH0rPrac/ccXcP2sVdgtbrA0srf0LhqdqSxo8LGXe9kVF9u8f0bKfsaO+DBkz6+1RnV7jFKI0PL5fAo4b/KlBDAxqJyrG4nJ5CHOXoFSPt7+6Metts8DjvItjgI3XfV9MmKPojXEDvmCkUlHItFkwOiBTZ+4kcr6cYyy1oJPseOzhymvnk5g8PBtZjfvP3vqbxk74kO0Vni8NkzKh9ncu9qNdrudyspK0tLSJIiJsPP5fKq8vDwJKGm7TQKYGFRe3PQaDU3p/N2Xs4izV5A1bS1gXFZa3zSf4aZKrrMZ6dTpyfvBbUNZ3cy5+PkIthrMZjc3X70CvCZoSAC3lWmZf2FMw0c4fAlsdF7PFdZPmWo5CsDoYTsAKPjbf/DJ/vvJveIHXDrtxV499+jRozlx4gTl5bIG2UB2+vRpi9frTY90O9rhA0o8Hs83226QACYGFY/XWJjSYm5CKbjxih8B8Jl7Ilsc2fxiyC+40f6OsbPLCs7Y8Fbe6IrZZ5Syctu4/OJfgzKGQv+76jlsluP8fdK/t97dbCy3EnjdvWG1WpkwYXAliQxG06dP/0xrnRPpdvSEZCGKQcXjsQNgMbdeR+tdl/F3e40taDKr22aUcTJ7w9a+bvHXR8RrfP9UCq6z7eID1yU06dYlpyzNAcwe9mYK0dfCHsCUUnlKqVyl1PIOtuf6/63s7jFCdIfPZ8anrYAPk6n19aB3XdlcYjlAuqnGeMBrAp/ZCBb97bKPxQPK16o+4nW2Ihqxs9M9o/Wu5iYAvBfQAxOivwprAFNKZQForQsAR+B+m+3z/duzlFJZXR0jRHcFhtGslqZWafIOXwIfey7iOtuulgddNvp80creCtRH9FrAZ7yQK22fYcPV3JMMCPTA3B7pgYmBJ9w9sCWAw3+7DMgN3qi1LtZaB9YyyNRaF3d1jBDdFQhg5jbDh9tdWfgwc20ggGnCt2hlbwWuy7ltAMQqJ5dbS3inzfIqgQAmPTAxEIU7gCUDVUH309rbyT9UGFgXoVvHCNEVb3MCR9vrX9kkq3PMthwwHnDbANW/kjfa8i92idvaXJnjelsRZd4xHPcOa97NYjGGEOUamBiI+mUSh9Z6FfCQUiq5O/srpZYppYqUUkWS6is6Yo+pJu+mr7Jg7qPNj/m0Yrsri2tsxZiVzwgGLiuYwrhoZW8Fkjk8RjLHdTajBui7Qb2wMcP+xoJ5/8QlU/7Q7imEiGbhTqN3AIHFeJKBVqUNgq53FWMMFy7r6hj//muANWAU8w11o8XAYLU4mTBqe6vH9ngyqdApLde/vGbQZohpjEALe8jsNZI53DawephgPsVY0xe868rha7F/BSAl6QgpEZyALURfCncPbD0QWL40EygACOpp5dI6WJV1dIwQoXBe+rzbZgQFSz9M3mhLATaXkczhNXWaTi/EQBTWAObvWaGUygUcgfvAVv/PNUCmUirPv39+J8cI0SPV58axfddySg62rN/0jiunJX3ep4zhOEs/Tt5oy+oGdHMyRyCdPrDIZV3DMHbtXcq+sjsi2Egh+kbYK3H4h/vaPpbt/+nAPxQI5Hd2jBA95agdy0ef/gPjRm5n5uR8HL4EPvFM4R/iXjZ2cFsBZfRqooXSRsB1WyGmKSidPptrbB9TUzuatz/6MSMzipiWuSnSrRUipPplEocQfaFtFY73XJe2pM9rjF6M2WNk+EUTmxtQ4LY2p9Nv8ydySCUOMZBJABODhtfbJoC5LyVR1THLcsAYOtSm/p063xGT1/jntoGGa23FlHrHcNKbEZRGL/PAxMAjAUwMGsGFfLU2emBXW3djCWTyKZ8xtyraKIzA6zODz8w828cAFLpmBxXzlR6YGHgkgIlBI/AhbjY7KfWO5gtfBvNsxeDzF8btj3UPuyuQzOGyMsV8lKGmSra7Lw0aQpQemBh4JICJQcMTVIlju8soqTnP9om/KG4/rXvYXYH6iB4rSivmWT/mfddslMkYEvVILUQxAEkAE4OGxdzEkPiTxNqreM99KRPMJxljOmMMH1qiMHmjLauLQDLHNbaPcehEPmckZpMTsymKg7MQHZAFLcWgMXvqS8ye+hJObeHBij+yyF5gFO3t73UPuytoscurY43rYB94Z/LPX58c4YYJ0TekByYGnV3uaTRiN65/uaz9c9HK3vLXR0zX9cywHGK7+9JIt0iIPiMBTAw677mysODhKtNn4LP072VTeiqw2KXbxjzrxxS7p1Hni410q4ToExLAxKCx9W8/5lfrPubzsjvJsu4n3qsxkjcGwPBhQHMyh4Vc6048WHhxcz7P5W+nriEj0q0TIqQkgIlBo8mVRKMzjZPeYdxo2WGUXxpIva8Af0CerQ9jp4lzdaNx1I7H45WemBhYJICJQSOQRu81aW4zf8SASd5oy6TB7MHiMXO1bTf1JiNXS1LpxUAjAUwMGoEPcJu5jlHeGn/yRj9ftLK3bG7QJu4zb6HRZAZkMrMYeCSAiUEj8AF+W8IWlDZFV9X5njIbyRxXqAN4/fPbpJyUGGgkgIlBo84zBIAFCQWAjo5FK3vLXx8xzudh+JDPARlCFAOPBDAxaJzzpBAfU8F429HornvYXf76iNeO3gCAW4YQxQAjAUwMGicmlDF8znOYlPavoTXAmTRYPFw6/E32TTpGRWyUl8oSoo2wBzClVJ5SKlcptbyD7cv8/1YGPbYysC1c7RQDi0ebKBhl5frhG/2LVg7Q5I22rC5sJhcZM/7Ep/FJkW6NECEV1gCmlMoC0FoXAI7A/aDtuUCB1noNkOm/D7BMKVUKlIWzvWLg2O2ZQo46QAr1AzN1viNmY7HLBy2vU+iaFenWCBFS4e6BLQEc/ttlQG6b7ZlBj5X57wMs0lpP9Ac+IXqs0DWbZZ53cflseAfTwLmCBl88U9QpVF0STdoa6RYJETLh/lNOBqqC7qcFb9Rar/H3vgCygKLA7c6GHYXoykH3OC6LLWbn/gfx6cG1CMOuA/fjcsfxdV8hxe5pkW6OECHTL7+L+ocWt2itiwG01qv8va+0oGHF4P2XKaWKlFJF5eXl4W6u6OfqnB4u9h1DaxOfluU1r1I8WCiTj73Hbmde0rvsdM6IdHOECJlwBzAHkOq/nQxUdrBfrtZ6FTQnfeT5H6+kZVixmb/nlqO1zsnIkIKlorWdh74gz7KdQ19cR6MrGaUGVzaexezkk7Il2EwuEryDIPtSDBrhDmDraQlAmUABgFIqObCDUmpZUPDKxbgWFrj2NZGWYUUhuqV65wbSVC2flC7BPMh6X2CsRF1ecxEn6zO5QX1KdV1TpJskREiENYAFhgT9gckRuA9sDXp8pVKqVClVHXTMYn8vrDToGCG6ZcrxlznjS+Xo2SsG3fAh0Pyaj1TMYYLpNJ//7fUIt0iI0Aj71eygJI3gx7L9PwuAlO4cI0R3VBzdx0zvPj7wzgJMWCyDr/dhMRuvuaZ6MjVj44gpWQ+590S4VUJcuH6ZxCFEqJz5cB0Adp8XYFD3wDyeBHYzgYsc28DdGOFWCXHhBlc+sRh0Ug6/xsdMZVbq35hx3wx8PnOkmxR2E0a/yzfuvh57TA2FvouI8zVRXvwaGZcvinTThLggPQ5gSqnxGHO0UjEyCcswrme9HdKWCXGB9Jm9jHSWUZjxHS5t2oHZVhvpJkVEjK2WGP9rn+iOobwxkYaPXwYJYCLKdXsIUSn1PaXUW8BKjGxABdT4b9+klHpLKfWsUmp2n7RUiB6q2vFHvFphu+TuSDel35hoOcm75qsZcWYbOAdnQBcDR5c9MKXUBOAh4I9a6593sW8SRt3CHK318yFqoxA9pzWWfX/iQ990cmZO5eSmbAo/foxRw3Yy99JfRLp1YeWoHUNh8WMkxJ3hujn/yZmxt2E78ga+/W9gmrU40s0Totc67YH5g9eNWuvva60/6epkWusaf5DbqpT6ZojaKETPfbGbpIZjfBh7HaNT4qhrHMqxL66mouqiSLcs7NzuOPaV3c3hE9cDMPqS6zilU6nbtT7CLRPiwnQawLTWh3vTk+rtcUKEivezfNzajGvKbQB4vMZqxIMzjd6fhehf0PLqyUN5zXsl8cffhcbqyDVMiAvU4zR6pVRiXzREiJDRGs+nr7DddwnZU43CL17/h/dgTKM3twlgGUNi+Cz5RszaA/tlUrOIXr2ZBzYxOFFDKTVBKXVD6JokxAU6sZOY+lO87ruCKzPTAfB4jA/vQVlKyt/rDPRCAYZedAXH9FC8n+VHqllCXLAeBzCt9cfAHH86PVrrw0CKUuqnIW6bEL1T8gourJwafiNJccb6V81DiObBO4QY6IUCzJ2SwV+8V2I6vB3qZAUHEZ16M4S4HigFqoOGEwuAZaFsmBC94vPiK3mVt32Xkj1lTPPDnkE8hBh4zW6PHe0vxH/5hFTe0FehtBf2/TmCrROi93ozhJgNFGmtawDlT53PBX4W0pYJ0RtH38dUf5a/eK7g6knpzQ+nJZVy0fjXyEjdH8HGRYbJ5GXM8A8ZN7IQrY1KJHE2CwljLuGoaSyUvBrhFgrRO70pJbUIo7f1lNa6xp9qn9LVHDEhwqLkFZymWD405/Bf41rqQl804XUumjB4Exa+vGDJeY/Nm5JB/vHL+Oejr6DOnYLEkRFomRC916trYFrrp4LuHwZ2SQUOEXFeN+z9C++Z5jA7cwQxlsFX97An5k3O4DXflSg07NkY6eYI0WMhqUbvT+w4HIpzCdFrZdugsYo/Nsxh3uTWK3PXNQzDUTsWlzs2Qo2LLLcnhkZnUqtixjNHJVEdO5YT9slQ8koEWydE74RsORX/NTEhIqfkFVyWIWz3XcI1U9JbbXpnxxM8l1/IoWM3RahxkfXbP2/mV+s+o/rc+ObHzCbF1RPT+ZP7CjhZBNVHItY+IXqjy1JSvSkJ1dvjhOg1dxPsf42iuKtJTRzCxIyEVpsHcyUOOL8aR8C8yemsb8gx7kgyh4gyXZaSwqhr+L/dmayslEpUSn0Po35iu6WklFJ5SqlcpdTyDrYv8/9b2d1jhOBQATjP8btzOcybnI5SqtXmwZxGD+3PBQOYOzmdEzqDM0mXSAATUafLLER/EPu2UupbSqnvAxooBir9u6RhrAs2EWN+2Cr/MedRSmX5z1mglMpUSmVprYuDtucCBVrrMqXUBv/9qs6OEQKAklfw2FPZ4riI/5qScd7mllJSg7QH1k41DoDRKXFkZsSzxTSXr575NZQfgIwpkWiiED3W7WtgWuvntNY3AYsxJi4fxlgPrAhYo7W+SWv9cEfBy28J4PDfLsOYPxYsM+ixMv/9ro4Rg52rHg5sZm/KDfiUmbmT0s/bxeMJVOIYnD2wtvUQg82blM7qiovRKNgjvTARPXo8D8yfrLG1l8+XjL9H5ZfW5txrgu5mAesxJk53eIwQHNgM7gZecV7OzJFJpMbbztsl8ME9GGshQkvPMxDIg82bnMFvP0zi3MjLSSp5Ba5dAW2GYIXoj3qVhaiU+qZ/9eVv9kV1ev9Q45buDhX6r5kVKaWKysulrtugU/IqvoThrDs9knmTz+99QcvQmVWSOM7bdsXENCwmxYdx10LFAThTEu7mCdErvamF+DNgEsbw4WLgsFLqwW4e7gBS/beTabmO1lau1npVd4/RWq/RWudorXMyMs6//iEGsKYaOPgWx0fcgtunmNtBALvtmu+y6Kb7GBJ/KswN7B+ypr3Andc9zOhhO8/blhBjIWtcCr9zXALKLHPCRNToTSmpnVrr5ne4UioZ+L5S6kta664G0NcD/pxdMjGupaGUStZaO/y3lwWClz+Jo91jhACM9ay8Lt5UVxFrNZMdVD4q2IiM3WFuWP8yatiuTrfPm5TO01uqcE29FlvJK3Djj2QYUfR7FzyRWWvt0Fp/n25cmwoMCfoDkyNoiHBr0OMrlVKlSqnqLo4RwugtJI9l3YkMrshMlfJRvXSNP3OzJDUXHMfgZOcBT4j+oDc9sDKl1E5gObBLa33O/3hHw4GttEnUCDyW7f9ZAJz3Fbq9Y4SgvhLK3sUx+9sc+aCRpXMzO9z17R0/xGJyMS97FUrpMDayfzh5JpsTZy5j5NBdjGln+8WjjOSXDXWzyDLbjDlho3Pa2VOI/qM3PbAlwMvAw8ARpdROpdSbQKZSagiAUupLIWyjEO3b9xfwedgecw0A17Yz/wvA59Hs2vMtdpR8G2Ma4+Bz9Iur2b7rcY6cvKbd7SaT4prJ6bxV2oieNN9Ip/f5wtxKIXqmNwGsFNigtV6stU7FWFqlALgJOKqUOgis7OwEQoREySuQNpmNp1IYnxbH+PT4dnfzuIygZTE7B+1lnc6yEAOuvSiDynoXx0beArVfwLEPw9U8IXqlN8upPAekKKXG++9/rLX+uX8icypGD00q04u+VXsajhTimX43H5ZVddj7AvA4AwFscKbQQ9A8MO/588ACAhX8/+qcDdY4yUYU/V6vkjj8QetIB9uKgRUX0ighurRnI6D5JOkGGt1err2okwDWZASwwTqJGcBiab8WYrD0hBguGZ3E1tI6mHIL7N0IXk+YWihEz4VsOZVg/vXBhOg7Ja/AsIvZfDoJm8XEFZkdJ8F6g4YQB6vu9MDAuI5YfKya+ikLoaESDm8LQ+uE6J0+CWBC9CnHMTixA2Z+iW0Hyrl8Qipxto4Tat1NMoTYXAvR03EPDIwA5tOw3TcLYhKlNqLo1ySAieiz508AnB57KwfP1nV6/QtAmSA16RBJQ46Ho3X9ks3SQIytpnkosSOzxySTaLfw9qEamHo77NsEnsHbcxX9W2/mgQkRWSWvwKhs3j4dB3ScPh+QMdnGg1/qcjm7AW3C6G18576L/fce6XA/i9nEvMkZbDtQjl50N2r3Oih9Gy5aEJ6GCtED0gMT0aXiEHyxG2bew7YDZxmVHMukoQldHye67dopGZytdbI/LhtiUyQbUfRbEsBEdNnzKqBwXXQX7x+q5JopGeetviwuTCCj891DDph+F+z/K7gaItsoIdohAUxEl5JXYNxV7KyyU+f0cF0n6fMB+zc38MyL+9lcuKrLfQcqR+1Ynsvfzh/++nKX+w5LtDN9RCJv7z8DM+8Bdz0cfDMMrRSiZySAiehxZi+U74eZX2LrvrPYLKYO1/8K5mnSuD1x+HyD95Kvwoejdjzn6kd1a/8bpw1l19FqqtPnQMIwozaiEP2MBDARPUpeAWVGT7uTrfvPcNXEtE7T5wOaK3EM0sUsITiNvvN5YAE3ThuGT8O2Q1Uw4244+BY0nev6QCHCSAKYiA5aGwFswjWUNcZxtLKBG6cO7dahLaWkBm86eHdqIQa7ZFQS6Qk2tu4/CzO+BJ4m+PyNvmyiED0mAUxEh1MfQ/VhmHkPW/edAeD6HgewwdsDC/Q+u6rEEWAyKa6/aCjvfn4W98hsSBoj2Yii35EAJqJDyStgssK029m67yxThw9hdEpctw4NBLDBXAvRbHIB4PPZ8Hm7t6TMjdOGUdvkoehojTGMWLoVGqr6splC9EjYA5hSKk8plauUWt7JPllt7q/0/1zW1+0T/ZDPZ1TfmJRLjU6g6Gg1N07rXu8L5BoYgFItPdBAbciuzJ2cjs1saslG9HmMyhxC9BNhDWCBwORfednRNlD598kFnmvz8DKlVClQ1vetFP3OiR1w7qQxeflgOV6f5oapw7p9+MRr7Vw35z8YO/yDPmxk/zdn5mqunPXf0M1pcwkxFi7PTDWug42YBakTpTai6FfC3QNbAjj8t8uA3LY7+INb23GKRVrrif5tYrApeQUssXDRArbuO0NavI3ZY5K7ffiYHDtzZj7HiIxP+66NUWBu1tPMzXoaq737f/a504ZRVl7P4coGoxd2eDvUne3DVgrRfeEOYMm0Dk4dr4HRWlZXw45igPJ6jOHDKTfhscTx7uflXHfRUMwmqb4RDjf4E2W27jsDM78E2gd7/xzhVglhiIokDq31Kn/vK80/xCgGi6OFUF8OM++h+JiDmkZ3j65/ARz9qIm9pXdRW9/9YceB6IvyWZQdvx5nra/bx4xJjWPKsAS27jsLQ6fB0OmSjSj6jXAHMAeQ6r+dDFR2dYA/6SPPf7cSyGxnn2VKqSKlVFF5eXmImir6hZJXwJYAk2/irT2nsZm7V30jWNFva3l9+y85U3lx1zsPYFs+/AmvFPyW6qM9W2U5d9owdhypwtHgMnphxz6EmhN91Eohui/cAWw9LQEoEygAUEold3JMWWA/YCJQ1HYHrfUarXWO1jonI6Pr2ngiSnhcsPcvMPU2tMXO5j2nmTs5nSF2a89OI1mIQNBkZmf3shADbpk5HK9PU7DPP6kZmtdkEyKSwhrAtNbF0Jxp6AjcB7YG9vH3tnICvS7/Pov990uDjhEDXdk70OSAmfew59Q5TlQ3cvOMng8DSiUOg7mXAeziUUmMTLKzueQ0pE2EkZfKMKLoF8Je3VRrvaadx7KDbucD+V0dIwaBklfBngyZ1/PW24cxKWM4q6cC854GcyUOAGugGkcPA5hSiptmDOcPO45R7/QQP/MeeOsJqCqD1PNG9IUIm6hI4hCDkLsR9r8O0+4Ai43Ne05z2YRU0hK6V8svmKdJemDQ+x4YGMOITo+PbQfKjaocIBXqRcRJABP908Et4KqFmfdQVl7HgTN13DJjeK9O5XHJNTDo/TUwgDnjU0mLtxnDiEmjYcwVEsBExEkAE/1TySsQnwHj5/HmHqN47029DWByDQxoGULtTQAzmxS504bxzv6zOD1eY1Lz2T1wdl+omylEtymte/5m7s9ycnJ0UdF5iYoiUp7uxYRjDdQNAasb7E3cVf00oPhzyj/3qglerxWP147NWodSA+v93hP1jWl4vTHYY6qxWRt7fPw7zhyWnvs31ib+iOutxVCfADYXxPTii8Gjg/f/ob9SSu3SWudEuh09IT0w0f94LIACi5tT3nR2ey7i5pje1zE0m93E2GoHdfACiI+tJDHhVK+CF8BVtk9IUA286boKTBrMXnBbjC8cQkSABDDR/3isoHxg9vKW6woAbrEN7kK8/UGM8nCDbQdbnJfj1SawuEGbwScfIyIy5J0n+heN0QOzuEHBG86rmWw+SqblVK9O5/HaeOm1V9nw1u9C284odPDofP60dQ2fHVjc63PcEvMhlTqZj9wzjCFetPGFQ4gIkAAm+hePFVBgdXPam8YO9wxuj3mv96fz2DlVnsMX5ZeGro1RqqZuLIeO3cLZqum9Psf1tiLiaGST8xpjWRazB9xWGUYUESEBTPQvbv/wocnHa865aEzcGbO916fzeO3A4F6NOaA5jd7b87l0AbHKyfyYj3jDeTVubQarB7QJfOZQNVOIbpMAJvoPnwKv2RiaUrDJeS0XWw4yoZfDh9DyYW0d5FU4IGhF5gsIYAB3xGzHoRMpdF1qDPWijWQOIcJMApjoP4KyD494R7DbM4U7LqD3BdIDC9bSA7Nf0HmusRWTpGr5S2AY0eIxhn5lGFGEmXxtEt1ybEcTw2fasMUZ33kOvdtIzYn2l+VIGmVh0vWxALjcsXx28MsdnnfimK0kDzkGgLMxBZ/Xyt7Pv8R2ZxaXuNOYFDeKXaalWC2NXDLlj83HfXpgCW5PXLvnHJH+CSOHfgxApWMSIHUQAcz+38HnR24H/q758d2f39vhsOLIjF3NK1lXnxtH2YkbALi7qYkSz0L+Fl9LRtwRJqZ/hMdlxxJjPMfBozdxrn5Uu+dMHnKUif7bzjofJRvrO2zzpBtiSRppfEyd2esicZSZ2CQZrhQGCWCiS001PjYsK+f+l4eRMcUGwKf5dZS+235QyLzGHhTAhvD2Rz/u8NxJCSeMAOZT2FQT7x/4Jh/u+zYA84BdGItwx8eebRXA3v/4Ueoa2q/MceXsZ5oDmNOVBIDddq4Hr3hgssfUtPv4e7uW0+hMbXfbvKyVzQHsbNX05v/LeOBy4D1+iMXcyN/fcQ3KpMAfwD7Z/zWOnLq23XNOHvfX5gDWVOPj7Z85Omxz6gQLSSMtNNZ4+fytBrxuuP57yV29VDFISAATXWqo8uLzwOYfVvG19UbQmHhtyzfjttImtaRVWy2NZE1b2+G5kxKM3hceK0qByVbPhIvy+bPzOq6wfspUy1EAbNbaVsddPHk9Tldiu+ccmf5x8+0RGcVkT/8N0ydK3b5RQ4u4Jvun5w0hXjLlDx32Zoelf9p8O3nI0eb/Sx+woWk+GaYqbrDtoqpuHMOS9xnDiAomjX2L1KSyds+ZkboXeAgAW7wi696EDtucONx4jx15v4mSjfWMmXNhw59iYJFSUqJLX3zm5PdfOcvwGdbmANZt3S0lVR8HKIivZ1Xd/axuvIcdaV8jzSQ9p/7q3+qWsa7xForSvkqizwWNcRBbDxZv1wf3sJRU6bZGXv37CjLn2bnnWVm0ti9IKSkxILnqjQ8bW0IfvV18CnzG5GWtYZPzGq62fiLBq5+7M2YbLmxGtRSzByMbsW8mNcf433vOel+fnF9EJwlgokvOWuNDwxbfR2+XwIee1U2RZzrHfcO5y76tb55LhMylls8Za/qCPzXd4M9GdPdZNqIt3ujJu+oG1oiRuDBhD2BKqTylVK5Sankn+2T19BjRdwI9sJiEXlSW7w6PFUweMGlebppPgmpgQcz7ffNcImSUgjz7Vt53z+a4d6i/tJTyT4cIrUDv31knPTDRIqwBLBCYtNYFgKNtoPLvkws815NjRN8KfGj0yRCi11/FweqhzhfL601zuSNmO3FK5m1Fg3vsW1H4yG/KNarTK1+f1EYMfHmSHpgIFu4e2BLA4b9dBuS23cEfqKp6cozoW/FpZkbnxJA6vg+SVj0WQIPFzV+dc2kgljx7QeifR/SJUeZy5lo/Ib8pFx/KP6k59Eus2OJNJI+xkDxWEqdFi3C/G5JpHZzS+ugYEUJTF8QxdUH7adYXRGN8Wzd7/cOHuUw0HyfLsj/0zyX6zGL7Fh6pXcEH7kuYaykBt80IYtb2J7r3htmq+NYbI0J2PjEwSBKHiByff/jQ4qbUM4oizwwW27eg+uhSm+gb82P+RqKq4+Wm+X06jChEW+EOYA4gMOU/GagMxTFKqWVKqSKlVFF5efkFN1K05qz14W70EfI5gx4rxvChhw1NuZjxcrf97dA+h+hzduVmYcy7bHZeRY2O92cj9s1KzVprtE+ugwlDuAPYeiDTfzsTKABQSiX39JhgWus1WuscrXVORoZMcgy111ZU8syckx2WjuoVjZE+b/biUYpXnTdwva2IoSZH6J5DhM1i+xZc2IwCv1YPRjZiaHthf/j6WZ6edYIze90hPa+IXmENYFrrYmjONHQE7gNbA/sopfKAHP/Pzo4RYdI8kTk+hGN7PpOxjpTVzTZXNmd9aSyybwnd+UVYzbCUMs1cxvqmm8HkH0YM8RIrSoH2yWRm0SLsKT1a6zXtPJYddDsfyO/qGBE+gTT6mCEh/L7jDgwfuvldzW0MNVVyg21n6M4vwkop+Ersm/xr3cN87JnCpdaj4LIZVVZMoRnyszWn0ksAEwZJ4hBdctWHuBJHIPvQ4qHMO5Jt7hzus7+BVXWjhp7ot74U8zYJqoHfNt7hX+gytJOam8tJyVww4ScBTHQpMHk0ZJU4vGZj+NDi5ndNt2PFzVdiN4fm3CJiEkyN5NkLeN05l7MMMYYSQ3gdLDCR3iVDiMJPApjolNY69JU4/NmHdSYr+U253B7zniRvDBBft7+GGyvrmm41JjV7zcYwYgjESD1E0YYEMNEprwt8HjBbwWILwQeRxhhWsnh4xXUjdTqOr8e+duHnFf3CBMsprrMV8VLTAlwWH6EcRrRJRXrRhtRlEZ1SJrjrmTS8rhB96/UPH/osTn5bezuzLJ8z23ogNOcW/cLX7ZtYeu7HvOG+irtMRUbCju3CU9/HX2XHFq8YPtMWglaKgUACmOiU2aqYkhvCMlL+4cNC3wzKvKN5ZshToTu36BeutRUzwXySFxrv4K64D8FlD0k24vAZNobPkOAlWsgQogifwORli5v/a1pIuqrm1pjCSLdKhJhJae63v8bHnqnsYbTxoJSWEn1AApjoVPUxDx+uPseBLQ0XfjKvBVAcUem868rhgdhN2FToCr6K/mORvYAkVcszTV8xshFDsFJzQ5WXko31fB6K96IYECSAiU5Vlrop/GUNJRvrL/xkbivg4+fOexmi6rhfkjcGrARTI0tj/8IW15WcMQ8xijb7Luzj5twXXt54ooq/rTkXolaKaCcBTHQqZCn0/uxDh9nO665reCD2NRJN8k16IHsgdhMJqoH/5/oSoC+4tJQsainakgAmOtVSheMCU+g9xvDh7z3zicP4di4GtmRTHV+zv8465y00miwXfB0sUAlGJjKLAAlgolMtVTgu8K3iseJB8YxzMV+N/SupJhkGGgwejNtIDC7+6r3MGEb09v591FwLsV56YMIgAUx0KiR1EP3Dhx9xESY034z7U2gaJ/q9dFMN98ZuZqXzPmN5sAvohVliFCYLeJwar1uCmJAAJrrgrA9BHUSPFVA841zEV+xvStmoQWZZ7J9wMISDjDASeXoZe5RSMowoWpEAJjplMkNMorqwpVTcFqp0Anv0OB6Oy+96fzGgDDdX8tXY1/mN+zajiPMFZCPGJBi9MBlGFCCVOEQXbliRwg0rUnp/Ag0+r5WXvdfxzbiNDDdXhq5xImo8Eree25uewaNNWC5gTtg3No3AbDV6Y0JID0z0Ke22YgLe883gobhXI90cESEpploeiHuNd3yzaXLHga93Q4AWm5LgJZpJABN9qtKVTplvOLfHbiNeNUW6OSKC7o/dxAd6Gna8eI99FOnmiAEg7AFMKZWnlMpVSi3v7nal1Er/z2Xhaqcw/P6+M6y55RQ1J3te8snlOE2Kr4EP9TQWxRb0QetENIlRHnLsn9KkrZS9+7teneP9/6nhhS+d5tA7jSFunYhGYQ1gSqksAK11AeAI3O/G9mVKqVKgLJztFVBzwkPNCS/mnq4F5m7i6B//GbPSTI4pxaIka0zArfb32aUnM+zIn6k/9H6Pj6+r8FJ+wE1dubcPWieiTbh7YEsAh/92GZDbze2LtNYT/YFNhFEg26tHlTiqj+J8bj6TT7/Oa/oy5thL+qh1ItooBan2s1TpBOy/vwM+/DXo7mcUxgTS6OvkC5EIfwBLBqqC7qd1c3tWZ8OOom943RpPk0aZwBrbzQB24E306mvwlJfyiP4e2fEfI9fcRbBpMWWsn/0iBd5L4c3HYcPXoal7lVmkGocIFhVJHFrrVf7eV5pSqm2vDaXUMqVUkVKqqLy8PAItHJhcDYFCvt3I/PJ5Yet/wLrFOGzDWdD0JJct+BojJG1etOOR27L5j/h/YbXt6+h9r8Fz18OZPV0eF+iBOaUHJgh/AHMAqf7byUDbT7fztvuTOvL8j1UCmW1PqrVeo7XO0VrnZGRkhLjJg1dzHcSuykjVnYUXF8J7T9F48Ve5+dwTDB83jfsuG9v3jRRRKc5m4T+/dAk/PXczf5z+P+CsheduhE/+0OlxLT0wCWAi/AFsPS0BKBMoAFBKJXeyvSywHzARKApHQ0U3l1I5+iGsvgaO70Df9T/8U8M3cHgs/PSeizGZZOxQdOyaKRnkZY/miY+T2Hfn6zA6BzZ+GzZ9F9ztT7kIvBedsqSKIMwBTGtdDOAfBnQE7gNbO9ruf2yxvxdWGnSM6GNxKWau/vtEZuXFn79Ra/jgV/DCbWCNhW8W8LvGuWzec5pH509hYkZC+Bssos4Tt01j6JAYHtp4gnOLN8Dcf4JdL8D/3QTVR87bP2WshUsWxTPhanvY2yr6H6V7kAEUDXJycnRRkXTS+lTTOfjz38O+v8DU22Hhr9ldrsn73w+4ZnIGz92f09L7elp6YaIdj7Z87uw6WsWS1X8jd9ownv1qFurzN+BP3wYF3L0GLrolcu0cRJRSu7TWOZFuR09ERRKH6EfO7IE118H+1+GmJ2HJ76nxxfF3LxUzdIidpxfPkqFD0SPZ41L5/oKpbN5zmrXvH4Gpt8JD2yB5HPxhCRT8GLw9n0gvBj4JYKJD1UfdHHqnkarDbuOBT9YZF9pd9fDAa3DVI/g0PLphN2drm/jVvZeSHGeLbKNFVHpw7gTmTx/Gf/51H8XHqiF1Ajy4BbK+DoW/MJKE6s7i82hO73FxotgZ6SaLfkACmOjQwbcb+dMjFXy2oQL+8ghsfNi40P7Qdhh3FQA/27yfgn1n+Jdbp3Hp2AuoWi8GNaUUT+XNYkSynWW/K+JoZT1Y7XDn/4OFz8KJIvjfeXhL3+fFJWfI/7ZMlxESwEQnXPWapPjjZLvyoPh3MPef4WsbYcgwAJ5/r4w128u4/8pxPHDV+Ii2VUS/pDgrax+4DK9Pc///7aC81t/Lmn0vfLMAbPFY/ngnOVNewN3gw+cdWNfvRc9JABMdGlLzFvffuAS77zh8ZT3k/gjMxhJyGz8+yZOv7+PWi4fzoztmyBIXIiQmDU3gNw/M4cy5Jpa+sIM6p//a1/CZsOwd1NRbuf6Sp7jryn/EVeWIaFtF5EkAE+fzeqDg35jl/iaO+tEcnLy5VSbY2/vP8NiG3VyRmcovFs/GLEkbIoSyxqbw6/uy2PdFLQ+9WESjy1+4154Ei1/kg7IVTBrxLtYXb4DTn0W2sSKiJICJ1mrPGBfMC/+LI84vs+6dFzGljm/e/OdPTrLsd7uYOmIIa+7PwW41R6ypYuC6YeowVt1zCR+UVvK133xETYM/kUgp9tcs5Y/b1oK7AZ7PhY9fimxjRcRIABMtjrxvVNU4UQQL/5cdFf+B1xfTXL7nhfcP890/fkL2uBT+8K0rSLT3fml4IbpyT/ZofvWVLHafcLBkzYecOWdU57DFmzhZmcXZawpgzGXw578zkozcskbYYCMBTBhVNd7/b/jtHWCLh29thdlfaa74bYlT/PzN/fzbpr3cNH0Yv/3GZQyR4CXC4LZLRrD2gcs4VtXAPc9+wKGztc1L+zR5042konmPGklGv5kPVbJk4GAilTgGu0aHUVVj/2sw/S6481dgTwSMgqlfnGniibc+470jFXx5zhieXDgTi7kH33ukEodoz6M9+9zZfdzBN17YSYPLy79dPYPcKcNJHGHGGut/Lx54E15dZnwZu/tZmHpbHzR6YIvGShwSwAayroKH1wSNcaAVxDjB6jLK9/j9zTWT79R+jxpfAj9OWM0S+1uytpeImDPeVB6p/R473BfzZfub/FvCauzK1bKDTxnvZ58ZbE7jX1fv1x4G0oEsGgOYDCEOVm4rNPiL9MY2gK0leNX6Yvlx3be4t+YnJKhGNqY8ypdjJXiJyBpmrmJd0g/4+7j1/LHpZm6t/n+875rVsoNJQ1y98UXMFeMPZvKmHcgskW6ACDMNOO3gtoHZA/ZG4w8fY/TlNec8/qP+m5R7U1i2I5nJ9gqm3ngkok0WIsCifHyp6hTph6p4M3UU9438CXfGvMsTCc8z1OQwvoTZm8DshSa78SXN3ggWb6SbLvqA9MAGE58y/qDdNmN4JbYBTBqtYZsrizzHKh6pXcEwUxX58T/EUj6eE19cKT0v0a9U1WRSceQ6HnQW8Z24dWx2Xs31VWtYVXc/VT7j+i1Wt9EbQxs9MafN+PImBhQJYIOF2wL1CeAzGYErxokHE286r2Ch4xd8vebf+cKXzk8SfsXG5EeZwhkAYmx1EW64EK3ZrMZ70ueO45/j1/Fmyt9zva2IZxvzuLry//jPuqWc9GaA2Qfx9WDxgMsOTbESxAYYGUIc6DTgjAF3DJi8ENvAYd8IXq6bzyvOGzjrS2OM6TQ/Tfgl99i3YlNG6R6newgANmttBBsvxPli/AHM6TIWTZ1gOcWvElfxj551/KphCc83LuS5xruZa/2EJfa3mB/zN2LMXuPvoD7B+AJn9kXyJYgQGXgBrPZ4ZJ//nX80fl7/TCRbYbTDp4xvnV4LFeZYXvJdz2bHVezzZmLCyw22Ihbbf831tiKsqvU1Apf/wyHwYSFEf2GzGV+qAl+yAiZZTvBM4tM85v0dG5rms6Epl3+o/T4JqoFrbUUstrzNPN/nmBriIaYJbG7j7ySSf6v96PNiXApjItuIngt7AFNK5QEOIEtrvao727s6RgA+H7hqodFBXU0FXxw+y6j6NMzax489X2Nd03xMeMmx7uUH9t9wZ8w2hpmrOjyd020EMJsMIYp+JjCEGPiS1dZoczn/FL+O78T9kUL3bDY7r6LAdRmvO68hDQfP2Z4my1nKMdcoLGdqGH5mP6a4FIhNBktMGF+JuFBhDWBKqSwArXWBUipTKZWltS7ubHtgW0fHDChBQYgmh/Gzsbrltv+nbnLgra/GU1+NbqzG5KzB6q7FhDEskgBMBkp9I/iJ9ytkWCv5RdzTXG8rIsXUvSFBlwwhin4qxv+edLXpgbVlVj6utRVzra2Yn2jFp57JbHNl8V/uhVzpOcDfWTbB/leNf35uUwweWxLYkzHHp2KJT8EU6w9u9uTOf0rwC7tw98CWAFv8t8uAXKC4i+1pXRzTittp5eTH7a/Wmj7JSswQI2+l5qSHujOBZcp1q58WGwybZmu+f+rTJrQP0BqNBozMPYUmYZiZ+KEmfFrTUOnBcSADY3L4fkxuB8rlQLmqMblriE85h8lZA40OPJXVqKYaLJ4azJ4arJ5zWL3nUHQ8Nu/RZupJoMabwDlfPLW+BCrMo6lSF1FvSiDGnEa8NYOEIekkNxwgteJD/kNtAjdYzE5S0luC0amzl6J1+zk8iQkniI8tZ8r41xmZMTC/K4joFWt3MDKjiOTEowCcrrgYr7f9lcAT4k+TlHASk9JM9Z0mo+4geRzEi6Ko6TIcKbM5Zx9NQ20ldaock6uGJFc96TWNJFPHENNpksz1DFH1xKmGTtvlUXY8lkQ8liQ8liS8lmRUcjLmxGSwp+DyJNLkTMRnTQZrEj5bCvpgMigr5oQKhs+woZQJpeDsfjfaDYEUYBXIt1OKhKFmkkYapdyaajWVpW5aUoVb/xw2IwZLjHG76rCbRkf7ny+xZ6NzMdpwB7BkIHjcKq0b27s6phWr6zQj/jTCuKOMAKT8gUiplhSkJP+/7hjZzf1igOa3wemft7uPW5upIR5fQzKepmSa3Ek0ucbS5EqkyZ2I05XIkXgLH45t4pyOw9oYy9XvX06TKwm3N5a2pQUuyV3OzSO3MNRUxbad/0LRnvv8W24GHmneLyWxjG/ec13z/ZfffAm3p/0hmGtznuSyi9cwetjObr5yIcInIe4M993+peb7f3nnWWrqxra77+UX/w/X5KwE4HTFLDa81XHl+m/lXU1M8lmOeYez/d1VOI5f2Wq7Uh7s1lpqhx2nePZe4pSbNE8jC/YnYrfVYLedI8Z6DrvtHHbrOey24+j43VgtdQxRXRQafn0VvN5yd1QXv4MAe1f7/qXlZiqgtfH5oQOfI833o1NYS0kppVYDq7XWxUqpXGC+1npFZ9sxAliHx/iPWwYsA7CZucTl5dMwvaTzjEthTK2T2KoGDkSqDYF2ABytJiRZLSnW0a0u8Fa7T3R53v72uzhXNxroXts7Evg99PQcYxJGTq9z15urnTU9WsCqt8/X0XkSE04AoXtf9EZP3hfBrz9Uv4vgdkD0/C76uh0V9STWOXVsJNvRU+HugTkwvgiAEZgqu7m9s2PQWq8B1oSqkRdKKVUUbTXF+or8LlrI76KF/C5ayO+i98IdwNYDgf+oTKAAQCmVrLV2dLS9g8eEEEIMYmGtxBHIHvQPBTqCsgm3drS9k2OEEEIMYmGfB+Yf7mv7WHYX2/vN8GA3RVt7+5L8LlrI76KF/C5ayO+ilwbcemD9lVJquUzCFkK0Rz4femfglZLqh/zDn3Mi3Y5I82eLAkxsm0k60Ek1mRaD+X3QHvl86D2pRi/Cwv9HWuAfDs703x8UgivMAI7gCjODzWB+H4jQkwDWx/ylryRz0sggDXxYlfnvDxZLMHpf0FJNZrAazO+D88jnw4WRIcS+l9r1LgNfm0ScLIwpE4NFMj2oJjOQDfL3QXvk8+ECSAC7QEHj+cHK/MWH5dtVG/7hsy0yHWJwk/eB9L5CQQLYBeoixT9TKZUZdHvgVtKn82AedD93ECYxOOiimswgNBjfB20Nqs+HviABrA9prfOh+YM9ObKt6XtdzddTSi0LWuMtdxB9++yowsygNIjfB60Mts+HviDzwERY+LPNNmBcC0oFFg2mDy7/h1QZkBmFE/NDZrC/D0RoSQATQggRlSSNXgghRFSSACaEECIqSQATQggRlSSACSGEiEoSwIQQQkQlCWBCCCGikgQwIYQQUUkCmBBCiKgkAUwIIURUkgAmRBgopbKUUqVKqQ1B95Mj3CwhopoEMCHCIxfIBlYHqvZrrR0RbZEQUU5qIQoRRv5eV6rWuizSbREi2kkAEyJMAkOG0vMSIjRkCFGIMAgsXBgIXkELGQohekkWtBSijymlsjAWtKxSShVgXA9zYKwPJoToJemBCdGHgoYN12CsxnwYmCOLOApx4eQamBBCiKgkPTAhhBBRSQKYEEKIqCQBTAghRFSSACaEECIqSQATQggRlSSACSGEiEoSwIQQQkQlCWBCCCGikgQwIYQQUen/AzyO77rhKDGgAAAAAElFTkSuQmCC
 "
 >
 </div>
@@ -16034,7 +15745,7 @@ The input and output shapes are: (51,) (2, 51)
 </div>
 <div class="jp-Cell-inputWrapper"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
-<p>Here we will great a 100 Gaussians with means distributed between -1 and 1, and widths distributed between 0.9 and 1.1.</p>
+<p>Here we will create 100 Gaussians with means distributed between -1 and 1, and widths distributed between 0.9 and 1.1.</p>
 
 </div>
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
@@ -16102,7 +15813,7 @@ The input and output shapes are: (51,) (2, 51)
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAYQAAAEJCAYAAACUk1DVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAlPUlEQVR4nO3deXST15038O+V5H235QVswHhlCwRjSIIDBGJIJkmnaSBJ9z2ka+ZM33baaTtzes7bLXRm3mmnpw1Jp8ukWxLStM1kaTAhBrMEjAlhM15kOzbGtuR9t5b7/qFH2BiMN+m5Wr6fcziW9Ajph5D11XPv8/yukFKCiIjIoLoAIiLyDwwEIiICwEAgIiINA4GIiAAwEIiISGNSXcB8mM1mmZ2drboMIqKAcurUKZuUMnXy7QEdCNnZ2aisrFRdBhFRQBFCNN3odg4ZERERAAYCERFpGAhERASAgUBERBoGAhERAWAgEBGRhoFAREQAAvw8BCJf6h22469nWgEAxUuSUJAeB6NBKK6KyHcYCEST1Lb349dHG/HS6csYGnNevT0uwoS7lqXhuw+uQkJUmMIKiXyDgUA0wQuVzfinF99FmNGA969ZiE9szEZ8ZBgqm7pwsrEb+041o/pKH3796Q3ITIxSXS6RV4lAXjGtuLhYsnUFectrZ6/gi7+vQkmeGT/+4Fokx4Rfd5+jdTY8/uwpRIUb8atPrcfKhQkKKiWaHyHEKSll8eTbOalMBKC8xoon/ngaaxcnYe/H1t0wDABgY54Z+z6/EUaDwCNPHcPZll6dKyXyHQYChbyq97rx+LOVyEuLwy8/uR7R4TcfSS3MiMNLXyhBXGQYvvL8OxixO296f6JAwUCgkDbqcOKrz59BalwE/ufTG2Y8WZyREIkf7LwFtR0D+PGBWh9XSaQPBgKFtP+uaIDFNoj/+/5VSI2LmNXf3VqYhkeKs7C3vB7vNPf4pkAiHekeCEKIXUKIUiHE7mnu96ReNVFoau0Zxn8dqMOOFem4qzBtTo/x7QdWID0+El994QyHjijg6RoIQohdACClLNOul05xv1IAOTqWRiHou69cgEtK/MsDK+b8GPGRYfjhztWo6xjAT9+s82J1RPrTew9hPQCLdtkCoGjyHYQQORPuQ+QTFbU2vHq2DV/amodFydHzeqwtBal435qF+OWRBnQPjnmpQiL96R0IiZOup9zgPjlSyikDQQixWwhRKYSotFqtXi2OQoPLJfGdl89jSUo0HtvsnR3RJ7blYWjMiV8dafDK4xGpoHcg9ABInmqjEKLUM5w0FSnl01LKYillcWrqdWtEE02r7GI76joG8H92FCIyzOiVx8xPj8PfrcrAr442om/E7pXHJNKb3oFwEuN7CTkA9k/a3qVNOO8CkCOEuG5IiWi+fnG4AZmJUbhvVYZXH/eLW/PQP+LAs8duuH45kd/TNRCklPvg/qAvBZA4YXJ5v7a9SrstGdcPLxHN25nmHpxo7MKnSrJhMnr37b8qMwFbC1Pxi8MWDI05vPrYRHrQ/bBTKeUeKWWZlHLPhNu2T7rP01LKXCllld71UXB75rAFcREmPLp+kU8e/0vb8tE9ZMfv337PJ49P5Es8MY1CRkv3EF4714YP3bYYcZG+aV+9bkkSNuamYO8hC8YcLp88B5GvMBAoZPzqSCMEgE9uzPbp8zy2KQfW/lEcuNju0+ch8jYGAoWEvhE7njvZjAdWL8BCH69jsLkgFQsSIvHHk80+fR4ib2MgUEj4yzutGBh14NN3LvX5cxkNAg+vy8KhWitae4Z9/nxE3sJAoJDw4qkWLMuIwy2Z+ixo83Cxe9L6hcoWXZ6PyBsYCBT06q0DeKe5BzuLsiCE0OU5FyVHoyTXjOcrm+FyBe6qhBRaGAgU9P5U1QKDAN5/60Jdn/fR9YtwuWcYR+ptuj4v0VwxECiouVwSL1VdxuaCVKTFR+r63DtWpiMxOoyTyxQwGAgU1I5ZOtHaO4KdRVm6P3eEyYiH1mbhjfNt6GIXVAoADAQKai9WtSAu0oTtK9KVPP+j6xfB7pR4+Uyrkucnmg0GAgWtwVEHXj/XhgdWL/BaV9PZKsyIQ2F6HF5594qS5yeaDQYCBa3XzrVhaMypZLhoovtuWYCTTV3o6BtRWgfRdBgIFLT+eqYVi5KjsG5JktI67l+dASndAUXkzxgIFJR6h+04WmfDfasW6HbuwVTy0jhsRIGBgUBB6cDFdjhcEvd6eRGcufIMG7Vz2Ij8GAOBgtLr59qQER+JNVmJqksBMGHY6Cz3Esh/MRAo6AyOOlBeY8W9qzJgMKgdLvLwDBu9epbzCOS/GAgUdMprrBh1uHDPSv8YLvLgsBH5OwYCBZ3XzrUhJSYcG5Ymqy7lGhw2In/HQKCgMmJ34s2L7di+Ih1GPxku8rg6bMTDT8lPMRAoqByps2FwzOk3RxdNtn1FOk41daNniL2NyP8wECiovH6uDXGRJmzMNasu5YbuXp4Gp0uivMaquhSi6zAQKGg4nC6UXWzH3cvSEG7yz7f2mqxEmGPDUXaxQ3UpRNfxz98aojk43dyD7iE7tq/wz+EiADAYBLYWpuGtSx2wO12qyyG6BgOBgsab1R0wGQQ2FfjncJHH3cvT0T/iwMnGLtWlEF2DgUBB42B1B4qzkxAfGaa6lJvalG9GuNGAAxw2Ij/DQKCgcLlnGNVt/di2LE11KdOKiTDhjtwUHLjYDiml6nKIrmIgUFA4WO3+th0IgQAApcvT0Ng5hHrroOpSiK5iIFBQOFjdgUXJUchNjVVdyoxsW+5e0vPAxXbFlRCNYyBQwBuxO3Gk3oZthWnK1z6YqczEKCxfEM95BPIrDAQKeMcsnRixu7A1QIaLPEqXp6GyqYtnLZPfYCBQwDtY3YGoMCNuz0lRXcqs3FWYBpcEKupsqkshAsBAoAAnpcSb1R0oyUtBZJhRdTmzsiYrAfGRJpRfYhsL8g8MBApodR0DaOkeDrjhIgAwGQ3YlJ+KQ7VWHn5KfoGBQAHN0yTursLACwQA2FKQiva+UVxq71ddChEDgQJbeY0VeWmxyEyMUl3KnHjabHDYiPwBA4EC1ojdiRMNXdicn6q6lDlbkBCFwvQ4HKplIJB6DAQKWCcaujDqcPl9M7vpbC4w42RDNwZHHapLoRDHQKCAdajGinCTAbcvDazDTSfbUpCGMacLxy2dqkuhEKd7IAghdgkhSoUQu6fYXqr9eVLv2iiwHK61YUN2MqLCA+tw08mKs5MQFWbEIa6iRorpGghCiF0AIKUs066XTtpeBKBI214khMjRsz4KHG29I7jU3o9N+YE9XAQAkWFG3J6TzGU1STm99xDWA7Boly0AiiZulFJWSSn3CCESAViklBYQ3YBnEnZzQeBOKE+0pSAVjZ1DaOpk91NSR+9ASJx0farB32IA9TfaIITYLYSoFEJUWq38RhWqDtfakBoXgWUZcapL8QpPsHHYiFTSOxB6ACRPdydtyCjXM8Q0advTUspiKWVxampwfDuk2XG6JCpqrdiUbw6Y7qbTWWqOQWZiFA7Xsq8RqaN3IJzE+F5CDoD9EzcKIZ6cMNncgxmEB4Wec5d70T1kx5YgGS4CACEENuWbcay+Ew6nS3U5FKJ0DQQp5T4AOdpkcuKEyWVPMOwFYJmw/Wk966PAcFibP7gzL/AnlCe6M9+M/lEHzrT0qi6FQpRJ7yeUUu7RLpZNuG279tOC8UnnMhDdwKFaG1ZlxiMlNkJ1KV5VkmuGEEBFrQ3rliSpLodCEE9Mo4AyOOrA6fe6cWde8AwXeSTFhGPVwgRU1HFimdRgIFBAOdHYBbtTBt1wkUdJnhmn3+vBANtYkAIMBAooFbU2hJsMKM4OziGVTflmOFwSb7ONBSnAQKCAcqTO3a4i0FZHm6l1S5IQYTLw8FNSgoFAAaOjfwTVbf0oCdLhIsDdxmLD0mSus0xKMBAoYBytcw+jBOv8gcemfDPqOgZwpXdYdSkUYhgIFDAq6mxIjA7DyoXxqkvxKc8RVEfqOI9A+mIgUECQUuJInQ0luWYYDMHRrmIqyzLiYI4NRwVXUSOdMRAoINRbB3GldySo5w88DAaBkjwzKuo6IaVUXQ6FEAYCBYQj2iRrsM8feJTkmWEbGEVN+4DqUiiEMBAoIFTU2bA4ORqLU6JVl6ILz54QjzYiPTEQyO85nC4cr+9ESV5gr508G5mJUVhqjrm6Z0SkBwYC+b0zLb3oH3UEZf+imynJS8Hblk7Y2Q6bdMJAIL93pM4GIYA7ckNnDwFwz5cMjjlxprlHdSkUIhgI5PeO1NmwcmE8kmPCVZeiqztytHbYHDYinTAQyK8NjTlQ9V53SBxuOllCdBhWZyZwHoF0w0Agv3aiIbjbXU9no9YOe5DtsEkHDATya0fq3O2u12eH5vLad+a522GfaOhSXQqFAAYC+bWKuk4UL0kK2nbX0/G0w+Y8AumBgUB+yzYwiotX+kJy/sAjMsyI9dnJnEcgXTAQyG8drQ+NdtfTKckzo7qtHx39I6pLoSDHQCC/daTWhvhIE1ZlJqguRSlPIB6rZzts8i0GAvklKSUq6my4IzcFxiBvdz2dFQvjkRgdxmU1yecYCOSXmjqHcLlnOOSHiwDAaBAoyTXjSJ2N7bDJp0yz/QtCiFsB5Gh/egB0AbBIKd/xZmEU2jxH1YTyhPJEJXlmvHL2Cuqtg8hLi1VdDgWpGQWCECIbwDcALAVg0f70ABAAcgHsEELkAKgH8KSUstEHtVIIqai1Xe34SePzCEfqbAwE8plpA0EI8TUAyQC+LqXsnea+CQB2CyG6pZS/8FKNFGKcLomj9TbcuyoDQoT2/IHH4pRoLE6OxuFaGz6xMVt1ORSkbjqHoIXBPinlP08XBgAgpeyVUv4IwAEhxFe9VSSFlrOXe9E34sCd+aHV7no6JXlmHLd0wsF22OQjNw0EKeWPpJQNs31QKWWDlPLf5l4WhTLP4vIlIdbuejp35pkxMOrAmZZpv5sRzcmsjzLS5hOIfOZwrbvddUpshOpS/MrG3BR3O2wefko+MpfDTpOEEJ/1XBFC7BRCbPNiTRTCBkfd7a7vzOfRRZMlxYRj1UK2wybfmXUgSClPA8jzhICU8kW4jzL6jLeLo9AT6u2up1OSZ0bVe90YYDts8oG5DBn9DYAEcEo7JwEAfgBgjxfrohBVEeLtrqezKd/TDpttLMj75jJklAtgr3bUkdAONX1G+0M0LxW1NmzITg7ZdtfT8bTDPlTDYSPyvrkEwg4AXxdCxGvDR6UATkgpv+Hd0ijUdPSN4FJ7P+cPbiIyzIjbclJwWDsSi8ib5jKHYJFSfl5K2addfxFALyeWab487So4f3Bzm/PNqLcO4nLPsOpSKMh4pbmdlPIZALM+X4Foooo6G5JjwrFiQbzqUvzaJu2EvQruJZCXea3b6VxOYCPykFLicK0NJXlmGEK83fV0CtJjkR4fwXkE8rppW1fM5UQ0IcRStq6g2bh4pR/W/lFs5vzBtIQQ2JSfioo6G5wutsMm75m2dQWA7UKIH8wkGIQQ8UKIHwLYOVXrCiHELiFEqRBi9w22JQohirT7PDnDfwMFgfIa9/DHlgL2L5qJzQWp6B22492WHtWlUBCZttuplPIZIcRSAJ8TQqzFeOvregCJAFK0n7nabXumGj4SQuzSHrNMCLFbCFEqpSybcJdHtO1PCyHWCyF2Symfnus/jgLHoRorlmXEIS0+UnUpAeHOPDOEcLf5WLs4SXU5FCRmtB6C9gH/DcA9HITxBXJ64Z5MtmiHoE5nPYDntMsWAEUArgbCpA//HAD7Z1IfBbbBUQcqm7rw6ZKlqksJGMlaG4vDtVY8cXe+6nIoSMx6xTQtHBoAHJjD8yVOun7DdpbaYjtdk/YePNt2A9gNAIsXL55DCeRvjls6YXdKbOZw0axsLjDjqXIL+kbsiI8MU10OBYE5HWUkhPisNq/wWSHEbI4R7IF7sZ3p7JJSPn6jDVLKp6WUxVLK4tRUfoAEg/IaK6LCjCjO5tDHbGzKT4XTJXGsnm0syDvm0svoKQB5cC+f+QiAhlk0tjuJ8b2EGw4JCSF2SSn3aJeLZlsfBZ5DNVbckZuCCBPbVcxG0eIkxIQbcaiG5yOQd8xlD2G/lPIb2p8dcE8m5wshHpruL0op9wHIEUKUAkj0DAkJIfZrP0sBPCmEOCWEOIWZ7U1QAHuvcwiNnUM83HQOwk0G3JGbgvIaK6Tk4ac0f7OeQ5hMStkD4BtCiMdmeH9PV9SJk8nbtZ9lcAcMhYhy7Wxbzh/MzV2FaSi72IF66yDy0mJVl0MBbi57CBYhxEkhxAcmzR9wIJNmrfySFVlJUVhqjlFdSkC6q9AdpG9d6lBcCQWDuQTCowCeB/AhAI1aODwH95wAAICN7mgmxhwuHKu3YUtBKoRgu4q5yEqKRn5aLN66xHkEmr+5BEI9gBeklI9IKZPhPgS0Eu5V0zqFECcB8CxjmlZlYxcGx5w8O3meti5Lw9sNnRjkKmo0T3Npf/0M3OsqZ2vXT0spfySl3CGlTAHwOIBu75ZJwejN6g6EGw0oYbvrebmrMBV2p+RayzRvczoPQQuBxim2VQH4+nyKotDw5qUO3JaTjJiIeR/bENKKlyQjJtyIt3j4Kc2T19pfTzTDNhYUwhptg7BYB3H3sjTVpQS8cJMBd+ab8VZ1Bw8/pXnxSSAQTefNavdRMduWpSuuJDhsLUxDa+8IatoHVJdCAYyBQEocvNSB3NQYLE6JVl1KULir0L2ndZCHn9I8MBBId4OjDrxt6cI2Dhd5TUZCJJZlxPF8BJoXBgLprqLOhjGnC1sZCF61dVkaKhu70TdiV10KBSgGAunuYHUH4iJMWJ/NVlXetG1ZGhwuiXKepEZzxEAgXUkpcfBSBzYVmBFm5NvPm4oWJyE5JhxlF9tVl0IBir+RpKvzrX1o7xvF1kIOF3mb0SCwbVkaDlZ3wO50qS6HAhADgXR14GIHhBg/Koa8a/uKdPSNOHCioUt1KRSAGAikqzcutGHd4iSkxkWoLiUobco3I8JkwP4LHDai2WMgkG6au4ZwvrUPO1byZDRfiQ434c48M/ZfaOdZyzRrDATSjedb644VGYorCW7bV6Tjcs8wLl7pV10KBRgGAunmb+fbUJgeh2wuhuNTdy9PhxDg0UY0awwE0kXX4BhONnZxuEgHqXERWLsokfMINGsMBNJF2cV2uCRwz0oOF+mhdEU6zl7uxZXeYdWlUABhIJAu3jjfjszEKKxcGD/9nWnedqxw74mVcS+BZoGBQD43NObA4Vortq9I59rJOslNjUVOagxePdumuhQKIAwE8rlDNVaMOlycP9CREAIP3LIAbzd0wto/qrocChAMBPK5v51vR2J0GDawmZ2u7lu9AC4JvH6eewk0MwwE8qkRuxP7L7Rj+/J0mNjMTleF6XHITY3Bq+9eUV0KBQj+hpJPvXXJioFRB963ZqHqUkKOEAL3c9iIZoGBQD71v++2IjkmHBtzU1SXEpI4bESzwUAgnxkac+DAxQ7cd0sGh4sU4bARzQZ/S8lnyi52YNjuxPtWc7hIFQ4b0WwwEMhnXj7TivT4CC6Vqdj9qxdy2IhmhIFAPtE3Ykf5JSvuv2UhDAaejKZSQXosclNj8Mq7rapLIT/HQCCfeON8O8acLrxvzQLVpYQ8IQT+fk0m3m7oQmsPexvR1BgI5BMvn2lFVlIUbl2UqLoUAvCBtZmQEnjp9GXVpZAfYyCQ13UOjKKizoYHVi9k7yI/sTglGhuyk/GnqhaupEZTYiCQ1/35nVY4XRIPFWWqLoUmeKgoE/XWQbzb0qu6FPJTDATyKiklXqhsxpqsBBSkx6kuhya4b/UChJsM+FNVi+pSyE8xEMirzl3uQ3VbPx4uXqS6FJokPjIMO1ak469nWjHmcKkuh/wQA4G86oVTzYgwGdi7yE/tLMpC95AdBy91qC6F/BADgbxmxO7En09fxj0rM5AQFaa6HLqBTflmmGMjOGxEN6R7IAghdgkhSoUQu2+yfb/eddH87b/Qjr4RBx4uzlJdCk3BZDTgwVsX4s3qDnQNjqkuh/yMroEghNgFAFLKMu166eT7SCn36VkTec8Lp1qwMCESG3PNqkuhm9hVnAW7U+LFU9xLoGvpvYewHoBFu2wBUKTz85OPtPYM43CtFTvXZcHIVhV+bVlGPIqXJOG3bzfB5eI5CTRO70BInHR91k3yhRC7hRCVQohKq9Xqnapo3l6obIGUwK51HC4KBB+7YwmaOodQUWdTXQr5Eb0DoQfAvFpfSimfllIWSymLU1NTvVMVzcuYw4Xfvd2EzQWpWJISo7ocmoF7V2UgJSYcvz3epLoU8iN6B8JJjO8l5ADg5HEQeP18Gzr6R/GpjdmqS6EZijAZ8cj6RSi72M6Gd3SVroGgTRjnaJPJiRMml68Gg7at2DMBTf7vN0cbkZ0SjS0F3GMLJB/esBgSwB9PvKe6FPITuh92KqXcI6Usk1LumXDb9gmXy6SUSTzaKDCcbenFqaZufPyObK57EGAWJUdja2Ea/nCyGXYnz1wmnphG8/Tro42IDjdiF889CEgfu30JrP2j+BtXUyMwEGgebAOjePlMK3YWZSE+kmcmByL3gQDReOZwA9tiEwOB5u6PJ97DmNOFT2xcoroUmiOjQeCxTTk409yD45Yu1eWQYgwEmpMRuxO/OdaETflm5KWxzXUg27UuC+bYCPy8vF51KaQYA4Hm5LmTzbD2j+ILd+WpLoXmKTLMiE+VZONQjRXnW7l4TihjINCsjTlceKq8Huuzk3B7zrzOMyQ/8dHblyA2woSnyi3T35mCFgOBZu3FqhZc6R3Bl7flc83kIJEQFYaP3L4Yr7zbiqbOQdXlkCIMBJoVu9OFn71VhzWLErEpn11Ng8lnSpbCZDBg7yHuJYQqBgLNyl/eaUVz1zCe2JbHvYMgkxYfiV3FWdhX2YLmriHV5ZACDASaMadL4mcH67BiQTy2LUtTXQ75wJe35UEI4D/216guhRRgINCMPV/ZDIttEE/czbmDYLUgIQqfKlmKP79zmUcchSAGAs1I/4gd//7GJazPTsI9K9NVl0M+9Pm7chEfGYY9r19SXQrpjIFAM/Lzt+phGxjDt+9fwb2DIJcQFYYvbc1DeY0VR7mATkhhINC0mruG8IuKBnxgbSbWLEpUXQ7p4GN3LMHChEj88PVq9jgKIQwEmtaev12CQQBfu6dQdSmkk8gwI76yoxDvtvTixarLqsshnTAQ6KZONXXh5TOt2L0pBwsTo1SXQzp6aG0m1i1JwvdeuYCuwTHV5ZAOGAg0pVGHE9948Swy4iPx+JZc1eWQzgwGgR88dAsGRh347isXVJdDOmAg0JT+60AdajsG8IOHbkFMhEl1OaRAQXocPrclF3+quoyKWk4wBzsGAt3Q2ZZe/Ly8HjuLsrCVJ6GFtC9uzcNScwy+9eezGLE7VZdDPsRAoOuMOVz42r4zSIkJx78+sEJ1OaRYZJgR33twFZo6h/Dvb/DchGDGQKDr/PTNWlS39eP7H7gFCdFcGpOAjXlmfPT2xXjmcAPerG5XXQ75CAOBrnGoxoqfHqzDQ0WZKF3BM5Jp3LfvX4HlC+LxlefPoLVnWHU55AMMBLqquWsIT/zxNPLT4vDdB1epLof8TGSYET/7SBHsDhe+/IfTsDtdqksiL2MgEAD3Gsmf++0pOF0Sez+2DtHhPKqIrrfUHIPvP3QLTjV14984nxB0+FtPkFLiWy+dw/nWPvzyk8XINseoLon82PtvzcSJhi7sLbdgaUoMPrhhseqSyEsYCIT/LKvFi1Ut+Ie787FtGecNaHrf+fuVaO4exjdfOgtzbATnm4IEh4xC3NOH6vHjA7V4eF0W/uHufNXlUIAIMxrw848UYVVmAr70hyqcaupWXRJ5AQMhhD17vAnff7UaD6xegB/uXA2DgW2taeZiIkz45SfXIyM+Ep/5zUkuqBMEGAgh6vdvv4d/+fM5lC5Pw/979FYYGQY0B+bYCPzPp29DVJgRH9x7HMctnapLonlgIIQYl0vih69V45svncVdhan46YeLEGbk24DmbnFKNF78/EakxUfg4788gdfPtakuieaInwQhZMTuxJf+UIWnyuvx4dsW4xcfL0ZkmFF1WRQEFiZGYd/nNmLFgnh84Xen8OsjDVxYJwAxEEKExTqAR/Yew2vn2vCt+5bjew+ugol7BuRFSTHh+P1jt2FrYRq+8/IFfOF3Vegdtqsui2aBnwhBTkqJZ4814r6fHEZT5xD2fnQdHtucw3WRySeiw0145uPF+Oe/W4b9F9px/08O4/R7PAIpUDAQglijbRCf+NVJ/MtfzmPD0hS88Y+bsWNlhuqyKMgZDAKPb8nF85+7A1ICO39+FP/6l3PoGeKqa/5OBPI4X3FxsaysrFRdht/pHhzDT96sxW+PN8FkMOCb9y3DR29fwr0C0l3vsB3/8cYlPHu8CQlRYfjaPcvwSHEWhysVE0KcklIWX3c7AyF4WPtH8bu3m/DfFQ0YHHXg0fWL8I+lBUiLj1RdGoW4C619+M5fz+NEYxcWJ0dj9+Yc7FqXxYMaFGEgBCkpJd5t6cVvjjXif89cwZjThdLl6finewtRkB6nujyiq6SUeONCO372Vj3ONPfAHBuOD29YjIeKstg/S2cMhCAipcT51j68evYKXjl7BU2dQ4gON+LhdVn4xMZs5KTGqi6RaEpSShy3dGHvoXqU11ghJbB2cSIevDUT25alYVFytOoSgx4DIYA5XRINtgFUNnbjaH0njtZ3wjYwCqNBYGNuCh5YvQD3rlqAhCiubkaB5UrvMP7yTiv+VNWCmvYBAECOOQabC1JRnJ2EWxclIjMxivNfXuY3gSCE2AWgB0COlPLp2W6fKNgCYdThxJWeETR0DqLRNgiLdRAXr/ThwpU+DI25FzdPjYvAxtwUlOSacffyNKTERiiummj+pJSw2AZxqMaK8horjls6MWJ3L8Bjjo3AyoXxyEuLRV5aLHJTY5GZFIX0uAhOTs+RXwSC9mEPKeU+IcRuABYpZdlMt0/mD4EgpYTdKeFwuWB3Sow5XBhzujBqd2LE7sKw3YnhMSeGxhzoH3FgYNSB/hE7uofs6B4cQ9fQGKz9o2jrHUHn4LWH5cVFmLBsQRxWLkzAqswE3LooAbmpsfy2REFvzOFCdVsf3mnuwTvv9aC6rR8W28DVkAAAo0EgIz4S5rgIpMaGIyUmAkkx4UiICkN8lAlxkWGICTciKtyI6HATosKMiDAZEBFmQLjRgDCT+6fJIGA0iJD6vZoqEPReD2E9gOe0yxYARQDKZrH9Gpfa+rHlRwcBAFPlmsS1G6S8/r5Suu8lpfv+7p/a7RJwSQmX56dLwiklXC7A4XLBNcc8jQ43Iik6HCmx4UiLi8CaRYlYEB+JjIRILDXHINscg5SY8JB6kxJ5hJsMWJ2ViNVZifj4He7bXC6Jyz3DsNgG0dozjNaeYVzuHoZ1YBSXe0ZwpqUXPUNjsDvn9ktpMggYDAJG4Q4Ig3CfU2EQ7suAgBCAQQBCu+z57Zz8ezrx6uRfYQEx5TbV9A6ExEnXU2a5Hdqew24AiF+Yg7WLEiduu+GTXnerGP9P8fwVoV2++h8t3I/n+c+f/OYwGQ1X3zhhRgGT9k0jwmRAhMmIcJMBESbDNd9O4iJNiI00IS7ShAgTD7cjmg2DQWBRcvRNJ52llBh1uNA3bEffiB1DY04Mjrr30EcdLow6nBi1uzDqcMHuHN+rd0oJp8sFh0v70ufyfBG89kshMH7d88XS82Xyag245sq19U2qVZVDU9yudyD0AEiex3Zo8wpPA+4ho//84Fpv1UZEAU4IgcgwIyLDjDz/5iZ+/KEb3673jMxJjO8F5ADYP8vtRETkI7oGgpRyH4AcIUQpgETPhLEQYv/NthMRke/xPAQiohAz1VFGPIiXiIgAMBCIiEjDQCAiIgAMBCIi0jAQiIgIQIAfZSSEsAJoUlyGGYBNcQ3+gq/FOL4W4/hajPOX12KJlDJ18o0BHQj+QAhReaPDt0IRX4txfC3G8bUY5++vBYeMiIgIAAOBiIg0DIT5u+kiPiGGr8U4vhbj+FqM8+vXgnMIREQEgHsIRESkYSAQEREABoJPCCGeVF2DSkKIRCFEkRBiVyi+Ftq/u1Rb3S9khfr7YCr+/FowELxMW8shR3Udij0CoFhb3wKh9MEohNgFABPW+ihVW5FSIfs+mIq/fz7ovYRmUBNC5ACwqK5DNW2ZU49QW/luPYDntMsWAEUAQnKhpxB/H1wnED4fuIfgXTlSSr/+D9eT9gvQFWIr3yVOup6iogh/EqLvgxvx+88H7iHMgjYckDzpZouUskwIURpKb/ibvRYTru+SUj6uY1n+oAfXvy6hLhTfB9cIlM8HBsIseMZCp9DlWQsa7nWhi6SUVfpUpr9pXgsIIXZJKfdol4P6tZjkJMb3EjhMErrvg8kC4vOBQ0ZeIqWs0r4BJOP6YYOQor3xnxRCnBJCnEIIfWPWgjLH88sfCN8KfSWU3weTBcrnA89UJiIiANxDICIiDQOBiIgAMBCIiEjDQCAiIgAMBCIi0jAQiIgIAAOBiIg0DAQiIgLAQCAiIg0DgcjLhBA5Qoh6IcR+7XqR1vGTyK8xEIi87+sAtgOo0lbHKvb3tsdEAHsZEXmdECJRStkjhEiEOwxCtsEdBRYGApEPCCGKAHeXS9W1EM0Uh4yIvExbPMjiCQPPOstE/o6BQORF2kLyOQCeEUIkanMIPWqrIpoZBgKRl3gWUddWCLMAaABQzzkEChScQyAiIgDcQyAiIg0DgYiIADAQiIhIw0AgIiIADAQiItIwEIiICAADgYiINAwEIiICAPx/dPXMdHEGU6QAAAAASUVORK5CYII=
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAYQAAAEJCAYAAACUk1DVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAleUlEQVR4nO3dd3Sc1Z038O+dGfUujYotWZZV3bBBkg1YuCIMC2RDwOBsOkkwqezZvBuSN2VPztkUQnb33WRzAphsypJCMSEJSwnINrLlLssYN1ldlixLGpVRL1Pu+8c8Y8uybLWZ5075fs7x0cw8o5kfYma+89z7PL8rpJQgIiIyqC6AiIh8AwOBiIgAMBCIiEjDQCAiIgAMBCIi0phUFzAfZrNZZmVlqS6DiMivHD9+vEtKmTz5dr8OhKysLFRWVqoug4jIrwghmqe6nUNGREQEgIFAREQaBgIREQFgIBARkYaBQEREABgIRESkYSAQEREAPz8Pgcib+kZs+OvJNgBA8eIE5KfGwGgQiqsi8h4GAtEktR0D+M3BJrx24iKGxx2Xb48JM2HT0hR8/4GViIsIUVghkXcwEIgmeKWyBU+++gFCjAZ8ePVCfHpdFmLDQ1DZ3INjTb3YdbwF1Zf68ZvPrkV6fITqcok8SvjzimnFxcWSrSvIU946dQlf/kMVSnLN+OlHb0FiVOg19zlY14XHXziOiFAjfv3oGqxYGKegUqL5EUIcl1IWT76dk8pEAMprLHjixRO4JTMBz32yaMowAIB1uWbs+uI6GA0Cjzx7CKda+3SulMh7GAgU9Kou9OLxFyqRmxKDX31mDSJDbzySWpAWg9e+VIKY8BB87eX3MWpz3PD+RP5C90AQQmwTQpQKIZ6c5n433E7kCWN2B/755ZNIjgnD/3x27Ywni9PiwvGjh25Cbecgfrq71stVEulD10AQQhQCgJSyDIDVfX2K+5UCWKNnbRSc/ruiEQ1dQ/jXD69EckzYrH53c0EKHinOwHPl9Xi/xeqdAol0pPcewnYAVu1yA4BSnZ+f6LI26wj+a3cdti5PxaaClDk9xnfuX47U2HD88ysnOXREfk/vQIgH0DPhetLkOwghCrU9CCKv+v4bZ+GUEt+9f/mcHyM2PARPPbQKdZ2D+PmeOg9WR6Q/X5xUTlRdAAW+itouvHmqHV/ZnItFiZHzeqyN+cn40OqF+NWBRvQOjXuoQiL96R0IVlz5wI8H0D1x40z2DoQQO4QQlUKISovF4pUiKbA5nRLfe/0MFidF4rEN2R55zCe25GJ43IFfH2j0yOMRqaB3ILwEwP0OzAZQBgBCiHj3bdpRSNu0y9dMOkspd0opi6WUxcnJ16wRTTStsnMdqOscxP/ZWoDwEKNHHjMvNQZ/tzINvz7YhP5Rm0cek0hvugaClLIKuHwUkdV9HcBubfsuKeUuuPYi4vWsjYLHL/c3Ij0+AveuTPPo4355cy4GRu144dCU65cT+Tzd5xC0b/hlUsqdE24rmuI+ORMCg8gjTrZYcbSpB4+WZMFk9OzLf2V6HDYXJOOX+xswPG736GMT6cEXJ5WJvOb5/Q2ICTNh+5pFXnn8r2zJQ++wDX84csErj0/kTQwEChqtvcN463Q7/uHWTMSEe6d9ddHiBKzLScJz+xowbnd65TmIvIWBQEHj1weaIAB8Zl2WV5/nsfXZsAyMYfe5Dq8+D5GnMRAoKPSP2vDSsRbcv2oBFnp5HYMN+clYEBeOF4+1ePV5iDyNgUBB4S/vt2FwzI7P3rHE689lNAg8XJSBfbUWtFlHvP58RJ7CQKCg8OrxVixNi8FN6fosaPNwsWvS+pXKVl2ej8gTGAgU8Ootg3i/xYqHCjMghNDlORclRqIkx4yXK1vgdPrvqoQUXBgIFPD+VNUKgwA+fPNCXZ93+5pFuGgdwYH6Ll2fl2iuGAgU0JxOideqLmJDfjJSYsN1fe6tK1IRHxnCyWXyGwwECmiHGrrR1jeKhwozdH/uMJMRD96SgXfOtKOHXVDJDzAQKKC9WtWKmHAT7lqequT5t69ZBJtD4vWTbUqen2g2GAgUsIbG7Hj7dDvuX7XAY11NZ6sgLQYFqTF444NLSp6faDYYCBSw3jrdjuFxh5LhoonuvWkBjjX3oLN/VGkdRNNhIFDA+uvJNixKjEDR4gSlddy3Kg1SugKKyJcxECgg9Y3YcLCuC/euXKDbuQfXk5vCYSPyDwwECki7z3XA7pS4x8OL4MyVe9iog8NG5MMYCBSQ3j7djrTYcKzOiFddCoAJw0anuJdAvouBQAFnaMyO8hoL7lmZBoNB7XCRm3vY6M1TnEcg38VAoIBTXmPBmN2Ju1f4xnCRG4eNyNcxECjgvHW6HUlRoVi7JFF1KVfhsBH5OgYCBZRRmwN7znXgruWpMPrIcJHb5WEjHn5KPoqBQAHlQF0XhsYdPnN00WR3LU/F8eZeWIfZ24h8DwOBAsrbp9sRE27Cuhyz6lKmdOeyFDicEuU1FtWlEF2DgUABw+5wouxcB+5cmoJQk2++tFdnxMMcHYqyc52qSyG6hm++a4jm4ESLFb3DNty13DeHiwDAYBDYXJCC9853wuZwqi6H6CoMBAoYe6o7YTIIrM/3zeEitzuXpWJg1I5jTT2qSyG6CgOBAsbe6k4UZyUgNjxEdSk3tD7PjFCjAbs5bEQ+hoFAAeGidQTV7QPYsjRFdSnTigoz4facJOw+1wEppepyiC5jIFBA2Fvt+rbtD4EAAKXLUtDUPYx6y5DqUoguYyBQQNhb3YlFiRHISY5WXcqMbFnmWtJz97kOxZUQXcFAIL83anPgQH0XthSkKF/7YKbS4yOwbEEs5xHIpzAQyO8daujGqM2JzX4yXORWuiwFlc09PGuZfAYDgfze3upORIQYcVt2kupSZmVTQQqcEqio61JdChEABgL5OSkl9lR3oiQ3CeEhRtXlzMrqjDjEhptQfp5tLMg3MBDIr9V1DqK1d8TvhosAwGQ0YH1eMvbVWnj4KfkEBgL5NXeTuE0F/hcIALAxPxkd/WM43zGguhQiBgL5t/IaC3JTopEeH6G6lDlxt9ngsBH5AgYC+a1RmwNHG3uwIS9ZdSlztiAuAgWpMdhXy0Ag9RgI5LeONvZgzO70+WZ209mQb8axxl4MjdlVl0JBTvdAEEJsE0KUCiGevM72Uu3fj/WujfzLvhoLQk0G3LbEvw43nWxjfgrGHU4cbuhWXQoFOV0DQQhRCABSyjIAVvf1Sdvv0rYXTt5ONNH+2i6szUpERKh/HW46WXFWAiJCjNjHVdRIMb33ELYDsGqXGwCUTtwopaySUn5Du5otpazSsTbyI+19ozjfMYD1ef49XAQA4SFG3JadyGU1STm9AyEewMRVQabc19eGkx7XoyDyT+5J2A35/juhPNHG/GQ0dQ+juZvdT0kdn5xUllI+DeBxIUT85G1CiB1CiEohRKXFwm9UwWp/bReSY8KwNC1GdSke4Q42DhuRSnoHghVAonY5HsBVs2hCiInzBg0Adkx+ACnlTillsZSyODk5ML4d0uw4nBIVtRaszzP7TXfT6SwxRyE9PgL7a9nXiNTROxBeApCtXc4GUAYAE/YESnF1YDToWBv5idMX+9A7bMPGABkuAgAhBNbnmXGovht2h1N1ORSkdA0E9ySxEKIUgHXCpPFu7edOANlCiG3a/XfpWR/5h/3a/MEduf4/oTzRHXlmDIzZcbK1T3UpFKRMej+hlHLnFLcVaT+tcIUCADAMaEr7aruwMj0WSdFhqkvxqJIcM4QAKmq7ULQ4QXU5FIR8clKZ6HqGxuw4caEXd+QGznCRW0JUKFYujENFHSeWSQ0GAvmVo009sDlkwA0XuZXkmnHighWDbGNBCjAQyK9U1HYh1GRAcVZgDqmszzPD7pQ4wjYWpAADgfzKgTpXuwp/Wx1tpooWJyDMZODhp6QEA4H8RufAKKrbB1ASoMNFgKuNxdoliVxnmZRgIJDfOFjnGkYJ1PkDt/V5ZtR1DuJS34jqUijIMBDIb1TUdSE+MgQrFsaqLsWr3EdQHajjPALpi4FAfkFKiQN1XSjJMcNgCIx2FdezNC0G5uhQVHAVNdIZA4H8Qr1lCJf6RgN6/sDNYBAoyTWjoq4bUkrV5VAQYSCQXzigTbIG+vyBW0muGV2DY6jpGFRdCgURBgL5hYq6LmQmRiIzKVJ1Kbpw7wnxaCPSEwOBfJ7d4cTh+m6U5Pr32smzkR4fgSXmqMt7RkR6YCCQzzvZ2oeBMXtA9i+6kZLcJBxp6IaN7bBJJwwE8nkH6rogBHB7TvDsIQCu+ZKhcQdOtlhVl0JBgoFAPu9AXRdWLIxFYlSo6lJ0dXu21g6bw0akEwYC+bThcTuqLvQGxeGmk8VFhmBVehznEUg3DATyaUcbA7vd9XTWae2wh9gOm3TAQCCfdqDO1e56TVbi9HcOQHfkutphH23sUV0KBQEGAvm0irpuFC9OCNh219Nxt8PmPALpgYFAPqtrcAznLvUH5fyBW3iIEWuyEjmPQLpgIJDPOlgfHO2up1OSa0Z1+wA6B0ZVl0IBjoFAPutAbRdiw01YmR6nuhSl3IF4qJ7tsMm7GAjkk6SUqKjrwu05STAGeLvr6SxfGIv4yBAuq0lex0Agn9TcPYyL1pGgHy4CAKNBoCTHjAN1XWyHTV5lmu0vCCGyABQCSAQQD6ABgFVKucejlVFQcx9VE8wTyhOV5JrxxqlLqLcMITclWnU5FKBmvIcghPi6EOIdAD8GkANAAOjTLm8VQrwjhHhGCHGzVyqloFJR23W54yddmUfg0UbkTdPuIQghlgB4HMCLUsqfTHPfOAA7hBDFUspfeqhGCjIOp8TB+i7cszINQgT3/IFbZlIkMhMjsb+2C59el6W6HApQN9xD0MLgTinlN6WU70/3YFLKPi00dgshPu+hGinInLrYh/5RO+7IC65219MpyTXjcEM37GyHTV5yw0CQUjbO5Zv+XH+PCMDlxeVLgqzd9XTuyDVjcMyOk619qkuhADXro4yEELHeKITIbX+tq911UnSY6lJ8yrqcJFc7bB5+Sl4yl8NOcyZOHAshlgghtniuJApmQ2Oudtd35PHooskSokKxciHbYZP3zDoQpJQnAKzRDj+FlLIRQIIQ4kcero2CULC3u55OSa4ZVRd6Mch22OQFcxkyeglAPYDeCcNHZQB2eLIwCk4VQd7uejrr89ztsNnGgjxvLkNGRQAqpZR9AIR2qGkpgKc8WhkFpYraLqzNSgzadtfTcbfD3lfDYSPyvLkEwsPQ9ga0UEgEkDDdOQpE0+nsH8X5jgHOH9xAeIgRt2YnYb92JBaRJ81pDkFK+W8TrjcCOM4zlGm+3O0qOH9wYxvyzKi3DOGidUR1KRRgPNLcTptobvTEY1HwqqjrQmJUKJYv4JHNN7JeO2GvgnsJ5GEe63aqDR8RzYmUEvtru1CSa4YhyNtdTyc/NRqpsWGcRyCPm7Z1xVxaUNzo94QQ24QQpUKIJ6+zfYf278ezfV7yX+cuDcAyMIYNnD+YlhAC6/OSUVHXBYeT7bDJc6ZtXQFXX6JnZ3LymRAiVgjxdbj6H13TukIIUag9bhkAq/v6hO2lAMqklDsBZGvXKQiU17iGPzbms3/RTGzIT0bfiA0ftFpVl0IBZNpup1oofEEI8ZgQ4psAJIAqAO4DoZPgWhchB67zE57Wfmcq2wG8q11ugOtw1aoJ27O1fzu17dmz+Y8h/7WvxoKlaTFIiQ1XXYpfuCPXDCFcbT5uyUxQXQ4FiBkvkCOlfB7A89p5B8VwhUAiXJPJDdrE8nTiAfRMuH5V9zJtz8CtEMBLM62P/NfQmB2VzT34bMkS1aX4jUStjcX+WgueuDNPdTkUIGa9Ypo2ebzbC7Vcpg0lvSulrJpi2w5o50FkZmZ6swzSyeGGbtgcEhs4XDQrG/LNeLa8Af2jNsSGh6guhwLAnI4yEkJ8Xlsd7fOz7H5qhWuvAnDtLVzv/PtSKeXTU22QUu6UUhZLKYuTk/kBEgjKayyICDGiOItDH7OxPi8ZDqfEoXq2sSDPmEsvo6cA5MK1fOYjABqFEJ+b4a+/hCvzAtlw9UCCECJ+wuPvcIcBJ5WDw74aC27PSUKYie0qZqMwMwFRoUbsq+H5COQZc9lDOKatoPZNKeVWuCaT84QQD073i+4hIO2D3jphSGj3hNt/LISoF0L0zqE28jMXuofR1D3Mw03nINRkwO05SSivsUBKHn5K8zfrOYTJpJRWAN8UQjw2w/vvnOK2Iu1nGQCOGwSRcu1sW84fzM2mghSUnetEvWUIuSnRqsshPzeXPYQGIcQxIcTmSfMHHMikWSs/b0FGQgSWmKNUl+KXNhW4gvS9852KK6FAMJdA2A7gZQBfBNCkhcPf4DqRLAYAZjJ8RDRud+JQfRc25idDCLarmIuMhEjkpUTjvfOcR6D5m0sg1AN4RUr5iJQyEa5DQMsAbAXQLISoBcC2EzStyqYeDI07eHbyPG1emoIjjd0Y4ipqNE9zaX/9PFxLZmZp109IKX8ipdyqBcR2sPMpzcCe6k6EGg0oYbvredlUkAybQ3KtZZq3OZ2HoIVA03W2VQH4xnyKouCw53wnbs1ORFTYvI9tCGrFixMRFWrEezz8lObJY+2vJ5phGwsKYk1dQ2iwDOHOpSmqS/F7oSYD7sgz473qTh5+SvPilUAgms6eatdRMVuWpiquJDBsLkhBW98oajoGVZdCfoyBQErsPd+JnOQoZCZFqi4lIGwqcO1p7eXhpzQPDATS3dCYHUcaerCFw0UekxYXjqVpMTwfgeaFgUC6q6jrwrjDic0MBI/avDQFlU296B+1qS6F/BQDgXS3t7oTMWEmrMlKnP7ONGNblqbA7pQo50lqNEcMBNKVlBJ7z3difb4ZIUa+/DypMDMBiVGhKDvXoboU8lN8R5KuzrT1o6N/DJsLOFzkaUaDwJalKdhb3Qmbw6m6HPJDDATS1e5znRDiylEx5Fl3LU9F/6gdRxt7pr8z0SQMBNLVO2fbUZSZgOSYMNWlBKT1eWaEmQx49yyHjWj2GAikm5aeYZxp68fWFTwZzVsiQ024I9eMd8928KxlmjUGAunG/a116/I0xZUEtruWp+KidQTnLg2oLoX8DAOBdPO3M+0oSI1BFhfD8ao7l6VCCPBoI5o1BgLpomdoHMeaejhcpIPkmDDcsiie8wg0awwE0kXZuQ44JXD3Cg4X6aF0eSpOXezDpb4R1aWQH2EgkC7eOdOB9PgIrFgYO/2dad62LnftiZVxL4FmgYFAXjc8bsf+WgvuWp7KtZN1kpMcjezkKLx5ql11KeRHGAjkdftqLBizOzl/oCMhBO6/aQGONHbDMjCmuhzyEwwE8rq/nelAfGQI1rKZna7uXbUATgm8fYZ7CTQzDATyqlGbA++e7cBdy1JhYjM7XRWkxiAnOQpvfnBJdSnkJ/gOJa9677wFg2N2fGj1QtWlBB0hBO7jsBHNAgOBvOp/P2hDYlQo1uUkqS4lKHHYiGaDgUBeMzxux+5znbj3pjQOFynCYSOaDb5LyWvKznVixObAh1ZxuEgVDhvRbDAQyGteP9mG1NgwLpWp2H2rFnLYiGaEgUBe0T9qQ/l5C+67aSEMBp6MplJ+ajRykqPwxgdtqkshH8dAIK9450wHxh1OfGj1AtWlBD0hBP5+dTqONPagzcreRnR9DATyitdPtiEjIQI3L4pXXQoB+Mgt6ZASeO3ERdWlkA9jIJDHdQ+OoaKuC/evWsjeRT4iMykSa7MS8aeqVq6kRtfFQCCP+/P7bXA4JR4sTFddCk3wYGE66i1D+KC1T3Up5KMYCORRUkq8UtmC1RlxyE+NUV0OTXDvqgUINRnwp6pW1aWQj2IgkEedvtiP6vYBPFy8SHUpNElseAi2Lk/FX0+2YdzuVF0O+SDdA0EIsU0IUSqEePIG9ynUsybynFeOtyDMZGDvIh/1UGEGeodt2Hu+U3Up5IN0DQT3B72UsgyAdaoPfiFEKYDn9ayLPGPU5sCfT1zE3SvSEBcRorocmsL6PDPM0WEcNqIp6b2HsB2AVbvcAKB08h20sOjRsSbykHfPdqB/1I6HizNUl0LXYTIa8MDNC7GnuhM9Q+OqyyEfo3cgxOPqD3u2wAwgrxxvxcK4cKzLMasuhW5gW3EGbA6JV49zL4Guxkll8og26wj211rwUFEGjGxV4dOWpsWieHECfnekGU4nz0mgK/QOBCsAd6ezeADds30AIcQOIUSlEKLSYrF4sDSaj1cqWyElsK2Iw0X+4JO3L0Zz9zAq6rpUl0I+RO9AeAlAtnY5G0AZAAgh4mf6AFLKnVLKYillcXJysucrpFkbtzvx+yPN2JCfjMVJUarLoRm4Z2UakqJC8bvDzapLIR+iayBIKauAy0cSWd3XAex230cIsQ1AsfaT/MDbZ9rROTCGR9dlqS6FZijMZMQjaxah7FwHG97RZbrPIWjf8MuklDsn3FY04fIuKWWClHKX3rXR3Pz2YBOykiKxMZ97bP7kY2szIQG8ePSC6lLIR3BSmeblVGsfjjf34lO3Z3HdAz+zKDESmwtS8MdjLbA5eOYyMRBonn5zsAmRoUZs47kHfumTty2GZWAMf+NqagQGAs1D1+AYXj/ZhocKMxAbzjOT/ZHrQIBIPL+/kW2xiYFAc/fi0QsYdzjx6XWLVZdCc2Q0CDy2PhsnW6w43MAGAcGOgUBzMmpz4LeHmrE+z4zcFLa59mfbijJgjg7DM+X1qkshxRgINCcvHWuBZWAMX9qUq7oUmqfwECMeLcnCvhoLzrRx8ZxgxkCgWRu3O/FseT3WZCXgtuzE6X+BfN4nbluM6DATni1vUF0KKcRAoFl7taoVl/pG8dUteVwzOUDERYTg47dl4o0P2tDcPaS6HFKEgUCzYnM48Yv36rB6UTzW57GraSD5XMkSmAwGPLePewnBioFAs/KX99vQ0jOCJ7bkcu8gwKTEhmNbcQZ2VbaipWdYdTmkAAOBZszhlPjF3josXxCLLUtTVJdDXvDVLbkQAviPd2tUl0IKMBBoxl6ubEFD1xCeuJNzB4FqQVwEHi1Zgj+/f5FHHAUhBgLNyMCoDf/+znmsyUrA3StSVZdDXvTFTTmIDQ/B02+fV10K6YyBQDPyzHv16Bocx3fuW869gwAXFxGCr2zORXmNBQe5gE5QYSDQtFp6hvHLikZ85JZ0rF4Ur7oc0sEnb1+MhXHheOrtavY4CiIMBJrW0387D4MAvn53gepSSCfhIUZ8bWsBPmjtw6tVF1WXQzphINANHW/uwesn27BjfTYWxkeoLod09OAt6ShanIAfvHEWPUPjqsshHTAQ6LrG7A5889VTSIsNx+Mbc1SXQzozGAR+9OBNGByz4/tvnFVdDumAgUDX9V+761DbOYgfPXgTosJMqsshBfJTY/CFjTn4U9VFVNRygjnQMRBoSqda+/BMeT0eKszAZp6EFtS+vDkXS8xR+PafT2HU5lBdDnkRA4GuMW534uu7TiIpKhT/cv9y1eWQYuEhRvzggZVo7h7Gv7/DcxMCGQOBrvHzPbWobh/ADz9yE+IiuTQmAetyzfjEbZl4fn8j9lR3qC6HvISBQFfZV2PBz/fW4cHCdJQu5xnJdMV37luOZQti8bWXT6LNOqK6HPICBgJd1tIzjCdePIG8lBh8/4GVqsshHxMeYsQvPl4Im92Jr/7xBGwOp+qSyMMYCATAtUbyF353HA6nxHOfLEJkKI8qomstMUfhhw/ehOPNvfg3zicEHL7rCVJKfPu10zjT1o9ffaYYWeYo1SWRD/vwzek42tiD58obsCQpCh9dm6m6JPIQBgLhP8tq8WpVK/7xzjxsWcp5A5re9/5+BVp6R/Ct107BHB3G+aYAwSGjILdzXz1+ursWDxdl4B/vzFNdDvmJEKMBz3y8ECvT4/CVP1bheHOv6pLIAxgIQeyFw8344ZvVuH/VAjz10CoYDGxrTTMXFWbCrz6zBmmx4fjcb49xQZ0AwEAIUn84cgHf/fNplC5Lwf/bfjOMDAOaA3N0GP7ns7ciIsSIjz53GIcbulWXRPPAQAgyTqfEU29V41uvncKmgmT8/GOFCDHyZUBzl5kUiVe/uA4psWH41K+O4u3T7apLojniJ0EQGbU58JU/VuHZ8np87NZM/PJTxQgPMaouiwLAwvgI7PrCOixfEIsv/f44fnOgkQvr+CEGQpBosAzikecO4a3T7fj2vcvwgwdWwsQ9A/KghKhQ/OGxW7G5IAXfe/0svvT7KvSN2FSXRbPAT4QAJ6XEC4eacO/P9qO5exjPfaIIj23I5rrI5BWRoSY8/6li/N+/W4p3z3bgvp/tx4kLPALJXzAQAlhT1xA+/etj+O5fzmDtkiS8808bsHVFmuqyKMAZDAKPb8zBy1+4HVICDz1zEP/yl9OwDnPVNV8n/Hmcr7i4WFZWVqouw+f0Do3jZ3tq8bvDzTAZDPjWvUvxidsWc6+AdNc3YsN/vHMeLxxuRlxECL5+91I8UpzB4UrFhBDHpZTF19zOQAgcloEx/P5IM/67ohFDY3ZsX7MI/1Saj5TYcNWlUZA729aP7/31DI429SAzMRI7NmRjW1EGD2pQhIEQoKSU+KC1D7891IT/PXkJ4w4nSpel4sl7CpCfGqO6PKLLpJR452wHfvFePU62WGGODsXH1mbiwcIM9s/SGQMhgEgpcaatH2+euoQ3Tl1Cc/cwIkONeLgoA59el4Xs5GjVJRJdl5QShxt68Ny+epTXWCAlcEtmPB64OR1blqZgUWKk6hIDns8EghBiGwArgEIp5dOz3T5RsASCwynR2DWIyqZeHKzvxsH6bnQNjsFoEFiXk4T7Vy3APSsXIC6Cq5uRf7nUN4K/vN+GP1W1oqZjEACQbY7ChvxkFGcl4OZF8UiPj+D8l4f5RCAIIQoBZEspdwkhdgColFJWzXT7ZIEWCGN2By5ZR9HYPYSmriE0WIZw7lI/zl7qx/C4a3Hz5JgwrMtJQkmOGXcuS0FSdJjiqonmT0qJhq4h7KuxoLzGgsMN3Ri1uRbgMUeHYcXCWOSmRCM3JRo5ydFIT4hAakwYJ6fn6HqBoHf76+0A3tUuNwAoBVA1i+0+R0oJm0PC7nTC5pAYtzsx7nBizObAqM2JEZsDI+MODI/bMTBqx+CYHQOjNvQO29A7NI6e4XFYBsbQ3jeK7qGrD8uLCTNh6YIYPFK8CCvT43DzojjkJEfz2xIFHCEEcpJdH/aPlizBuN2J6vZ+vN9ixfsXrKhuH8CRxishAQBGg0BabDjMMWFIjg5FUlQYEqJCERcRgtgIE2LCQxAVakREqBGRoSZEhBgRZjIgLMSAUKMBISbXT5NBwGgQfF9B/0CIB9Az4XrSLLdf5Xz7ADb+ZC8A4Ho7OhJXb5Dy2vtK6bqXlK77u35qt0vAKSWc7p9OCYeUcDoBu9MJ5xx3sCJDjUiIDEVSdChSYsKwelE8FsSGIy0uHEvMUcgyRyEpKpQvUgpKoSYDVmXEY1VGPD51u+s2p1PionUEDV1DaLOOoM06gou9I7AMjuGidRQnW/tgHR6HzTG3N6XJIGAwCBiFKyAMwnVOhUG4LgMCQgAGAQjtsvvdOfl9OvHq5LewgLjuNtX8boEcbShpBwDELszGLYviJ26b+nemuMH9P8X9K0K7fPl/tHA9nvt//uQXh8louPzCCTEKmLRvGmEmA8JMRoSaDAgzGa76dhITbkJ0uAkx4SaEmXi4HdFsGAwCixIjbzjpLKXEmN2J/hEb+kdtGB53YGjMtYc+ZndizO7AmM2JMbsTNseVvXqHlHA4nbA7tS99TvcXwau/FAJXrru/WLq/TF6uAVddubq+SbWqsu86t+sdCFYAidrleACTe+VOtx1Syp0AdgKuOYT//Ogtnq+SiPySEALhIUaEhxh5/s0N/PQfpr5d7xmZlwBka5ezAZQBgBAi/kbbiYjI+3QNBPcRQ0KIUgDWCUcQ7Z5mOxEReZnucwjakM/k24putJ2IiLyPB/ESEREABgIREWkYCEREBICBQEREGgYCEREB8PP210IIC4BmxWWYAXQprsFX8G9xBf8WV/BvcYWv/C0WSymTJ9/o14HgC4QQlVN1DQxG/Ftcwb/FFfxbXOHrfwsOGREREQAGAhERaRgI88czq6/g3+IK/i2u4N/iCp/+W3AOgYiIAHAPwSuEEE+qroGIfJMvfz743QI5vk7r1LpGdR2qaQsZAUCOlPIbSovRmRBiG1xrexRKKZ9WXI5Swfw6mIqvfz5wD4E8TnvRl2mda7O160FBCFEIAFLKMgBW9/VgFMyvA3/FQPAgIUSh9kEQ7LIBuN/8Dbiy6FEw2A7X3gHg+m8P5g/BYH4dXMMfPh84ZORZidPfJfBNWtOiEK6V8IJFPICeCdeTFNWhXJC/Dqbi858PDIRZmDAeOlGDlLLMH9Jfb9pwybtc+S648XXgH3sHAANhVqZZzS1bCJE94XJhIL8BbhSOE66XBuGkqhVXvgnGA+hWVonvCMbXwWR+8fnAQPAQKeUu4PIHZbzaarxvuqVOhRA73B8CQohSf/h25CEvAXD3qskGECz/3VMK4tfBVfzl84EnppHHaUeTvALXWHoigIeD6YNAe9M3AMgO5jXCg/114I8YCEREBICHnRIRkYaBQEREABgIRESkYSAQEREABgIREWkYCEREBICBQEREGgYCEREBYCAQEZGGgUDkYUKIQiFEvRDilQnX4xWXRTQtBgKR55UCKALwnLsrrJTSqrQiohlgLyMiL9H2ChKllA2qayGaCQYCkRe4h4i4Z0D+hENGRB7mXgjFHQYTFkYh8mlcIIfIg7TlIosB9AghyuCaT7DCtT4CkU/jHgKRh0wYJtoJ12ppjQDWcFEY8hecQyAiIgDcQyAiIg0DgYiIADAQiIhIw0AgIiIADAQiItIwEIiICAADgYiINAwEIiICAPx/GorJJgUmIakAAAAASUVORK5CYII=
 "
 >
 </div>
@@ -16136,7 +15847,7 @@ The input and output shapes are: (51,) (2, 51)
 <span class="c1">#print(&quot;Making spline from samples&quot;)</span>
 <span class="c1">#ens_s = ens_n.convert_to(qp.spline_gen, xvals=bins, samples=1000, method=&quot;samples&quot;)</span>
 <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Making quants&quot;</span><span class="p">)</span>
-<span class="n">ens_q</span> <span class="o">=</span> <span class="n">ens_n</span><span class="o">.</span><span class="n">convert_to</span><span class="p">(</span><span class="n">qp</span><span class="o">.</span><span class="n">quant_gen</span><span class="p">,</span> <span class="n">quants</span><span class="o">=</span><span class="n">quants</span><span class="p">)</span>
+<span class="n">ens_q</span> <span class="o">=</span> <span class="n">ens_n</span><span class="o">.</span><span class="n">convert_to</span><span class="p">(</span><span class="n">qp</span><span class="o">.</span><span class="n">quant_piecewise_gen</span><span class="p">,</span> <span class="n">quants</span><span class="o">=</span><span class="n">quants</span><span class="p">)</span>
 <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Making mixmod&quot;</span><span class="p">)</span>
 <span class="n">ens_m</span> <span class="o">=</span> <span class="n">ens_n</span><span class="o">.</span><span class="n">convert_to</span><span class="p">(</span><span class="n">qp</span><span class="o">.</span><span class="n">mixmod_gen</span><span class="p">,</span> <span class="n">samples</span><span class="o">=</span><span class="mi">1000</span><span class="p">,</span> <span class="n">ncomps</span><span class="o">=</span><span class="mi">3</span><span class="p">)</span>
 <span class="c1">#print(&quot;Making flexcode&quot;)</span>
@@ -16164,10 +15875,6 @@ The input and output shapes are: (51,) (2, 51)
 Making interp
 Making spline
 Making quants
-(7,)
-(100, 7)
-(9,)
-(100, 9)
 Making mixmod
 </pre>
 </div>
@@ -16222,10 +15929,6 @@ Making mixmod
 Making interp
 Making spline
 Making quants
-(7,)
-(100, 7)
-(9,)
-(100, 9)
 Making mixmod
 </pre>
 </div>
@@ -16279,29 +15982,10 @@ Making mixmod
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>(9,)
-(1, 9)
-(9,)
-(1, 9)
-(9,)
-(1, 9)
-(9,)
-(1, 9)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAasAAAEnCAYAAAAXY2zOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABT9ElEQVR4nO3deXzU1bn48c+ZNZksZGVfw74IGgKyqYgB1KqlitpqbetVodrb2lu90EW73Nprodrl9vZnQVurrd4q1NrWBUlA0YgoIYiEHcIOgezbJLOe3x+zZBISCGEyk2Se9+uVVzLfLc9MJnlyzvec5yitNUIIIUR3Zoh2AEIIIcSFSLISQgjR7UmyEkII0e1JshJCCNHtmaIdgBCi+9i2bVtfk8n0HDAJ+WdWRJ4XKHa73fdPnTr1bOgOSVZCiCCTyfRc//79x2dmZlYZDAYZKiwiyuv1qrKysgmlpaXPAbeE7pP/nIQQoSZlZmbWSqIS0WAwGHRmZmYNvpZ9y31RiEcI0X0ZJFGJaPK//87JTZKshBC93vPPP58a+Hr37t2WG264IQvg9ddfT5o1a9bo6EUmOkqSlRCiVysvLzfm5eUlBx5PmDDB+fbbb5cALFq0qK5Pnz6e6EUnOkoGWAgh2vWLScentrfvmkf6HJ1+b3I5wCfP12ZserpmWHvH/mfxkG0d/Z4PPvjgoIULF9YCHDx40Dpq1CjHypUr+2/evPnAY4891q+iosL0zDPPnARfyyhwzKJFi+pef/31pJUrV/ZftmxZaWFhoe3666+vA9ixY4ft9ddfT1q0aFFdQUGBbdmyZYM2b958IPT7lpeXG3/9619n5OTk2A8ePGh99NFHyzsas+h60rISQnQbTz31VMbIkSMdixYtqgOorq42hrZ+7rrrrqrAsbt377YEksrKlSv7g6+ldPz4ceuiRYvq7rrrrqqXXnopdc6cOfahQ4cGrzlnzhx7W62pxx9/vP/1119ft2jRorqioqKEyDxj0VHSshJCtKujLaLp9yaXB1pZl2LDhg3JP/jBD0oBMjIyzts9N2HCBOeECRPKy8vLjaHbJ02aZO/M996xY4dt4cKFtQUFBbaHHnqorDPXEF1HWlZCiG5j6tSpDVu2bLGBr1uu9f79+/dbA18XFBTYHnvssX4Xc/2CggJbe/vmzZtXC76W17hx4xwXc13R9SRZCSG6jSeeeOJMdXW1saCgwFZYWBhMLFOnTm0oKCiwHTx40Pr+++8nl5eXGw8cOGBNSUnx7N271zp8+HDn888/n1pQUGArLi627d692/LWW28l79ixw1ZeXm4cPny44/XXX08aN26cI/SY0K+feOKJM4WFhbbXX3896XxJTUSHkvWshBABO3bsODJlypRuMbCgoKDAtm7duqQnnnjiTLRjEZG1Y8eOjClTpgwP3SYtKyFEt/TSSy+lbtu2LaGt7kARe2SAhRCiWwoMTxcCpGUlhBCiB5BkJYQQotuTZCWEEKLbk2QlhBCi25NkJYToNkIrorcntIK6iB2SrIQQ3UZoRfS2tK6gLmKHDF0XQrTt9W8M4ezu8FZy6DvBzqLfHW9vd2hF9I5UUG9dKT1Qof2BBx4oP3TokCUnJ8f+gx/8YPDPfvazE6HV2cP6nERESMtKCNFthFZE70gF9daV0gPn3HvvvVVPPPHEGX/FdveiRYvqHn300fJvfvOb7S5jIro3aVkJIdp2nhZQpFyognpbldJbnxO6HMiQIUMcu3fvtkyYMMHZNRGLriLJSgjRIxUUFNhCK6W3V5appqYmuP348eNWSVQ9kyQrIUS3EVoFvbKy0nS+Cupz5syxz5kzx956mZDi4mJbQUGBbc6cOXaAmpoaU0FBgW3Lli223/72t0ej88zEpZKq60KIoO5UdT1cbrjhhqzzjTAU3Y9UXRdCxJTXX389KdA6i3Ys4tJIshJC9Fr+0YHFcp+q55NkJYQQotuTZCWEEKLbk2QlhBCi2+vRQ9czMjL08OHDox2GEL3GypUr2b17t1R56OUcDof7iiuu2BHtOC5Gj05Ww4cPp7CwMNphCNFr7Nmzh/Hjx0c7jHaVlJSwfPly1qxZ02XfY/ny5aSnp7Ns2bIu+x7RVlxc3OMGnEg3oBCix8jKyurSRAVw5513dun1Ref06JaVEKLrrPhkBXsr94b1muPSxrF8+vJ29+fn57NixQqWL19OUVERWVlZpKSksGbNGlasWBFsWeXl5bF27VoeeOABDh8+zAMPPMD8+fPJyso67/kpKSmsXr2anJwcCgsLWbJkSfB7r1y5kuzsbIqKisL6nEV4SLISQnQbubm5LF26lNzcXLKysli6dCl5eXmUlJRQWFhIbm4uKSkpACxevJjKykpeffXV4DnAec8vKioiNzeX7OxsKisrWb16NUuWLGH16tVkZ2eTm5tLWloa+fn5UXwVRFskWQkh2nS+FlBXys7OPufrtLS0No9dsmQJU6dOZcOGDR06Py8vj8WLFwO+LsVVq1axZMkS8vLyWLFiRXifiAgruWclhOixioqKePbZZ1m+vGOJNTs7m5ISX5nAkpISpk2bBsC0adOC3X+VlZVdE6y4JJKshBDdRlFREUVFRZSUlJCfnx/8Oi8vj7y8vBb7165dy/Lly4MJaOXKlRc8f8WKFRQVFQX3BUb8LVu2jJKSkuD5eXl5VFdXR/fFEC306KrrOTk5WoauCxE+3X3ougiP4uJi+6RJk/ZEO472SNV1Idqgtcbj9Vz4QCFE1EiyEjFLa82HJz/ki29+kQVrF7C/an+0QxJCtEOSlYhJxeXF3PvOvXw9/+vUOGoAuHfdvewo61EVaISIGZKsRMypaqrivnfu40jNEb5/5ff516J/8cINL9DH2ocH1j/AltNboh2iEKIVSVYi5ryw6wUa3Y38ceEf+dK4L2E2mhmcNJgXrn+BQYmDeCj/IfZUdNt7z0LEJJkULGJKVVMVL+99meuHX09WSlaLfZm2TJ5f+Dw3vnYjz+18jqfnPh2lKLuRp1V4r/dIzx19LKJLWlYipry4+0Wa3E0snbK0zf0pcSncMfYO8o/lc6z2WISjE0VFRUydOpXly5dTXV1Nfn4+I0eOZPXq1ZSUlHD77be3e+7atWsjGGnbWsffnq6KNT8/n/nz55/3mI5+7wcffHDQY4891q/19oKCAtvEiRPHP/bYY/2ef/751MDntvY99dRTGU899VRG63MffPDBQYH9s2bNGt2ReCRZiZhR3VTNy3teZuHwhYxMGdnucXePvxujMvLi7hcjGJ0AX4WJrKws7rzzTlJSUoK1AO+4447zVlyvrq4mLy8vwtGeq3X8benKWENrJ17q97777rur2to+Z84c+9ChQx3XX3993b333lv1xBNPnHn44YeHlZeXG1vve/TRR8sBAgkrsP/uu++uCux/4IEHyjsSjyQrETNe3P0ije5Glk5uu1UVkGnL5JaRt/D6wdepaKyIUHTiQoqKioKthkAVirVr15Kfnx8sVBtagHb16tUUFRWxevXqFtvWrl3LypUrg+fOnz8/uA18rZPVq1cHrxU4Jj8/v8V5S5cuvWCVi9bnBipqhMZaXV3NypUrW3zf0Jjy8/OZOnXqOXG19xxbf//QcwLfe/PmzQaA8vJy42OPPdbv9ddfTwoklMDjdevWJV3Ej6ddX/va16p+85vf9G9rX0FBge3KK69s6Mh15J6ViAk1jhpe3vsyC4YvYFTqqAse//kRX+JvB15jwR/+m7j6z5EzPJWcYalcNTqT4RkJEYg4tuXn5wdr9AUSQnZ2drDV8MorrzB//nwWL15MSUkJWVlZZGVlBSuvr1y58pzq6llZWaSlpbF48WJuv/32YKmlpUuXBovblpSUUFJSwpIlS5g/fz65ubkdqgTfntbnrlq1ihUrVrSI9cknn+TOO+8kOzubpUuXsmTJkhYxga8Qb+D4kSNHcujQoTafY+iSJ209l0DLb9asWV6Axx9/vP/dd99dNWfOHPtdd92V9tRTT5GTk2NftGhRXUZGhud8CWvLli228vJy48GDB62/+c1vjmZkZLQ5sz4jI8Nz4sQJa+i2devWJW3ZssUGEGh9XYi0rERMWH90PQ2uBu6bdN95j6ttcvGfa3Zw5+9KcNVOwJNYwGWD4/joUAWP/2MX83+1iX98ejJCUceuQJJor1vre9/7HqtWrWLkyJFttm7y8vKC52VlZZGXl0dOTg5bt25t0UKDllXas7KyWLJkyTnXvJhK8K2FntuWoqIiKisrKSoqYunSpW2eE/oaZGVlBesdtn6Oodp7LqF27NhhKy8vNxYUFNgeeuihsg0bNiSPGTPG0ZHnNWPGDPuiRYvqHn300fJ77723zS5D8LXeBg8e3OKa119/fd3Xvva1qvT09A6XjpFkJWLCpuObGJQ4iHFp49o9ptHp4b4/beXv209yZ84Qnl7wMB5lZ052CR9//zo2/edcpg5L5eG/fsoz7x2iJ9fV7Ony8/NZs2YN27ZtO2ftqaKiojarq1dWVgYXaAxtgbQ+N9AdGAmhiTPQ6mlLaMIJtCTbqyAfeu3zPZeCggLbvHnzasF3L2ncuHGOqVOnNnz88ccJ4Esyl/DUgv70pz+lPvzww6Wtt2dkZHjOl+Rak25A0es1uhvZcnoLi8csRqm2h2I73V4efGkbhUer+J8vXsHNUwYC8NLBy/jnoX/y5QlfZlh6Ai/823QeXfMZK9bt5VR1Iz++ZSJGQ5iHd3cnER5qHrin88orr5CVlUVhYSElJSW8+uqr5OTkBPdv3boV8LUeQtenys/PJycnhxUrVgT/UAeqq5eUlLBq1SrWrFlDZWUl3/ve94ItmtAEl5KSEkwIa9euJSsrq91K7oFBIO3FH6jkHnpudXV1i1iXLVt2TlIJjQkIxllYWMiqVasA2nyOoVXn23ouixcvJisri82bNxtuvfVWx5w5c+yhI/6eeOKJM4899li/goICW2FhoW3jxo3J5eXl5aFdfAUFBbZjx45ZX3rppdRx48Y52tq3bt26pEAXITR39YWem5aW5p4wYYKzo+8Nqbouer13j73Lt979Fqvnr2bmwJnn7Pd4NQ//dTtvfHaaJ2+9jC9NHxrc98KuF3iq8Cne/MKbDE32bfd6NSvW7WXV+yU8Mn8M37yuQyNve4TeXHV9+fLlLRZYbP24O7v99tvbHQnZGT2x6rq0rESv996J90g0J5LTLye4beff67GlGRl5TTy/ytvP+x9V8B+miQz8MJlNH1YHj0s2zIAUeGPPOh660td1tG+dnVn7BtBQYWDLb2sZvPksaYkWAFIGm5hye2Ikn57ooDvvvDPYUiopKeHOO++MdkgdEtqaa6+bMBZIshK9mld72XR8E7MHzcZsNANQecTFuserGH+jDSZ4WPX+IW4bMhTni0Y+oa7VFWxk3D2O/MS8YLI6+G4Te9+20wcbl2Pj4EEH4Lt/PCTHKsmqm8rOzg52q11o0EN3kpuby6FDh6IdRtRFPFkppRYD1UCW1rrtyQG+41ZorTu2VrUQ7dhVvouKpgrmDpkb3FZ72tfFfvC9Rl4Ze5A4s5GlX8jibJq7zWs0Gebzav1vOVZ7jKHJQxl3g42+Y32Jb29pHf/49CRXj85k5sh0kgaE5Z60EKKViCYrf6JCa52vlFqilMrVWue3cVwuELvtXRE27x5/F6MyctWgq4LbGsp9ycp2OXxwoJwf3TyBEaNtjGjn1tPQ+pt59W+/Zf3R9dx/2f2MnhcP8+IBuJJkPnnpDP9v915uvHkOY/olsO0vdWz7cx1Tv5zE1HvCMq9SiJgX6aHr04AS/9clwDltcaVUVsgxQlySTSc2cXnfy+lj7RPcZq/wJattlZWM7ZfEPTOGnfcaAxIHMDlzMuuPrG9z/08+P5HEOBM//ucuADxOTc1JD7WlbbfUhBAXL9LJKqXV4/Q2jsnSWkuyEpfsVP0p9lft59oh17bY3lDuBaCMJn7y+YmYjBf+NVgwbAF7Kve0Wdw2I9HKQ3NHsvlQBduOVpGQYWzxfXq9d7/t+xCiC0U6WVUD7U77bq9bsNUxS5RShUqpwrKysnDHJ3qDpxU8rXjvhcsAuGb9kuA2nlZUvf8SAKMTdjHj7xkt9rX3sWD9AwCs/8vUNvff9fEEUlUNv/vDr7G9dwMADRUdnpwv/HpL1fVADcHVq1cH50JdKP7zXStQB3Hq1KkdPn/58uURneDc1SKdrLbS3LrKAlqX/61USuX6721lKaXO6SbUWq/WWudorXMyMzO7NlrRo31kTmSIx8Fwb8t5hyUNYwG4qc+6Dl9rgNfFZJed9SHdiaFsysG/xf+Tjc7plJp9ZdDs5ZKsLlZvqLqek5NDbm4uixcvZsmSJaxatSo4Efhi5koFXotA2anFixfz7LPPXrB4bkBPGZrfURFNVlrrtfiSUC6QEmhFKaXy/PuL/NvSOLfLUIgO8wKfmm3kuOwttju0ibXZZ9mfu5YrB75xUdec76xhjymeUwZzm/u/Ev8GSaqBl5kDQENFjHQDRkhPrLq+du3aYMINjb+tauwXsnbt2mAx3/OdH2iJhb4WrV+vnijitQG11iu11vla65Uh2+a3Oma11nqk1vrCP0Eh2nDEaKXaYOIKV8vVB/7puIbTxj58pd+LWMz2ds5u2zVO3xys9y1tj/DrY2jgnrg3eZNsMEBjlRePq+dWiImmwB/b/Pz8dquuA8HyQaGtEPD9wc7JyQluDySfQNX1rVu3snjxYnJzcykpKWHx4sXBkkyBSuWB6haBYwKtm1WrVpGbm8vUqVNpr4JOYWEhRUVFpKSkBLvuQuNvfc3A82nvtVi9enWwCv35zl+9ejXZ2dnB1lhA69erJ5JCtqJXKjLZAMgOaVlpDX+wL2Kc8TBzzJ9e9DVHeJwM8zjY1E6yArjP9jpJqh7jnMNc9XAfvB5JVp3R06uuBxJlbm4ueXl5bd5P6+jE5NzcXJYsWRJMPoFWVFvn5+XltZmMLvR69QSSrESvtN1sI83rZmjI/aoPXVM4Yh/F57aMYsOW/+rUda921vGJOQE7bRevTfc28G7cozyYeRsjb2nAHCe/Yl2hJ1VdD1dyyMrKorq6ukULq7Vp06YFk1noced7vXoKKbckeqUicwLZroYWKeW5xi8wxNlI05kcjjs6V2niGmcdf47PYIslkXnOkNJMGnDEgctCMg2YlKbgvdeYf+c3Lul5xJreUHW9sLCQkSNHUllZGbzO4sWLW1REr66ubrMae2grMnB8YCHK6upqnnzySdasWdPiWqHnByq4B/bn5eWxZMmSc14vu/3iusC7A6m6Lnqds78yc13aOP6z/jRfafItS3/QPZjcqt/zH7VbcL6/hKEDCrjz+rsu+touFFenjWOhs4Yf15/ybXQboSketAKzE6wOauuHsMMxjfH3/x8ZIy3hfHpdqlNV1wNzrK79dbjDCaueXHU93Hpi1XXpoxC9zvbA/Sp383+Pa5pyMeFmuucoAAnxZzt1bTOaWa563jcn4dVAYxw0JoDSYLNDnAMUlLqvYiqFvLdW5gJ2F4Gq60VFRaxdu7bXDe3u7aQbUPQ628024rWXse5GADzawOuOa5lrKcTgSAAgIb6809e/xlnHemsf9rjSmOh2gcXh+wjpc9T9FmKreIPqI1uA2y7l6XR/3bxFFdBTq64LH2lZiV6nyJzAZJedwGyoza7JnPGmc1vcRhoafRPJE+I72eLxKq6qdaG0ZpMtHmwNYG2ZqAD0kOvwagMDXZuoa3J1/skIIQBJVqKXaXA1sM8YxxUhXYCvNc0jWdUzz/IJ9sYMAGwX27LSgMsE9gRSnQamOJvYlBAHxrYn/sb1S+dUxeVc1ucj3vjsdGefjhDCT5KV6FV2lO3Aq1RwMnC9N551jlncZP0Aq3LTL72YrMEbSEu+iFrJXuUbQNFk89+bauAadw27zfGcNbTdk56QYeDQ6asZkrSf9Vs+DcMzEyK2SbISvcr2s9sxaM0U//2qdc6ZNBLHbXEbAJg26Vlum38vA/tuv/DFNOAyQ0MiuE1gafJ1+xm9XO0ftr7J3PYE4YR0IyWnrwYg88z77CttvQJx77Hx51Vs/HlVtMMQvZwkK9GrbD+znbGeJhK0r3vutabrGGY4RbZp78VdyKugMd7XojJ4IKEBrM7gvanRHgeDPE7es7adrOJTDFQ0jKbW3o9cw6f849OTl/K0xCUKrSARWv08UGNPdH+SrESv4fa6+az8M67wl1g66cnkI9dl3Bq3EaXA6zVwtnIcDY1tLaPmpwGnvzXlMYG1yTck3dDy3pQCrnXWssWc2GY1C2VQLH1nIImzb+QqUzF5nx2jJ89p7MlaV2QPrX7eXjkn0f1IshK9RklNCY3uRi7zD6543TEXjYEvxL0LQENjJi/8Yz1/+sc7bV/Aq6DRBo54MHogoR4sznNG+gVc66zDqQx8ZElsc39SfxOGsQuI141kVm9n9+naS36OsWD58uXBIraBArSB1s/KlStZvnx58NgLVUgPVHkIrcjeujZgQHV1dbBieWildtE9SLISvUZxeTEAk1y++1VvOWaTbdrDUOMZAOztDVtv0ZoygrUR4u1gOH9L6ApXA0leD+9akts/KOsatNHKdcZPeWunjAq8kNWrVzNy5MhgCaPq6uoWrZ9AaSWgQxXSX3nllXMqsodWPw/15JNPBovnbtu2rWufqLhokqxEr1FcXkySOYmhXifHPf3Y5R7FDdbNwf3BOVZxIcPWvYaQ1pTb35pytduaCmXGV9j2fUsSbS2zWPR/dbx8fz32pJncYP2Mt3aWSlfgBQSqo8P5q5pDxyqkX4yioqJgrcClS5d26hqi60iyEr1GcXkxEzImYADeccwEYGFbySq+zN+askBDgq81FdcI8Y0XbE21NtdZS5XBxA5/iadQ9aUeThY5Oeu9loHuE3gqSthzuveOCgyHadOmBdeIaqu6eKCSOnSuQvr5FjkMdA0GWmKie5FkJXoFh8fBgaoDTEqfBMA6x0wmmA4FuwABGpp8ySqzz16wJ/iqpJv8rSlzx1pTrc1x1WPSXt5tY40rW4avsvupxrkAXGfcLl2BF7Bs2bJgRfLQxBJY+iJQZby6urrNCuntVSMPVGQPVFAPHBP69bJly4JVzqVAdvcjtQFFr7Cvch9u7WZSxiTOelLZ5h7Pf9hebnGM3Z7GzPG/Z+qIV30V0uPsvmTViSQVkKi9THc18J4lmUfsZ1rsS0j3JauKysEwfDSL6nfxHztP88iCMSh1Cd+0l1u2bFnw68CgiMC27Ozs4FpUofevVq1aFfz60KFDACxZsiR4bGh19ezs7OAxoce3/t6ie5GWlegVgoMrMiax3jkDjYHrQ7oA8RiYOuJV5kz8X+ocGb7JveZLS1QB1zrrOGKyctjYcimQhAzfr1dDuRdGL2CSayenyyvY24snCIfTK6+8wtatW3vsyrYivKRlJXqFXRW7SI9Lp5+tH+84ZpJlPMFo4zH/vSkrOC0k2UopaxxCfOLZi743dT5znbX8jIG8a0lmRGPz4I1Ay6qhwgNjFmDc8jvmGHfx1s5JjB9wnhGEPcy876Z2yXVjda0p0TZpWYleobi8mMsyLqOm0cVHrskstHyE8hp996acVjC5MCTWkNl3F4m28K4x1d/rZoKrkbxWQ9gT/PesGso9MHQWWBK5o88e3tlVGtbvH24yYlFEk9frVcA5FaIlWYker95Zz+Gaw0zMmMiGPWcx4eFewztgt/nuTcU3QHxTWLr82nOjs5pis42jhuauQGuyYuzCeCbekoA2mCFrLjM929h/po7jld1zWfG4uDgqKiokYYmo8Hq9qqysrA9Q3HqfdAOKHm93xW40mkkZk/jwzTzyrE/Q12P3jfCz+pKU22Nh/eYnSU44xZzsp8Mew/WOGp629efNuBQesvtWIVZKccvTGc0HjVlI4t43GKeOs3HvWb46a3jY47hUgwcP5sSJE5SVyQrHvVlpaanJ4/FkXPjIiPMCxW63+/7WOyRZiR6vuML3T9jI+GFccfI2nMroa02Zmqfq2hvT2XXwdhJtpV2SrPp53Ux3NfCWtQ8P2s+23Ygb5ZvHc1vSLjbsndotk5XZbGbEiBHRDkN0sQkTJuzUWudEO46LId2AoscrLi9mUOIgzn76IQmqiRPm5BaJCrj0FYI74EZHDUeNVnaZ4pu/b7mH0zsd1Jd7IHkA9J/MQstnbDlUQYPD3WWxCNHbSLISPd6u8l1MyphE06512LWVMZZD5xzT0NgXgIT4s10WR66zBrP28qa1T3DbB7+p4S9fOsuhd331ChmzkCENO4nz1PLBgYtcrViIGCbJSvRIWmvqyzwcP1HGqYZTjLaOZ3h5AfutObia0nC544LHOl3xVNUOBzqxnP1FSNZernHW8ba1D26vr9UUmGtVdcxNfZkHe+Z1KO1lYdwuNu71TSJuKPdQX3buh9ctgxyECJB7VqJn0vDMtac4MWIrLIYzv/DQ77IyPv3oG+QdXsXC2cuYPOavAOw6dBvvbf0h0KqIbRe40VFDvrUPn5z+hFmDZgWHr299vo6tz9ehGMA3bknl9vTdPLT3arxezYt3nqH+zLmlcPuOM/OVNf2k2oUQSMtK9GAJGQbqsg6CVlxpOwrAScdVJMSfxWRsCh5nNjaREH+W1OQSRg9b16UxXe2sI8nr4c3DbwIw4qo40keaSMgwkJBhwJZh5mT9VUxxFFJZ38hnJ2uwpRmC+wMfAGf3uvA4uzRcIXoM1ZPnU+Tk5GgpOBnbvrnxmxytPcrPd1diddcz8oefwtPRbYn8MHEQ7yQOYuMdG0kwJ5x7wM618Lf7uNX5E+bMvYHvLBh7ziE71tSjDDDxlgSMZmlZifBSSm2T0YBCdCGtNX+6rZS/3HUGrTW7K3YzOmkkYxy7ONv/mmiHB8DipkrsbjuvHXit7QNGzgNl4K7UvWzY2/aAjym3JzL5tkRJVEL4SbISPYrHCWX7XJzd46SiqYKz9rNkVDkxKS8pl98U7fAAmOxuJLtvNn/Z/ZfgQIsWbGkw5EquUdvZdaqW0pqmc48RQrQgyUr0KO4mX7e1KU6xu2I3AMNOH6WaREZfMTd6gbXylYlf4VTDKfKP5bd9wOj5ZNbvJZMq3j9w7tyv/fl2tv+1DntVW2sQCxF7JFmJHsXt8Ccrq2JX+S4Uimsqd3AgaQYmsznK0TWbO3guQ5OG8kLxC23X2Ru9EIBbEop5f/+5yWrL6lryn6im9qQkKyFAkpXoYYLJyt+yGmTtyyBdC2PmRzmylowGI1+Z8BWKK4opOtvGUur9JkLyID5v20XBwXI83pYJzWjx3asKPF8hYp0kK9GjBJOVRbGrYhdDGg14tCJrxuejHNm5bhl1CynWFF7Y9cK5O5WC0fMZ37iNBnsjO0/WtNhtipNkJUQoSVaiRwncs2rqU0lZYxkTa86yzzyO9MwBUY7sXPGmeO4ceyfvHX+PwzWHzz1g9ELM7gamGfaxaV/LrkCzVZKVEKEkWYkeJa6PgSm3J2C82jcJ+KrGU5QNmBvdoM7ji+O+SLwpnqcLnz733tWIq8Fo4Y7k3ecMsjAGklWTJCshQJKV6GFShphY8KM0PNOOoFCMczrpM/lz0Q6rXRnxGTx0+UNsOrGJjcc3ttxpTYThc7iKIj49Xk1Noyu4yxRIVk5JVkKAJCvRQ+2u2M0gt4kabxrjL58Z7XDO6+7xdzMmdQxPfvwkdlerFYJHLyS96SiDdCmbDzbXLTTFKVDgcUmyEgKikKyUUouVUrlKqSXt7M/1f6yIdGyi+7NX+taHKj5bzOTGOvYlzcBq7t71mE0GE4/PeJwz9jM8s+OZljtH+0Yx3mD5rEVX4PzHUnn0s8FMWZwYyVCF6LYimqyUUosBtNb5/se5rfZnA9n+/dlKqaxIxie6v5IPmlh9/x4qnBVMdtrxjMy98EndwOV9L+e20bfx591/Zn/V/uYd6SMhfRS32IrZtK8seF/LYFRSbV2IEJFuWU0DSvxflwDZoTu11kVa65VKqRSgRGtdghAh3E2aiv4HABjd5GH49O57v6q1b2d/m2RLMo8VPEaju7F5x+iFjHPsoKqmmkNl9dELUIhuLNLJKqXV4/R2jssBzl3uFVBKLVFKFSqlCsvKum6JctE9uR2aiv4HMWhoco8ha2DfaIfUYSlxKfx09k/ZW7mXH374w+bRgaPnY/Q6mWXYxab9vvtWu/7VwAuLS/nkj7VRjFiI7iPSyaoaSLvQQf5uwJGBbsNW+1ZrrXO01jmZmZldEKLoztxNmtpBn5HlclLVb26P6yq7Zsg1PJz9MOuOrGP1Z6t9G4fNBksin7cV86F/kEVTjZeze13UnpZyS0JA5JPVVppbV1lAXuhOpdSKkIEX1XQgsYnY4nJ4Ke93gIkOJ0mX3RDtcDrl3yb9Gzdl3cT/fvq/bDi6AUwWyJrL1Wo7W0rKcXm8UsFCiFYimqy01muBLP/AipSQgRaBpLUKKAnZvzqS8Ynur8xVSn2cgyENNq6YMjXa4XSKUoofz/oxl2VcxvcKvseOsh0wegEprrMMcR3h0+PVzfOsJFkJAURh6LrWeqXWOl9rvTJk23z/5xL/vnyt9dJIxya6v8N6OwDm+smkJliiHE3nWY1W/mfe/5ARn8GD+Q+yr+8oAOYZP+WDA+XNLSupYCEEIJOCRQ/jGPU+Zq2xjlgY7VAuWUZ8Bs8ueJZ4UzxLN/+AYwMmclP8Tj48WI5Jqq4L0YIkK9Gj7Kr+jFEON1mzF0Q7lLAYlDiIZ+c/i1d7eSDBQ5p3PyXHT+Ay+AZWSMtKCB9JVqLH8Ho9HPTWkOpI5oqsftEOJ2yyUrL4/fzfU4OXh/ulM0MVcdBVz+TbExg1Lz7a4QnRLUiyEj3GkZJ87AZF5tkrqD/mjXY4YTUhfQIrr/kF+yxmqga+y9a6Mhb+KI2cryRFOzQhugVJVqLHKNz9GgBxn3wOe0Xvm3909ZC5fMc6nF2JdtafamPBRiFimCQr0WPsLC0izgPm05ODy773Nl+Z+FW+UFdPve0dnl3/Gqd3OqIdkhDdgiQr0TPYKzmoaxlUm4JBG4NDu3sbNeo6Hquopr89kWeOrODFR/dFOyQhugVJVqJHcO5fzz6rmdQzk4DmZd97HVsa5sHT+X55I16Dm4Lpz1z4HCFigCQr0SPs2PUaLqVIPDkLoNe2rADUmAVc6znM1MJbODKqgI3HNl74JCF6ue69ap0QAF4P+8uKIDWefmfHA3T/e1ZPX0J8HgOQyOdPJrG/bBj/nf8QV1YfIEF3YgTkIzJPS/QO0rIS3d/Jbew1ebB4LIwaNIS+482Y47t5sroUBi9uBaP7f8jM9d/irMHE/9p6zlIoQnQFSVai2/PuW0ex1UqqeTRf/EM/vrqmPxZbL37rKjCZnGT1/Yh+p0dxa72dl+LSKTFaox2ZEFHTi3/jRW9RufstDpnNTMicEu1QIsfoxmpuYHBGEV+p9GBF88f4jGhHJUTUSLIS3VvtKQ7ZS9AKFo6cjtuhm1fY7c1Mbjxa4Zj2DyqNSdzWVMmb1hROG8zRjkyIqLjoZKWUulwpdatS6lGl1P3+ry/vgtiEgAN57LD6ur+uSMzmV1NP8P+uORXloCJAgdekmRVXyEeeSXy1sQKAF+LToxyYENHRoWSllBqulPq9UuodYCkwEqgBlP/rryul1iulnlFKDe+yaEXM8ex7h4/jEkk2DCLB66uTZ+qtc6xaMZuaGGU4xQHXMAZ4XXzOUc3f4tKoVMZohyZExF1w6LpS6j/xLS+/XGtdc4Fj+wBLlFJVWuvnwhSjiFVuB96Sd/lsYF8uT58cXC6jN8+xCrXz8Be4bODbDLE7aOxj5d8ay/inNYWX4tP5pv1stMMTIqLO27LyJ6q1WuvvXShRAWita7TWvwA2KKUeDVeQIkYd/ZDjykmT0cu84dOCCxHGSstq/7HrqawbxtWmHWx1TSDL4+Q6Zy3/F5dOvZLbzSK2nPcdr7X+hdb68MVeVGt9WGv9VOfDEgI4kEeR1QbAlQOnBpOVMUaSldHooKT0aq6w7uQTx0QA7m8so85g5O/W1ChHJ0RkdWaAxfAuiEOIc3j2rWO9tS8WlcDwPsODyarX1gVsxWRsouT01VgMLuyeRAAmupu4zGXn9biU6AYnRIR1pi8hVSl1f+CBUuo2pdS8MMYkBFQcwlhVQrHVzNiUSRiUIea6Ac0mByfKp+L0msnSZ6jyDzC52VHNflM8e41xUY5QiMi56GSltd4OjAokKK3134AFSqn7wh2ciGH736HWoKizNjB7yFQAMseYueGJNLK/nBjl4CLDaGzC47VQ3jiYucYdbHH6Ks7f4KjBpL38Q1pXIoZ0phvwHUAD20LmVz0JrAxjXCLWHVhPvnUQAFP7XwFA8gATkxYlMGJ2fDQjixiT0bfwot3el8GqnP2uEQCkaA9znXW8ZU3BFc0AhYigznQDjgRW+UcHKv9w9Wf9H0JcOkc9+uiHvGHuj8LAZRmXRTuiqEhJOsbAzELc2jcpOs7TXHX9Fkc1lQYTH1qSohWeEBHVmWS1AFiulEr2dwnmAp9orb8b3tBEzCp5D+VxsjvOyNDELBLMCQCU7nJS9FIdJz+NjaXeLx/3F+6+6VbGjXyDChK5XJVw3OOrvj7HWUea180/rSnRDVKICOnMPasSrfWDWuta/+O/ATUyyEKEzYF3qDck0BBfxfSBVwQ3H93SxIYnqzm4sTGKwUWHMrmYqvaz1T+E3Qzc6KjmPUsSNVLRQsSAsMws1Fo/C1z0fCwhzqE1+kAer5nGg6GJK/o2J6tABYtuv/BimGgNHo8Zt9tKqrkSk/JS404J7r+lqRqXMvC2tU/0ghQiQsI2Db4zk4eFOEfpTlTdad40+ZbDmBKyLEhwnlWMlFvadeg2fvniId7ZvAJl9NCgrWR66/Fq3/Mf52litLuJf0lXoIgBFyy31JlJwEqpEVJuSXTKgXcA2BunyYjry5CkIcFdwdqAMTLPKjAa0O2OAwUVhgRmGPaw1z0M8FWRvt5Rw2dmG2XqgmU+hejRLlhuCZivlHqyI0lLKZWslPo5cJuUWxKdsn89JZbR6KQTXDlwGko1Jya3M7bKLZmMTQC4Pb7RgEnmGjJULfudWcFjrnXWAvCuVUYFit7tgv+Oaa2fVUqNwLcMyBVACVANHAJSgHT/55H+bSulS1B0SkMF+sRWXjbdiDbsZFq/aS12x1zLyhRIVr5KFamWajyOZHA3/9qO8jgY4nGw0ZLMHU1VUYlTiEjoUN+BP/l8F3xdfECW/6MG38CKEv8wdiE679AGFJoN5mQApvVvmay0BmWMnXtWwZaV29eyQmlOqnRG6dM4tAmrcqOAeY46XopPo14ZSNTe9i8oRA920R3d/sR1GNgQ/nBETNv/Dg3mNEpttQyIb3m/CuCmFenctCI9Npa1J+Selae5BqDDqJjEUbY5RzPVugeAec5aXrBlUGBO5Hp/t6AQvU2nRgP6l7N/0v85OdxBiRjkccPBfLYYr8CaeJTpA1rerwrV3vbepnU3IMAA82kAylyZwW1T3HbSvG42WuRXUfRenakN+HtgFL7BSHcAh6WIrbhkJ7ZCUzUvNQ3DY6g9535VLEqyneb6OY9wTc6TwW2JJjsVOolkT3MVDyNwjbOODyxJuIiNRC5iT2daVnla6+/6PxbgG1gxWil1a5hjE7HkwHq8ysjWOAtw7v0qgL9/q5w/3VpKRUlslG+1Wuq5bPQaRg3Na96o4JRK4TJ1mGpPc/X5ec5a6g1GtpptUYhUiK53yZMztNbVwHeVUg9cejiiR3v6Ev6rb0jgqB6A13aU/h4XQ54dds4hlds2UlkzCv38REg5cAmB9mzx5nqSXE1scY5kRvwOAGY464nXXjZakpnlaohyhEKEX2daViVKqa1KqS+0ul9VEa6gRIzxKvAaecczFUvCIaa5GtrszHK7ffduAqPkejutFUV7vsLW4vtbbB9uOY5Tm3C6m5dKiUMzy1nHu5ZkYmP4iYg1nUlWdwKvAl8CjvgT1yv4hrIDIEVtxUXxzxv6q+Fy3KYmprXTMghMjo2VZAWaDVv+i/e2/hCvt7lYrcng5SADGKIrCB0Yea2zjrNGM7tlBWHRC3UmWR0C1mit79BapwFLgEJ8qwVXKKW2AivaO1kptVgplauUWtLGvhSlVLb/mHavIXoZj4l6rJyM9yWp9pOV74+w2RQbyUqp5ucaSNQBDUYTI9QZjrkGBLfNdtYBsFnWuBK9UGeWCHkWSA2UX9Jab9da/0JrvUBrnQ4sBdqcSq+UWuw/J9//OLfVIXcAOVrrtf795yQ00ctowG2iUI8mMWEPfT0uhnidbR4aa92AcG7JpYBBllMAnHb1D27L0B7Guxv50JKIEL1Np+ZZ+RPUkXb2FQHL2zl1Gr5yTfg/Z7c6d7XWerX/YVbIsaK38hgBxSvuuaiEEma46tu8X+X1GvFqM+DFYIiN0YAAxtBitiEGmss4rjNI8LhbbJ/trGeHyUa9CtuCCkJ0C13yjj5P6aWUVo/T2zpIKZUFVAZaYK32LVFKFSqlCsvKyi4tUBF9bhMeFO+a++MyupjtrG/zMK0NTJ34LNnj/0SMzAkGQltW596HOq7SGc0pnN7mQb2znHW4leJj/+rKQvQWkf73qxpI68Bxi7XWS9va4W995WitczIzM9s6RPQUGnCbOUomOvEQSmtmutpOVkaji3nTf8p1M34c0RCjzdTOPSsAi6mROOXisGNocNvl7kYSvB42m6UrUPQukU5WW2luXWUBea0PUEot1lqv9H+d3Xq/6EW0AbSB9Z4ckhM/Y5K7kVTtiXZU3YrF1IDZ1IDXaz5n3xhLCQ3aSqO7OTGZ0Ux3NfChJUmGsIteJaLJyj9wIss/sCIlZKBFnv9zLrBCKbVNKbWNjrXCRE/lH7L+oucqHHFlzG6nVQXgdMVzvPRKzlaOi1R03cLdN93Kt+8ZT/+MnefsSzba2aWHMVBXEZqZZrvqOWm0cNRgiWCkQnStiC8vGmg1Afkh2+b7P+fjK98kYoHbRC1WzibUEK+ah163pbpuOH99ew0ZqXu4d9HCCAbZvdUZLfTVNVR5kkk1+Squz/K/jh9aEhkexdiECCcZMiSiQwMeI9sYTXziLpK9Hia5G9s9PHDPxhxDw9Y7YqB/CPsJx6DgtiFeF8M8Dj6U+VaiF5FkJaLDbQIUr7rmYkncxwxX/Xmb+cE5VjEyIThgU+F3ee5v73Lg6Pw29481H2WfdxDxnpaLLs521rPVnIAjpDq7ED2ZJCsRHR7fkPV801CcpibmnKcLEJqHbgfmHcUKe1M6VbUjaXS0ffvWoDTHVAbDOYPH2/zrPNtZR5MyUHSmKFKhCtGlJFmJyPNXrTis+kLCIQBmnWdwBcRm9QoIWS3Y3X69vziTHZPyctTZvLJyjqsBs/ay+dTmLo9RiEiQZCUiz+sbsr7OM40+STsY7W6in9d93lMCLStTjLWszjcpOOAy6z6qdCKNruaJwDY0l7vsfHz64y6PUYhIkGQlIs9tQqN5wX0trvjT5x0FGDwlUHE9xu5ZtVcbMFSKsZ6dehiDdGWLIewzXQ3sqdxDVVObpTqF6FEkWYnIc5uoVjaqEsrwKs01HUhWY4e/yb99YR6zL/9lBALsPporWJx/2Y9Go4kUZafK3Se4bYa/a1VaV6I3kGQlIsu/0OLH3vHYkj4l1evmCrf9gqdZLfWkpxwkOfF0BILsPoItq/PcswIYYjmBRytOO5ursE9wN5JkTmLL6S1dGqMQkSDJSkSWxzdk/QXXdRiS9nOtsxbjBU+KXf0zdjJ1wnMM6X/+hDPOfIRiPaJFFXYjMH3AdD469RFaS/El0bNFvIKFiHFuEy4MbI2PJ97gZp7jwl2AALsPfZ6SE9cyIesfZA15t4uD7D6G9P+YIf0v3I1nUJqTKoUpqgSPx4jR6KuxOGPADDYc28CJuhMMSR5ygasI0X1Jy0pEjn/I+j4GYUraTbzXG7yvciGl5VPYU3IrFTVSjas9iWZf4j/qHBzcNmPADAA+Ov1RVGISIlwkWYnI8S+0+E/PDOKSdjLHVYe1g7XBg0PXY2w0YJOjD8dLp3OmYuIFj73csodSnYLDbQtuG5Y8jP4J/eW+lejxJFmJyPGY0MDLpgl4TI1c56zt8KnNk4Jja57V6fIp/PXttWwq/P4Fj0022tmjhzBElweHsCulmDFgBp+UfoLHK8uviJ5LkpWIHLeJsyoZV9IhjFpzdQeGrAdP9cRqBYsLz7MKpU0eEpWDU86+wW0zBsygxlHD3qq9XRKjEJEgyUpEhn/I+nueSViTPuNKVz1J2nvh8/yCk4JjNVldYOh6wFjrQZzaSJmrOVldOeBKALackq5A0XNJshKR4V9o8Vk1E22pvqguQIjde1YdnRQcMMhUTrEeTrq3IbgtIz6D0amjZZCF6NEkWYnIcJuwY+ZYUiVKw9yL6AIEyEjZx6C+W7HFVXZRgN1TsJBtB7sBAWqMcQxWFVS7k4PbZgyYwfYz22lyx1ayF72HJCvR9TTgMVGoR2FN3s5UVwN9L1C4trV5V/4Xd33uNvql7+qaGLupi+0GBBhg9lX5OOwYGtw2Y8AMnF4n289uD2+AQkSIJCvR9fxVK54z5IC1khsd1dGOqMcIdAN6LqJlNdZyhOM6E5NHBbfl9MvBZDDJEHbRY0kFC9H13L6FFguT3Jg1zL/I+1UADmcSBoMTk9GBUhc+vrewmuu4d1EuJlNjh89RCo6pdKbqQzTZ64izJWEz25iSOUWSleixpGUlupa/asV+BmBI3slMZwMp+uLn+/zhtXf59Z8P0NDYL/wxdmMGg5eM1P2kJB2/qPMSTLXEKRf7t7wV3DZjwAz2VOyhuqk6zFEK0fUkWYmu5V9o8TnTZShzLTc7OzdAIjDAwBhjQ9c7a5z1EDXahnX7H4PbZgyYgUbzcaksGSJ6HklWomt5fD3N7yZaMHnh2g4Wrm0tVudZAeR99AT/ePcZnCErAV9InMHFRiYztm4LngMbAJiUMYlEc6J0BYoeSZKV6FpuE6dJwpl0gKucdmx0fCJwgNYKT4wuaw9w4OhC9h/5HE5X4kWdZ7PUcMybSdOb3wevB5PBxLT+0/jolMy3Ej2PJCvRdTTgMfJH61iUyc4iZ1mnLuP2WABfqyqWBlcEBBK06yKGrwNcY93Or7mbhOq98OnLgK8r8GT9SY7XXdw9MCGiTZKV6Dpu35D1txISsXoNzHF2bDmQcy4To3UBA5qrWHR8+DpAnHLiHHsLnzEGvfEJcNQzc+BMAOkKFD2OJCvRddwmypWFmqTj5DbVYengciDnXMbfojDGYBcgdG5icMDnJg/kx467UPWlsPm3DE8eTj9bP+kKFD2OJCvRNTRoj4lVtiyUwcWXnKWdvpTVUsvN13yD62b8MIwB9hyBbkBPB+sDhpo7ti97TOPZ2eda2Pw/qLpSWTJE9EiSrETX8BpQ2sDbSVbSXSYmuzs+qbU1i7mRcVn/Yuzwt8MYYM8R6AZ0XWQ3IEC8xci88X15rH4x2uOCd59g5sCZ1Dhq2FO5J9yhCtFlpIKFCNJa42xov6vOZFUYzb4RDm6nxuNsdayzebSaVTspMZuoia/igZp6nM62R7IZDS5MJl/Lwes14nLHt3mcUh4s5s4nvJ6sb9outDZgNdfjcsfh9bb9axv6GmmNb/RgvZeFWf15ZNsZTmbfw6Dtz5Mz9osoFB+e/JBJGZPa/lmGsCY2/0/rtHtpa2UXgwnMcfK/r+g6SuvO3UfoDnJycnRhYWG0w+g1HHVe/mfmyXb337QynfE3+pZM/+SPtWz6ZU2bx1nMtXzrC1fyWPII/pmiuO/Fn+E6e3mbx06b9HvmTvtvAI6emsWr7/y1zeNGDX2HCSNfi9nWVcAbm37DnpIvtLlvcL+P+dKNtwPgdMXzm7/sa7Hfaq7hgetv5Ez1eB6e3Yc+6XG8eMOLbH2hjvd+Ud3mNc3xim9vHRx8/IebT1N5+NwixMoAn/t5GuNv7PhcMBE9SqltWuucaMdxMaRlJVqwJLQ/NtwQ8m4xmtW5x/pr/vVJOIHHayQvyczoJgMpbjM15rYnAxsNzubrGzxY2jnueOkMhg7Y3MFn0XuZjE3tvkat6wdazHVg8S0T0uTyUO9N5JNDD3LNhJ8zXX+VV8s2UeOowWg2tPtzN8W13G6OP/fn7mzQaC+c3eti/I2dfWZCnJ+0rGKc16PZ9pd6hs+0kjHajLqUiUxP+891mXlfpfKN/n35WfUZbnF3bn6VCINHfL/f63eVsuTP23j+nslcu+EWPjUbucfm4KlrnmLh8IWX9C1cTb6uQYtNugF7ip7YspJ3V4wr3eXkvV9U8/dvlYftmtpt4pXEVEweCze4w3dd0Xlzx/Yl1WbmbzvKIPcnTDpzgCSDlQ9PfnjJ1zbHGSRRiS4n77AYV/K+b6RZ1lXxl9aqCtBQ5o2jIMHMdLsBcyfnVonwspgM3DxlIOt3n6F2xPWYhs5ipr2BD09+QLh6V7xuTdWxi1tUU4iOkmQV40re993nyLr64ufwtMlj5F9JNrwKvuXad+HjRcTcmj0Yp9vL28WlsOAJ5tTVcLaxnAPVBy752rWn3fzu6lP89Wtnw5b8hAglySqG1Zd7OLPbhcmqGDLt4ufwtKXRHceapCQyGpOZ6O1chXXRNaYM7kNWRgJ/KzoJg6cye+h1ABQcevOSr53U34jRCvVnPZzd57rk6wnRmiSrGHb4A1+rauh0a9jmyGwypXLSbOKOpqqwXE+Ej1KKW7MH8cnhSo5X2um74GeMcbr4cO/fwnLtrKt8c+QOvx+bNRxF15JkFcNKPvD9URkRri5Ar+KNZCvxbhP3ufeG55oirD5/+SAAXt9+ElKGMjttIkXuahqOXXqtwEBX8qH3Y3PytuhaEU9WSqnFSqlcpdSS8+zPi3RcsSguyYA1qfk/4ktV7Mnk/fg4Lm+wYVFy36I7GpJm48oRafx9+0m01szJ+XfcSvHJxh/4yl5cguEz4zCY4PRnThqrpe6gCK+IJiul1GIArXW+/3Fu62O01msjGVMsW/iTNP79g0GkDA7P3PC/xaehgG84L/2Gveg6t2UPpqS8gaJjVVwxeA4JBjOb6g7DvkurDmJJMDA4x4r2wuEPpStQhFekW1bTgBL/1yVAdoS/v2jFYArPaoZN9io2JirG261MUTIJuDv73OQBJFpNvLTlGGajmTlD5vJeYiLevMfBc2mDIwKt9BPbYnM5F9F1Ip2sUlo9Tr/YCyilliilCpVShWVl8kexs2pOuWmo8KC94emue3HD01SajOQ2SPdPd5dgNfGFKwbxxs7TVDU4mTc0lwoDfFZ/DLb96ZKuPeFzNr6yth/zH08NT7BC+EU6WVUDaZdyAa31aq11jtY6JzMzMzxRxaBX7y/j/11ziqqjlz6JU9eXsb707wxyerkLWXaiJ7h7xlCcbi9rt53gqsFXYTKY2DhgDLz3JDS1XaC4IxIyjPQbZwnPBHMhQkQ6WW2luXWVBchAiihpqvGt8xDX5xLfAh43n7zyRfZZDIyr7YstpDCt6L7G9U8mZ1gqL318lARTItP6TWNjgg1tr4QPno52eEKcI6LJyj94Iss/sCIlZKBFMGn59+UEBmOI8NNeTVOtP1klX+JbYMOP+T/HEcweM9/w7A5DdCJSvjxjGEcq7Gw+VMG8ofM4ai/l8KRbYMvvoepop6+77oeV/PXeszRUSJewCJ+ID13XWq/UWudrrVeGbJsf8nW+1jpVRgV2HUedBg3WJHVpAyyK/8bxT55hg81GpnEho41nwxek6HI3XNaftAQLf9lylLlD5gKwcdgUUAo2/Fenr3tyu4PjWx00VrWxSqMQnSSTgmNQYzi6AM/sgn/8O8/2zUJj5Fs5Xw1TdCJSrCYjt08dTN6eM+BOYVL6JDae3QYz/x2K18KJbZ26buB9FehqFiIcJFnFoKYaX/dMp7sAG6vgr3dTE5fMPyxe4h1TuXHC2DBGKCLlriuH4vFqXv7kGPOGzmNn+U7OZN8NCX1hfecmCsf7k1WjJCsRRpKsYtAlDa7weuG1JVBzgt9PuBWvcvLFsV+W0V891LD0BHLH9+XPHx1h5oCrAXjvzFa49vtw7CPY86+LvmZcSqBlJfesRPhIsopB/S+zcMdzmcz+Rp+LP/m9J+HAehwLn+DVswXQOIqvz7wq/EGKiPn6NSOpsrvYus/MsORhbDi2Aa64BzLHQf6PwH1xIzwD/wQ1VkvLSoSPJKsYFN/HyLAZcQy6/CKXBdn7Jry/Ei7/Mn802XBSzdx+XyLBGp5yTSI6coanMW14Ks8VHOHaIfP4pPQTKl21sOAJqCyBrc9d1PXi5Z6V6AKSrETHlB+A15bCwCtwXf9znt/1R7yNw/jBvJujHZkIg69fM5KT1Y0kuq7Eoz28ffhtGJULWdfCphW++5QdlDHawpj58aSPNHdhxCLWSLKKQXvX2Xn/V9WUFnewe8dRB3+9G0wWuOPP/GXfWzTqCmal30H/PuGp2C6i69qxfRnTL5G/f+xhbOpY3ix50zeEfcETvooW7z/V4WuNnhfP53+VwcSbE7owYhFrJFnFoEObGvn4D3WUH+pA0VKt4fUHoeIg3P4n3MkDWPXZc3ibBvH4vNu6PlgREQaDYunVI9lbWsf4pLnsLN/J4ZrD0H8SXHE3fLzK1yUoRJRIsopBFzUasOCXvhFh8/8LRlzNmj1v0OAtZWryYoamy3/Ovcktlw9kYJ84iveNxKAMvtYVwLWPgdEM+T/u0HW8bk3NKTcVJbK8vQgfSVYxKJisLjTP6mA+bPgpTLoNZn4Dr/byv9t/j7epHz+87o4IRCoiyWw08PW5I9l+xMuY5Ct4o+QNtNaQPABmPwy7/wHHPr7gdWpLPaxecJq1X5dVEUT4SLKKQYG6gPHna1lVHoa190G/iXDLb0Ep1uz9J7Wek0xKuI1RfZMjFK2IpC9OG8rQNBtnTk3kZP1JPi371Ldj1jchsX+HJgrHy9B10QUkWcWgC3YDOu3wyj2Ahjv/DJYEnB4nvyz8H7xNA/np/LsiF6yIKIvJwCMLxnDs+EjMBiv/OuSfFGxJgHmPwYmtsOu1818jUaGM4LJrPK7wrJcmhEyQiTFa6/PXBtQa/vUtOFMMd6+FtCwAfrftz9i9ZcxO+x5j+nViMrGIjqcvvrLIzVqxyvhrSquH887ev/LdzT/Ggq/4MYYE+NvXYN1iaOfSCogzbafRk07Tir4kPCbdgeLSScsqxribNOlZZlKHmzCa2/hrs+UZ2LkG5v0ARucCUOes48Xdz4F9NP99g4wA7O0MSrMs4QVqqmdTazCyweLv8lWAtQm0AVyW814jzloNQJMjpUtjFbFDklWMMccbuPfv/bn/jQHn7jxSAOsfg3E3wZxHgpuf+OAZ3Kqe20cuJSPxIqteiB7pGnMROc5GcKbyYnzIitwmDxhd4LCCt/1WW7zVN4m4UZKVCBNJVsKn5iSs+Rqkj4RFz4DB99YorT/L28dfwdSYzbJrc6Mbo4gYpeD7CX/CUTmbYnMcO00hk7+tDt9nZ/utqzhrDSAtKxE+kqxijPZq33DkUG4HvHoPuJrgzpcgrnmk3yP5T+LFzcPZ3yTObIxwtCKappgP8IWmSrTHyv9ahzXvMHrB7PJ1BXrb/hMyJ/spvnTjrQzu90mEohW9nSSrGLPvnUZ+lX2Cd35U2bzxrUfh5Db4wu8hc0xwc96hj/isJp8MzwK+Om1qFKIV0fZ920uYai5jc5yZUyqkJWXxt64cbXcL90vfxeB+hcRZayMQpYgFkqxiTGONF48LVOAnX/g8FL0IVz0K428KHuf0OPnBBz9Bu1L5/U3flfWqYlQfQwPfcexDA4+bpjfvMGhfwnKbwS0tbtH1JFnFmBZzrI5vhbf+01dd+9rvtzjue/n/j0Z1klsGP8S4funRCFV0E/eYPiK1YQAfJzg57Mlo3mFxgvKCI843rD3E6bLJbPz4RxQfWBzZYEWvJckqxjT6V29NSiz33afqMwhuew4Mzf8d7zxzhPWn/kyCewo/XXBntEIV3YRS8F3nLpTJzkPqJrza38pW+AZbeI3gbjlls6p2BNt238fhk9dEPmDRK0myijFNNV4MysWYqod8Sz/c+RLEpwb3e71evrHucTSaX+b+CKNBuv8E3Og9SX+nmWMph/itPWSunckFBs85rat4mWclwkySVYxpqvEyd/IvSGj42Ffzr/+kFvu//dYqqviUqzPuYdaw0VGKUnQ3CviJfT8GSxW/i8viE+fE5h2BicIhQ9kDk4IbHannXEuIzpByS71FB8vq9C9/hKnjXqbOlUrS+tthffO+1zyXsTHTRGpTBr8t+w7s/04XBSt6olnuBq502PkkYyPfLPkmb5uWkWao9U0UNrnAafUNaTdoqWAhwk5aVrHEY2DG2OeobcpEWRta7DrqyeDHyf0waCMv2gsxSu+faMOj9lNgaKQ2dQf/Ufsd3Nr/JyQwlN3pG8oe7AZ0Sh1JER6SrGKFV0GjDYPBQ3J6CYkJ5cFdTdrM3eb56PhSlteWM4L6KAYqurNxniY+56jBmv4B7+tR/LD+Qd+KIcGJwmbwGLBaagEvDmcfvG6pvC4unSSrWKCBpnjQCuLtvjkyfi5t5C7316hOLWZGg5m7PUeiFqboGb5pP4MBL5MHPMvLTTfwW/sXfTtCJgorpemfsZMBmUW4miRZiUsn96xigdMKHhMes4sd+79MQnw5Y4e/hUcbeMBxH/sHFjLAaeZ/GrdHO1LRAwz0uvhyYwXPJxq4JuVVfln9ZfoZKrgzPs+XsJxx4HZyz803+05IlGQlLp0kq97OZfLf+HZS705nw5YnSLKdYsywt/hO431sHVBMstfL/9UXE996ZqcQ7XjIfpb3LUkc6/sJsxoH8/36fydOOfi89X1fzUBHHBgb2l3zSoiLJd2AvZnH4Ov+M7jB2hQcmWW11rCs4evk9T2C1VjPC3V7yNDu6MYqepQ4NCvqTlBjMJA26GWyzbv4dt2jvNj0Od9Qdq8R3Ga8XqOsFizCQpJVb6WBxnhQGuIbQTUPIz5gtfJG5klM1tP8praEMR5HVEMVPdNYTxMP28+wyZrIbf1+yXWWrfyw/kF+5bgdbfDQVJfJb/6ym71v26MdqugFJFn1RoFEpQ0Q1xgcUHG6cTCOuDreveFXmG2H+Xndca5yy8g/0Xn3NFZwpbOeXyb25ZHUp7jNms9vGu/mGe9NxJnrmTbmhWA9SiEuhdyz6o2cVvCYwdrom7AJbHTk8LuGL1J253dpTD3Gr+uOMs9ZF+VARU9nAH5Wf4K7+ozkwZSh/JFnGFBXzkr7Pcx0VDJ97B/YXvVVICnaoYoeTlpWvY3bP6DC5ASzC7u28oO6h7jf8QDHrvw1dSmn+HpRjiQqETb9vG6erT2MRrGkz3C+lPQKf+rzQ/5Udi9Gg4u00h+ia09HO0zRw0my6k28Bl/3n8GDtjbxniubG6t+w6txKSSN+F+sxgbmr/lvrqg3RztS0ctkeZysqjmCXRm4v88Ixsd9xhcT36Jw/1cZbXkb9ctxOH85Bf7xDdj+ElQehtYrVgtxHuqcJc57kJycHF1YWBjtMLqHpxTYE0ArDljS+C/7/RR4x5DW/xWcyQeY46zjv+tO0Mej0dqI0eiKdsSiF/rMFM8DycNJ1F7+41Ame/7xEkNyijkx4m2meHYz27wfm8e/enDSQBg2E4bNgqGzIHMcGOT/50hQSm3TWudEO46LIfesegOtoSke7TXyW30zv6q5jaS090nL/G88ysO3G85wb2O5rxltAJAb3qJrTHY38kLNYR5JHsIPRlczZfoa+tnv4r5Hc/nF+n0s/eQIE02lfH3EGa6NP4jt6GYo/pvv5PhUX9IaNsuXxPpPAaP8iRI+0rLqqTxuqDtF49kSTm75G6NKXuSnri/yakI/kvq+RZ3ZwWxnHcsaSsmSoekiwuqVgcfjh5NvszElbjqPz1/G2LSxHDhTxzObDvHPT08BcP3Eftw9TjNd7cV4/CM4uhkqS3wXsSTCkOnNCWzQVDDHRfFZ9R49sWXVs5PV2H66cN+Z6AXw7rd9n6/9dfivrTXUn4HqY1B1FKqP+D8fxVt5FGpPYvBP5C03Gvh54hgKkh00mDyMcDfxaEMpV7taDktfu/5PNDrSuHnuN0hJOh7+mIUIoYE1can8OmkYddrN9cOv56HLH2JEnxGcqLLzh4LD/H37SartLjISrdw8ZQDzxvVleoYT68mPfYnr6GY4u8t3QaPFl7CG+ZPXkCvB2sFRhl35u9pR3SEGgHe/zfDbfnP2SKXuF91ALo60saNFa2is8iWj6qPBRBT8XH0M3E0tTqk3p3FC92WfYyDFpvHs6eOlPK2OU5xEY2e2s467aiqY46pvc+TM2cqJNDT2w2hwRuY5ipimgDuaqlg47ku8kDqWv+z5C+uPrufK/ldyw4gb+I+F1/HdG8bx7t4yXis6wUtbjvH8h0eINxuZOXIIOcO/zhULv8fkdC8JZwrh6Idw9CMo+DV88DQoA/SfDMNm+7oNh86ChPRoP23RRSKerJRSi4FqIEtrvfpi9/cozoaQllEbCclR2+Jwj7UPjbbBVFiGcCp9KgedaWyrTWKHy0SpWaOt5aSmnsZjOUqj9yQAY1PHstQzghuPvsMIT/tJSOvmtYUCC+MJ0dV2H/o89TvdfH3c97jb4uDl+HTeOrGJH57+iJ9++BjZLjtT3Ha+7LLz4zQPex0Tec+ZwwcHrmDj3kEAGPAw3HiK0UbNKNMgxhjdjFEnGaQrSTxbiOH0dtjyO983NHjA6AGj2/c5ZIUBsh+OwisgwiWiycqfiNBa5yulliilcrXW+R3d35rLYebk9lb3Y7QGNOlZJuKSFKCpOeWi/owbX8eERvmPAY3RrOg3zoTWXrRXc3q3A+32oLUOfgB4tRdbhiI+TeHRmsZqNzW7UtBH8zGum45ROTErN2aDA7OhCaupARNe3Ao8KNwK7Jip8CZSoftwWo/ktE7huCGJg9ZETqoknEqT0ODE66xFWUoxWPfgHlyN1+AN/qDSPQ4m2+2MabBwWUUq/V1H/Hsu46T/K6PRSf+MncGX5HTZFFxuGx5PHCZjE2aT3MMSkVGw/VFq6obRJ/EkibZSbgW+gOZUeimb+njZak7gufhMvDZfxdtETxMDnB8y0bmZK11mXM5UGiwmKtz92e0eSGHNbIzOheA1gdeE0kbSqGOKeT+T44sZbz3AaO9p4l1uFFDvSaTMk0G1OxXPx16MJ/+KyWgkYYAFS4IRk8mEs0rhrjdgMBpBGTEoAxhMGIxGTFYj6SOtKIMBlImyfW6UMoIyoAxGwPc1ykjSIAuJmWZQBhqqoPqEF/zHggFKBvpelBQHA6dYUAbfcy7b78TZ0PbtGFuagdRhvqkmrkYvZ/e2P4o3Y7QZa6KvT6X6uJuGck+bx8WfSb3on2N3ENF7VkqpFcArWusipVQukK21XtnR/a3ZRsTrsT8a2eVxt36FgqlOhb+ktNFlIb4hjfiGVOLr00iq6U9y5SCSKwdzz+SfMaX/hwBsKvwun+x8qM1r9Ek8xpLb5wQf//alz2hypgCQaDvNg3deGfa4hWjLn//1T0rLLz9n+7wrf8TUCc8DUHjoVv7v8L1U9DtEXcpp6lJPUd+nlMaEKtyWpnPO7QyldbAAfOvPsajqO7t63D2rSCerVcCqkGQ0X2u9vKP7/ccsAZYAWIxMdnr4LGJPoJVhqQypcxBfaWd/tGIIxAFwtIrzjppINQ8eAlDlOnG8rceXGkNXvxYdifd8r0Vnnm9nzhmWypBae58UvEnVnX1tw/Gz6ej7Ihzae28lJ56gJ/2OdHUM3eW1KG8gud6h46MZx8WK9D2raiDtEvbjv4/Vbe5lKaUKe9oQ0K4ir0Uz32tRLa8F8r4IJa9F50V6uvhWIMX/dRaQd5H7hRBCxKCIJiut9Vogy9/FlxIYPKGUyjvffiGEELEt4kPXQwZM5Idsm3++/d1ct+mS7AbktWgmr0UzeS2ayWvRST26goUQQojYICWOhRBCdHuSrLqAf75YzFJKpSilspVSi2PxtfA/71z/NIuYFevvg/bIa9E5kqzCzD84JCvacUTZHUCOf8AMsfRHO7QKi/9xbnQjiqqYfR+0R/4+dJ4Usg0jpVQWUBLtOKKtVU3HWJuCMA14xf91CZBNzxksFFYx/j44h/x9uDTSsgqvLK21vBn9/L+clTE2BSGl1eOYLwMeo++Dtsjfh0sgLauL4O/iaV1ho8RfePe8RXd7m/O9FiGPF2utl0YwrO6gmgtUYYlBsfg+aCHW/j50BUlWFyHQ996OysBkZnwTm7O11kWRiSzyLvBaoJRaHJgz19tfi1akCkuIGH4ftBZTfx+6gnQDhonWusj/n1Ma53YFxRT/L+UKpdQ2pdQ2YqilIVVYmsXy+6A1+ftw6WRSsBBCiG5PWlZCCCG6PUlWQgghuj1JVkIIIbo9SVZCCCG6PUlWQgghuj1JVkIIIbo9SVZCCCG6PUlWQgghuj1JVkIIIbo9SVZChJlSKkspdUgpled/nO2vPC6E6CRJVkKE33JgPlDkXxU2R5aGEOLSSG1AIcJMKZWita5WSqXgS1QxW8xWiHCRZCVEF1BKZYOv2na0YxGiN5BuQCHCzL8wZUkgUfkfCyEugSQrIcJIKbUE36KLzyqlUvz3rKqjG5UQPZ8kKyHCxD/ir8S/Mm4JcBg4JPeshLh0cs9KCCFEtyctKyGEEN2eJCshhBDdniQrIYQQ3Z4kKyGEEN2eJCshhBDdniQrIYQQ3Z4kKyGEEN2eJCshhBDdniQrIYQQ3d7/B1+IbEIb851+AAAAAElFTkSuQmCC
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAasAAAEnCAYAAAAXY2zOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABVFUlEQVR4nO3deXzU1bn48c+ZNZnsC/sedkSQJCCbChhBrVpaUax2kVuL1V5vvZVCbW1/vbd2kWpvbzcrtrVq9RahShcVIaJoFIQQRMNOwr5mm2yTzHp+f8ySSUgghMlkmef9evFi5rvNMyHMM+d8z3mO0lojhBBCdGeGrg5ACCGEuBhJVkIIIbo9SVZCCCG6PUlWQgghuj1TVwcghOg+duzY0ddkMv0BmIh8mRXR5wOKPR7PfTk5OefCd0iyEkKEmEymP/Tv3398nz59qgwGgwwVFlHl8/lUWVnZhDNnzvwBuC18n3xzEkKEm9inT58aSVSiKxgMBt2nT59q/C375vu6IB4hRPdl6O2Jas+ePZabbropC2DdunVJM2fOHN3VMYkmgd+/83KTJCshRK/33HPPpQUfT5gwwfXiiy8eBVi4cGFtSkqKt+siE+0lyUoI0auVl5cbN27cmBx8vmfPHsu+ffusXRmTuHQywEII0aafTzye09a+6x5JOTptSXI5wLbnajI3P1U9rK1jv108ZEd7X/OBBx4YtGDBghqAQ4cOWUeNGuVcuXJl/w8//PDgAw88MAjg6aefPglNLaaKigrjsmXLytetW5e0cuXK/suXLz9TWFhou/HGG2vLy8uNu3btsj333HNpS5YsqQJYvnz5oA8//PBgy9d+7LHH+uXm5joOHTpkXbZsWXl7YxadT1pWQohu48knn8zMyMjwLFy4sBbAbrcbg48BHnroobLg44KCAltJSYllyZIlVc8991wf8HfrVVdXmxYuXFh79913V7300ktpCxcurB06dKgzmKgmTJjgaq3r74EHHhiUm5vrWLhwYW1JSYm0vLoZaVkJIdrU3hbRtCXJ5cFW1uUoKipKePDBB8sAxowZ4ywsLLQBtJZcZs+e7SgvLzeuW7cuKSUlxRPcHv74Uhw5csRaVVVlKigosI0cOdLZ0fcgOoe0rIQQ3UZ2dnb91q1bbQAHDhw4r3UTvu3JJ5/MPHTokDXY8iovLzdC64ktqKCgwNbWvpycnPrRo0c7Z8+e7bj33nurLud9iMiTZCWE6DaWLVtWXlJSYl23bl1SsFUF/kSybt26pKqqKtN7772XvGfPHsuoUaOcdrvdWFBQYJs8ebLjn//8Z/K6deuSiouLbQUFBbaXX345bdeuXbby8nLj8OHDnc8991zauHHjnAUFBbbi4mLbnj17LMHHBQUFtscff/zs+vXrk9atW5d0oaQmuoaS9ayEEEG7du06Mnny5G4xsKCgoMC2fv36pMcff/xsV8ciomvXrl2ZkydPHh6+TVpWQohu6aWXXkrbtGlTcrB7T8Q2GWAhhOiWgsPThQBpWQkhhOgBJFkJIYTo9iRZCSGE6PYkWQkhuo3wiuhChJNkJYToNsIrorclvIK6iB2SrIQQ3cbFKqK3rKAuYocMXRdCtG7dN4Zwbk9kKzn0neBg4W+PX+iQYEX09lZQD6+UnpGR4X3llVfS7rzzzqqSkhLLyJEjXU8++WT/H//4xyeCFdzDC+OKnkNaVkKIbiO8Inp7Kqi3rJS+ZMmSquLiYtuSJUuqHn/88bNLliypGjp0qHPhwoW1y5YtK3/ooYfaXMZEdG/SshJCtO4iLaBouFgF9dYqpU+cONHR1vFDhgxx7tmzxzJhwgRXpGMVnUuSlRCi27pYBfXwSunjxo1rdVmP6upqY9hjkySqnkmSlRCi2wiviH7gwAFrsCL6+vXrk1pWUL/11ltrZs+e7Xjsscf6hdcPDJ4ze/ZsB/gTVEFBgW3r1q22H//4xye67t2JyyFV14UQId2p6nqk3HTTTVlvvvlmaVfHIdpPqq4LIWJKcH2rPXv2WLo6FnF5JFkJIXqthQsX1h4/frxY7lP1fJKshBBCdHuSrIQQQnR7kqyEED1GNArdPvDAA4Mee+yxfp35GuLS9ejRgJmZmXr48OFdHYYQvcbKlSvp379/V4dxQTU1NSQnd155wD179rBlyxa++tWvdtprdDWn0+mZMmXKrq6Ooy2tjQbs0fOshg8fTmFhYVeHIUSvsXfvXsaPH9/VYbSptLSUxsZGJkyY0GmvERcXR2lpaae+RlcrLi7ucQNOpBtQCNFt5Ofnc8MNN5Cfn8/KlStZu3Yt+fn53H///djtdgBWrFgBwNq1a0lLS8Nut3PHHXewcuXKdp2/atUqioqKWLVqVbPXDp6/du3aaL5l0U49umUlhOg8T2x7gn2V+yJ6zXHp41gxbUWb+/Py8lixYgV5eXlkZWWxYsUK1qxZQ2lpKYWFheTl5ZGamgrAokWLAHjllVe4//77ycvLA7jg+UVFRWRnZ5OdnU1lZSWrVq1i6dKlrFq1iuzsbPLy8khPTyc/Pz+i71tcPmlZCSG6lfT09NDjrKys87aFW7RoEc888wy5ubntOn/79u2hbVlZWWzcuBGAHTt2hLaL7klaVkKIVl2oBdSZgi2n9sjPz+fZZ59lxYoVPPPMMxc9f+rUqZSWlpKVlUVpaSlTp04FICcnJ7RddE+SrIQQ3UZ+fj5FRUUUFRWFHpeWlrJ69WrS09NJT08PbcvPz2fNmjVs3LiR0tJSVqxYwQ033HDB85955hlWrlwJQFFREcuXLwdg6dKlzbZv3LiRpUuXXlLiFJ2rRw9dz83N1TIaUIjI6e6jAUVkFBcXOyZOnLi3q+NoixSyFUII0SNJshIxT2uN19fmGn9CiG5AkpWIWVprPjj5AXe9fhfz187nQNWBrg5JCNEGSVYiJhWXF7PkrSV8Pf/rVDurAViyfgm7yrptBRohYpokKxFzqhqr+OpbX+VI9RG+e/V3+efCf/L8Tc+TYk3haxu+xtbTW7s6RCFEC5KsRMx5fvfzNHga+NOCP/GFcV/AbDQzOGkwz9/4PIMSB/Fg/oPsrei2A6WEiEkyz0rElKrGKl7e9zI3Dr+RrNTmE0D72Prw3ILnuPnVm/nDp3/gqTlPdVGU3chTKrLXe+TCU2WKioq44447yMvL44knnqCwsJA77riDRx99lEWLFoXKJ3VXwfgXLVrEo48+GvV5Wvn5+TzxxBOhyhyX44EHHhiUkZHhefzxx8+Gby8oKLB94QtfyLrllluqpk2b5ti2bZttwYIFNQsXLqxtua+iosKYkZHhXbJkSVVr55aUlFhee+219N27d1/026EkKxFTXtjzAo2eRu6ffH+r+1PjUrlz7J08t/s5jtUcY2jy0ChHGNuCdfvuv/9+UlNTQzX+ghN0n3322TbPXbt2baheYFcJxr948eILJqrOijUvLy9UyeNCrz1u3LiLXuuee+6pWr9+fVLL7bNnz3Zcc801tffcc0/V7NmzHUuWLKlKTk6+qqam5uOW+8Cf9NLS0jwLFy6snT17tmPixImO8P3tJd2AImbYG+28vPdlFgxfwMjUkW0ed8/4ezAqIy/seSGK0YmLKS0tpbS0tNV9drs9Iq2JaOjKWC/ltdPT0z3tvW5KSopnz549ltb2PfTQQ2Xf+973Bre2r7y83Jibm9uupCUtKxEzXtjzAg2eBu6f1HqrKqiPrQ+3jbyNdYfW8cDkB8iIz4hShOJiVqxYwcaNGykqKqKysrLZvsLCwmYtllWrVpGbm0thYSFLly7FbreHqqsXFRWRmppKeno6q1evZvHixZSWlrJ8+fLQEiGVlZUsXbo01LW2YsUKioqKyMrKIjU1lTVr1vDEE09csAXV8ty8vDwqKyvPi3XlypVkZ2dTWlp6XkxZWVn89Kc/5Yknngg9D1aYb/keW2r5XgoLCyksLGT9+vXGiRMnAvDYY4/1y83NdRw6dMi6bNmy8uDzwsJCW3v+TcrLy43JycneCRMmtLpG1oQJE1zHjx+3trbvn//8Z3Kwi/BipGUlYkK1s5qX973M/OHzGZU26qLHf3bEF3B6Xcz/40+Y9bNNfPOvO3lxyxGOlNdHIVoRXFdq7dq1oXWogkkCYPXq1QChbsLg3+Ef/llZWWRnZ5OVlcWqVasoLCwMdS1u376dpUuXsmjRIoqKili0aBHLly8P1RIMVnMPvkZlZSV5eXksWrSI1atXk5eXR05OzkUXf23r3PBYV6xYEVqepKSk5LyYFi1aFHqPS5cu5f7772/zPYZr671kZWVx4403esHfRZebm+tYuHBhbUlJifXJJ5/MDD6/8cYbay/03tavX5+0bt26pD//+c9pmzdvvuAkxdraWmPLc+++++5hFRUVxrbOaUmSlYgJG45uoN5dz1cnXnip8ppGN99es4vFvy3FXTMBb2IBVw6OY0tJBd//+25u+J/N/P3jk1GKOnYFP9wXLVrUasvl0UcfZePGjeTk5ISSWbjWlgIJtkaCrZ2g7OzsZo+zs7PJz89vttTIpSxb0tLFjistLcVut1NUVMTIkSPPi6mlYMX4tpY7udh7CXfkyBFrVVWVqaCgwDZy5EhnUVFRwpgxY5zteV/BpLZs2bLyzMzMNkvAlJeXGydMmNCsq+/GG2+sffnll4+OGjWqXa8FkqxEjNh8fDODEgcxLr3tG8sNLi9f/fN2Xtt5ksW5Q3hq/jfxKgezs0v56LvXs/nbc8gZlsY3//oxT79bQk8uAt3TBRPOjh07zlsosaioKLQUCBBaCiTYDRdsXbRm1apVlJaWhhJbMBFezqi+C50bjDXYQrrzzjtbPS48IVdWVpKVldXqe2zPewkqKCiw5eTk1I8ePdo5e/Zsx7333luVnZ1df+DAgVa77Drql7/8ZeayZcvOtLZv4cKFF2y9hZN7VqLXa/A0sPX0VhaNWYRSrQ/Fdnl8PPDSDgqPVvGru6Zw6+SBALx06Er+UfIPvjjhiwzLSOD5f5vGsjWf8MT6fZyyN/DD267AaIjw8O7u5CJDzSMtuLzH6tWrycrKorCwkNLSUlatWkVeXl6oa6u0tDR0PybYnZaVlcXatWvJy8tj+fLlrS4FkpOTQ1ZWFllZWTz66KOh1YODKwhnZWU1e56fn09qauoFlx0JJoO24m95rt1ubzXW8Htw4TGAP0EVFRVRWFgYahW29h6D5wXvrbV8L8EuxfXr1xvvvfde5+zZsx2PPfZYv/LyciNA8J4VQGFhoW3Tpk3J5eXlzVpOBQUFtl27dtnAPzKw5b73338/KSUlxXPw4EFrSUmJJTU1tdnQ9eLiYttLL72Ulp6e7mnrPldrZIkQ0eu9c+wd/uOd/2DVDauYMXDGefu9Ps03/7qTf31ymp9+/kq+MK1puPrzu5/nycInef1zr4eGsft8mifW7+OZ90p55IYxPHT96Ki9l87Wm5cIWblyZWgIfGlpKc8880yz7sDu7I477ojo/LKeuERI1FtWSqlFgB3I1lqvvMBxyy+0X4j2evfEuySaE8ntl9tsu7POx9Zna9hWWkn5Mc1/Zl3BwA+S2fyBHYCJtyUwf9h8nix8ktXvv860A18InTuTAdRXGNj66xqGf1zGrY/0Ce3b8kwN1kTFlC8konpzq6uHCW8p2e12Fi9e3NUhtUt4ay6WVzKOarJSSmUDaK3zlVJZSqlsrXVRK8flAVPPu4AQl8infWw+vplZg2ZhNpqb7XM3aLb9sRYwk0NfXCWwjaYu9EFTrIwaOYBJfSbxzpl8+OMtzc5PwcZV2Nh1qo6bHs7AZPTfAi74tb8wbuZoM0OnxXXuGxTtFt5d15MERwnGumi3rBYDwSErpUAecF6yEiJSdpfvpqKxgjlD5py3z2yD07NqOF3dwH3XZJFobf7fIWOE//n8YfN5suxJxj5cSz+az23cd6aWtZ+e5Zn3vHxjbvMh8TWnZY0sISIl2skqFQifyXfebMtAaytfKXXhmZtCtMM7x9/BqIxcM+ia0Laz+1yc3OHkiK2WV9OO8P++PIHrZ7U9vDjYFXju6g+57cr7mu27mmS2vXSW/80/yA0T+jGmXxK5X0mk8Pk66iskWQkRKd1x6Hr7Ji8I0Q6bT2zmqr5XkWJNCW07trWRt39q562XyhnbL4kvTR92wWsMSPR3BW44sqHV/f/12StIjDPxw3/sBsCW4Z/n6JBkJUTERDtZ2WlKRqlARfjOYKsqyjGJXupU3SkOVB1g7pC5zbbXl/sAKKOR//rsFaF7TRcyf9h89lbu5VjNsfP2ZSZaeXDOSD4sqWDH0SoSAskq+Dq93jsP+/9EQHBi7P3334/dbic/P5+0tDRWrlxJaWkpd9xxR0Rep7MUFRWRk5PDihUrWLt2LStWrAhVlrjU+IM/i+C1Vq1aFZo03B4rVqwIDW3vDaLdDbgaCA7JygLyAZRSqVprO5CllAoOd2l1AIZSaimwFGDoUKmILVoRWNbi3bh0SBzIdRuWwvp7Q7ur3vsNcBujE3Yz/bWr23XJ+QYzT6aPZcNfcrivofy8/XdrK79Vf+K3f/wl3697F/iLdAN2QG+oup6bm8vixYvJzs5m0aJFpKWlceedd5KVlXXB+Fu7VrCCe3C+VXurZgAsXrz4vAnTPVlUW1bBxBMY7WcPS0RvB/av1Vqvxd/6Sm3jGqu01rla69w+ffq0dogQAGwxJzLE62S4r/m8w9L6sQDckrK+3dca4HMzye1gQ1h3YjibcvJv8f9gk2sa5+I1WdfGMeiqiBYCiHk9tep6sKbhheJvD7vdTl5eXruvEe21tDpb1OdZaa1XtbItp5VjzjtOiPbyAR+bbcx1Na/m4tQmKh2DSAXGJO6+pGve4KrmqYQBnDKYGehzn7f/y/H/YlXD53nBNJPf/k6+SHWGnlZ1HWg28TgYf2vV2C9UDxAIVaBITU294PnBCu5FRU2dUi1/Xv3797/4D7ub6Y4DLIS4bEeMVuwGE1Pczauk/8N5HRanv8WTEF92Sde8LpD43rOctx4dACmGer4U9zpvOGdx6FxdB6IWQT296nphYSH5+fnccccdrFix4rz4W7vmhX4WK1asaNaiauv8YDIO1kAMavnz6okkWYleqcjkX4on291U7Flr+GP9QozKi1IebHEVbZ3eqhFeF8O8Tja3kawAvmpbRzJ1/PUfWyg74MLdGCODLCKsp1ddz83NJS8vjzVr1pCenn7e8h0XOz9cXl4eTzzxRCjOYNJq7fwdO3a0mowu9vPqCSRZiV5pp9lGus/D0LD7VR+4J7PPN4Kxn3+Ab315NAbDpQ+AuNZVyzZzAg5aL6OU4avnnbhlLD96D39dfIDK0nYvtiouQU+rut5aYrnUa+bl5WG320Pvq7Xzc3JyWr2ndaGfV08hVddFr1RkTiDbXd8spfyh4XP0MVRym3UzBtWxkXrXuWp5MT6TrZZE5oXfD9OAMw7cFpKpx2TUDO//AfUV7R9qLHpH1fVgd2MwzmD3ZPAawe2tVWMPT0DhP4vS0lIqKyt55plnWLNmTeiclucvXbq02fveuHEjS5cuPe/n5XC0ayX5bkWqrote59z/mLk+fRzfrjvNlxv9XX2HPIPJq/o9y2wv8O8Jr3T42m4U16aPY4Grmh/WnfJv9BihMR60ArMLrE7q7EM5enI23lufYdLnEyPxtqKiQ1XXg3Os5v4y0uFEVE+uuh5pUnVdiG5gZ/B+lafp2+OaxjxMeJh62siqnQVcMepvzJryP5d8bTOame463jMn4dNgaIwDjwUMXohvAKO/xXaK2YzoX8AbB6uZRM9JVr1ZT626LvwkWYleZ6fZRrz2MdbTAIBXG1jnnMscSyE4UqmuG4rLbevw9a9z1bLBmsJedzpXeNxgcfr/hPU56n4LsFX8C/uRrcDtl/mOurlu3qIK6qlV14WfDLAQvU6ROYFJbgfBBUE+dE/irC+D2+M2Ud+YCUBC/PlVKNrFp7imxo3Sms22eLDVg7V5ogLQQ67Hpw0MdG+mtvH8OVlCiEsjyUr0KvXuevYb45gS1gX4auM8klUd8yzbcDT4J+te6hwrNOA2gSOBNJeBya5GNifEgbH1oenx/TM4VXEVV6Zs4V+fnO7o2xFCBEiyEr3KrrJd+JQKTQau88Wz3jmTW6zvY1Ue6gPJynYpycqn/AMoGm2gNNjquc5TzR5zPOcMrfek95tgIWHmTQxJOsCGrR9f7tsSIuZJshK9ys5zOzFozeTA/ar1rhk0EMftcW8DhJJVu1pWGnCboT4RPCawNPq7/Yw+rg0MW99sbn2CcFyygbTrPwNAn7Pvsf9MbavH9QabflbFpp9VdXUY7RZe/Tw/P58bbrihiyMS7SHJSvQqO8/uZKy3kQTt7557tfF6hhlOkW3aB4CjoZ33rHwKGuL9LSqDFxLqweoK3Zsa7XUyyOviXWvb1SzoOwFv0kCuN37M3z8+ednvTXRccI4R0Kz6eV5eXq8r+NpbSbISvYbH5+GT8k+YEiixdNLbhy3uK/l83CaU8pdbmjrxGXIm/JF4a2XrF9GAK9Ca8prA2gg2Bxia35tSwFxXDVvNiW1Ws/joj7WctF/HtYZiNn5yjJ48p7Ena1mR/XKrn4uuIclK9Bql1aU0eBq4MjC4Yp1zDhoDn4t7BwCl4OpJTzPv6v/CYGhlYIRPQYMNnPH++VIJdWBxnTfSL2iuqxaXMrDF0vo8qn1vOSjcOpN4Guhj38me0zUReZ+93YoVK8jPzyc/P59Vq1Y166pbsWJFqDAsECp2G6y9Fzw2Pz+flStXhipKBCuyh79Ga1auXBl6XdG9SLISvUZxeTEAE93++1VvOGeRbdrLUOPZC5/YrDVlBGsDxDvAcOGW0BR3PUk+L+9Yklvdn5Bh5Ni5q/EpK9cbP+aNT2VU4MWsWrWKjIyMZrX5wudH3X///aHHl1IhPbwie3j183ArVqwIVSwvKSnpxHcpOkKSleg1isuLSTInMdTn4ri3H7s9o7jJ+mFof3XdIA4cuZHyqjFNJ/kMYa0pT6A15W6zNRXOjL+w7XuWJFqrNJiQacDttVGfMIObrJ/wxqdnpCvwInbs2BFKTuHFZltLLu2pkH4pSktLsdvtoeXkRfciyUr0GsXlxUzInIABeMs5A4AFYcnq2KlZ/P2dVWz79OuB1pQF6hP8ram4Bn+5pIu0plqa46qhymBil+n8ihgJGUYAyg1zGeg5gbeilL2ne++owEgIXyOqtftK4ds6UiE9fEHClqZOnRpaA+vOO+/sQPSiM0myEr2C0+vkYNVBJmZMBGC9cwYTTCXNugDrG/3D1vuk7AdHgr9KuinQmjK3rzXV0mx3HSbt451W1riyZfqT1amGOQBcb9wpXYEXsXTpUkpKSkKVxIOmTp1Kfn4+drud/Pz8UDXzYEso2MIKr0a+du3aUDXyYEX28Krq4ZXPg5XZg9eQAtndj9QGFL3C/sr9eLSHiZkTOedNY4dnPP9pe7nZMQ5HOjPG/56cEav9FdLjHP5k1YEkFZSofUxz1/OuJZlHHM3vjYVaVhWDYcRoFtbt5j8/Pc0j88eg1GW8aC8XrISenp4eWnspuMQHNF8SJNiqCl9AMXi/KTs7O3Rey8UWw+9JhT8Ofx3RvUjLSvQKocEVmRPZ4JqOxsCNYV2AeA3kjHiF2Vf8hlpnH//kXvPlJaqgua5ajpisHDZamm1PHmik7zgzKQNNMHo+E92fcrq8gn29eIJwJK1evZqNGzf22JVtRWRJshK9wu6K3WTEZdDP1o+3nDPIMp5gtPFYYFFEKzgSsBgdvPbBr7C7+17yvakLmePyD0lvOSpw0FVWvrK2P3OWpcKY+Rh9LmYbd/e6rsB530lj3nfSIn7dJ554go0bN8qkXQFIshK9RHF5MVdmXkl1g5st7kkssGxB+Yz+e1MuK5jcrP3wNxw6Pe/S6gK2Q3+fhwnuBja2MYQdgKEzwZLInSl7eWv3mYi+fqTJiEXRlXw+nwLOmwgpyUr0eHWuOg5XH+aKzCt4e+85THhZYngLHDb/van4eohvxF47AuhAxfV2uNllp9hs46iheVeg1pqGai8+ZYasOczw7uDA2VqOV3bPZcXj4uKoqKiQhCW6hM/nU2VlZSlAcct9MsBC9Hh7Kvag0UzMnMgHr29ko/Vx+nod/hF+1sbQfakH7srF0ZBBvNUe8RhudFbzlK0/r8el8qDjXGj7szedpvqEl6VvDSBlzAIS9/2Lceo4m/ad4yszh0c8jss1ePBgTpw4QVlZ5BO66D7OnDlj8nq9mV0dRyt8QLHH47mv5Q5JVqLHK67wfwkbGT+MKSdvx6WM/taUqflUXZPRRXJi59wv6ufzMM1dzxvWFB5wnAuN24hPMVB9wkt9uZeUUf6SQbcn7ebtfTndMlmZzWZGjBjR1WGITjZhwoRPtda5XR3HpZBuQNHjFZcXMyhxEOc+/oAE1cgJc/J5iSoabnZWc9RoZbcpPrTNFhi+Xl/hg+QB0H8SCyyfsLWkgnqnJ+oxCtFTSbISPd7u8t1MzJxI4+71OLSVMZbz67odOz2Dl1//G1t3faPT4shzVWPWPl63poS2JQQmBteXB5LnmAUMqf+UOG8N7x+8yDIlQogQSVaix9E+TV2Zl7oyL8dPlHGq/hSjreMZVlHA/oQcrAYPHq+FOkff0J+zFVdw8txUqmqHd1pcydrHda5a3rSm4PH5W00JGf7/YvbjHrRPw+j5KO3jFuNe3t1+LvQ+wv80VrdSEV6IGCf3rESP8+o3yil9vxGAEyO2wyI4+3Mv/a8s42jWg3B0PSfP5vLKW38979yEuM5tzdzsrCbfmsK209uYOWhmqGW1/blaZixNxjooB2wZ3HVsP289lcbTT5067xpjF8Rz21Pd8d63EF1HWlaixzm1ywWALd1AbdYh0IqrbUcBGD79swAYjW4S4s81+5OWXMroYes7NbZrXbUk+by8fvh1AEZcE0fGSBMJmQb/qESDEUblMTptCw5rI5Y0RUKmodkfa7L8txSiJWlZiR4neZARa7JiyWv9+daW44yoGc6Q8Zsp8Yxg5GD/0g6D+23nwbuiP9jJiibPVcNbR/P57tXfJW1oAv/29wHNDxo9n/hPVrNrwevMnnMT35w/9rzrnPrEiateMyTXitEsdQSFkK9wosf5ypr+LF0/EHO8gT0VexidNJIxzt2c639dV4cGwKLGShweB68efLX1A0bOA2Xg7rR9vL3vXKuHvPZQOWu+VkZDldy/EgIkWYkerLyhnHOOc2RWuTApH6lX3dLVIQEwydNAdt9s/rLnL6GBFs3Y0mHI1VyndrL7VA1nqhvPO8Qc529NeZxSSUIIkGQlerA9FXsAGHb6KHYSGT1lTpfGE+7LV3yZU/WnyD+W3/oBo2+gT90++lDFewfPrxZhskqyEiKcJCvRo9Sd8/I/OSf4462n2V2+G4XiuspdHEyajsls7urwQuYMnsPQpKE8X/x863X2Ri8A4LaEYt470EqyCrasGiVZCQGSrEQP427UeJwar1uzp2IPg6x9GaRrYMwNXR1aM0aDkS9P+DLFFcUUnWtlKfV+V0DyID5r203BoXK8vuZJKdSyckmyEgIkWYkexhv48DZZFLsrdjOkwYBXK7ICQ9a7k9tG3UaqNZXndz9//k6lYPQNjG/YQb2jgU9PVjfbbbRKy0qIcJKsRI8S/PBuTKmkrKGMK6rPsd88jow+Ay5yZvTFm+JZPHYx7x5/l8PVh88/YPQCzJ56phr2s3l/865As9yzEqIZSVaiRwl+eJdlHgLgmoZTlA2Y04URXdhd4+4i3hTPU4VPnX/vasS1YLRwZ/Ke8wZZ5D2Wxn1v9GfYdGsUoxWi+5JkJXqUYLI6l3YAhWKcy0XKpM90cVRty4zP5MGrHmTzic1sOr6p+U5rIgyfzTUU8fFxO9UN7tCu5AEm0oaaMcfLf1EhoAuSlVJqkVIqTym1vI39eYE/T0Q7NtH9BZPVmeQDDPKYqPalM/6qGV0c1YXdM/4exqSN4acf/RSHu8UKwaMXkNF4lEH6DB8ekirsQrQlqslKKZUNoLXOB+zB5y323xDYn91yvxAZI83MXZ7KuYwDTGqoZX/SdKzm7l01zGQw8f3p3+es4yxP73q6+c7R/lGMN1k+adYVuOf1ev7xSDmH3mmIZqhCdFvRblktBuyBx6VAXvhOrXWR1npF4GmW1rqVMb8ilqUNNTF0UQN2XyWTXA68I/MuflI3cFXfq7h99O28uOdFDlQdaNqRMRIyRnGbrZjN+8tC97XKD7jZ/1YD5YfcbVxRiNgS7WSVClSGPc9o7aBAF+H90QhI9Dy7y3cDMLrRy/Bp3fd+VUsPZz9MsiWZxwoeo8ET1mIavYBxzl1UVdspKasDwiYFy2hAIYBuOsBCa70SuF8pldpyn1JqqVKqUClVWFZ2/sx/0buVHXSxecsuDBoaPWPIGti3q0Nqt9S4VH4060fsq9zHDz74QdPowNE3YPS5mGnYzeYD/vtWMs9KiOainazsQHrgcSpQEb5TKRV+n6oUWNryAlrrVVrrXK11bp8+fToxVNEdlbzTyI79H5HldlHVbw5K9azlM64bch3fzP4m64+sZ9Unq/wbh80CSyKftRXzQWCQhcyzEqK5aCer1UBW4HEWkA8Q1oLKo3kyK41ibKIHcLt8lPc7yBVOF0lX3tTV4XTIv038N27JuoXffPwb3j76NpgskDWHa9VOtpaW4/b6mlpWkqyEAKKcrIIDJpRSeYA9bADF24G/VwFZSqlFgePXRjM+0f2Vuc5QF+dkSL2NKZNzujqcDlFK8cOZP+TKzCt5tOBRdpXtgtHzSXWfY4j7CB8ft0vVdSFaiPo9q0A3Xr7WelXYtpzA3/bA/rVaaxlgIc5zWO8EwFw3ibQESxdH03FWo5VfzfsVmfGZPJD/APv7jgJgnvFj3j9YTlI/I0NyraSP6N7D8oWIlm45wEKItpwxbMKsNVbjzV0dymXLjM/k2fnPEm+K5/4Pv8exAVdwS/ynfHConKHT4rjrz32Z+fWUrg5TiG5BkpXoUY5b9zDG6SFxcPdYwv5yDUocxLM3PItP+/hagpd03wFKj5+gtlHmVwkRTpKV6DF8Pi+H46oZUpnJyEHpFz+hh8hKzeL3N/yeanx8s18G01URWw5V4Kzz0Vjt6+rwhOgWJFmJHuNIaT4Oo8KbPJrxeQldHU5ETciYwMrrfs5+i5mqge+wpaCCX00/yV+XnOvq0IToFiRZiR6jcM+rAAwefgtGc8+aX9Ue1w6Zw7esw9md6ODtRv+CjTIaUAg/SVaix/j0TBFWH+RNntvVoXSaL1/xFT5XW0dV2pscHrtZKlgIESDJSvQMjkoO6RoG1qaw+3tu7Mc9XR1Rp1CjruexCjv9HYlsXfBrqk2ybIgQIMlK9BCuAxvYbzWTcfpKTuxw4fP00haHLR3z4Gl8t7wBn8FDwbSnL36OEDFAkpXoEXbtfhW3UiSenAk0VSXvjdSY+cz1Hian8DaOjCpg07FNFz9JiF5OpseL7s/n5UBZEaTF0+/ceACMlm6erJ66jPi8BiCRz55M4kDZMH6S/yBX2w+SoDswjP2RXtoCFTFHWlai+zu5g30mLxavBVtFPwDMvbhlhcGHR0Hq2HyuPz2McwYTv7H1nKVQhOgMkqxEt+fbv55iq5U082h8Tv+2YKHXXkmByeQiJ6GQ0wkp3NlYyUtxGZQarV0dmRBdRpKV6PYq97xBidnM+IzJaB8YTGAw9eJkBWD0kKCceDxWltaXY0Xzp/jMro5KiC4jyUp0bzWnKHGUohXMHzGNiQttjP+Mrauj6nwmD15t4Lbq45TWTuH2xkpet6Zy2mDu6siE6BKXPMBCKTUcyMa/SGIq/gUS7VprGbIkIu/gRnZZ/d1f12blkvJ4jFQhV3C68kpmWwv5S/U8vpKyk9VxGTwfn8F36s90dXRCRF27W1ZKqW8rpTYATwAjAQVUBx7PV0ptUEo9rZS6qlMiFTHJu/8tPopLJNkwiBRrjCSqgNNVE8lIPswpd18G+Nx8xmnnb3HpVCpjV4cmRNRdtGWllBoB3A/8VWv984scmwIsVUrlaq3/EKEYRazyOPGVvsMnA/tyVcYk3I0+qo56sCYaSBnU+2ddnLOPA2CgsYwGbeXfGsr4hzWVl+IzeMghBW5FbLlgyyqQqK7XWn9Ha/3xxS6mta4OJLS3lVL3RShGEauOfsBx5aLR6GPe8KlUlnp4/vazrPtmbJQganCnUFk7jOlxRWx3TyDL6+J6Vw3/F5dBnZLbzSK2XPA3Xmt9uCMtpI6eJ0QzBzdSZPUPprh6YA7uQFFXY28eth7GZGqk9My1TLF+yjbnFQDc11BGrcHIa9a0Lo5OiOi65K9nSqnkzghEiJa8+9ezwdoXi0pgeMpwvC5/sjLHSrIyNlJ6+losBjcObyIAV3gaudLtYF1catcGJ0SUdaQvYWT4IAql1Ail1LzIhSQEUFGCsaqUYquZsakTMShDaLmMXj0hOIzVUktZbRYun5ksfZYqXxIAtzrtHDDFs88Y18URChE9l5ystNY7gamBIexorQ8DaUqpn0Y4NhHLDrxFjUFRa61n1pAcADyBllVvLmIb7oYZ3+cbd02l3mRkjnEXW10TAbjJWY1J+/i7tK5EDOlIN+BqoASoCusSzAeWRjIwEeMObiDfOgiAnP5TAGKuZRWUZK5msCrngHsEAKnayxxXLW9YU3F3cWxCREtHugFzgEKtdTWgAsPV84CfRTQyEbucdeijH/Avc38UBq7MvBJoWuI91pKVyeQCIM7bVHX9NqedSoOJDyxJXRWWEFHVkWR1B4FWVCBhpQNpF5uDJUS7lb6L8rrYE2dkaGIWCeYEAEbNi+fuF/sydUlsfEDv2n83z6z5gC2ffoMKErlKlXLc66++PttVS7rPwz+sqV0bpBBR0qF7VlrrJ8OeHwZ2SOUKETEH36LOkEB9fBXTBk4JbU7IMDJoipX04bFRH8/tiaembgiOhkyUyU2OOsD2wBB2M3Cz0867liSqpaKFiAERmVkYGHRxOBLXEjFOa/TBjbxqGg+GRqb0nXLxc3opk7ERAI83jjRzJSblo9qTGtp/W6MdtzLwZoyVoRKxKWLT4ANdgkJcnjOfompP87rJvxzG5D6TQ7v2b3SQ/5Mqjn7U2FXRRZXJ6F+8y+ONQxm91GsrfXx1+LT/nt04byOjPY38U7oCRQy4aLmljpRN6uh5QnDwLQD2xWky4/oyJGlIaNeJ7U52vlxH2YHYGANnMgVaVp44UFBhSGC6YS/7PMMAfyXpG53VfGK2UaZ6f61EEdsuWm4Jf52/37dn4q9SKlkp9W389QSl3JK4dAc2UGoZjU46wdUDp6JU08i/0DyrGBkN2NQN6F8iJclcTaaq4YArK3TMXFcNAO9YY2PQiYhdF/06FkhYX1dKfU0p9R1AA0VAReCQDPzrWo3EP/9qZeAcIS5NfQX6xHZeNt2MNnzK1H5Tm+2OtXlWoZaV11+pIs1ix+tMBk/Tf9tRXidDvE42WZK5s7GqS+IUIhra3XegtX4WeDYwryoXf4JKxz+wojQwyEKIjit5G4XmbbN/rvnU/i2SVWCelTlGKlikJh1j2pW/Iz251L9BaU6qDEbp0zi1CavyoIB5zlpeik+nThlI1L4LXlOInuqSO7oDAyne7oRYRKw78Bb15nTO2GoYEN/8fhU0taxipep6atIxrsttPtfeaVRM5Cg7XKPJse4FYJ6rhudtmRSYE7kx0C0oRG/TodGASqn7AqsC3ydV2EVEeD1wKJ+txilYE48ybUDz+1UQuxUswg0wnwagzN0ntG2yx0G6z8Mmi/xXFL1XR2oD/gwYhX9J+zuBw0qpr0Y6MBFjTmyHRjsvNQ7Da6g5734VQPJAIxlZJuKSY2PhQY/HypGT13Dk1OzQtkSTgwqdRLLXGdpmBK5z1fK+JQk3sZvIRe/WkfGu27XWfws+UUqlAt9RSn1ea/1qxCITseXgBnzKyHarBTj/fhXATY9nRDuqLtXoSmbNhpewxZXxjS/4K8+j4JRK5UoOY/cmkmqsA/xdga/FpbHdbGOmu74Loxaic1z25AyttR1/svra5YcjerSnLuNbfX0CR/UAfLaj9Pe6GfLssMjF1UOFTwoOF2+uI8ndyFbXSKbH7wJguquOeO1jkyVZkpXolTrSn1KqlNqulJrb4n5VRZtnCHEhPgU+I295c7AklDDVXd9qZ5bWUY+sSzUNXbc22z7cchyXNuHyxIe2xaGZ6arlHUsyMfZjEjGiI8lqMfAK8ABwJJC43gKylFJJAEqpz7d1slJqkVIqTym1vI39SwN/nuhAbKInCswb+qvhKjymRqa20TL43epCfvHCAeobMqMZXZcxGlyAD5/Pgs/X9F/VZPBxiAEM0RXNEvhcVy3njGb2yArCohfqSLIqAdZore/UWqfjXy4kH5gPHFVKHQRaTTRKqWwArXU+YA8+D9ufB+RrrVfhT355HYhP9DReE3VYORnvT1JtJSuPJx6vNy7UPdbbKQXmNlpX9UYTI9RZjrkHhLbNctUC8KGscSV6oY4sEfIs/mXshwee79Ra/1xrPT+QvBbTdgX2xYA98LgU/6KN4bLCtpUGnoveTAMeE4V6NIkJe+nrdTPE52r1UI/H32IIliGKBeGV18MNspwC4LS7f2hbpvYy3tPAB5bE6AUoRJR0aAxwIEEdaWNfEbCijVNTgcqw582Gd2mtVwVaVQDZQGFH4hM9iNcIKFZ75qASSpnurmv1fpXPZ8SnzYAPgyE2CtkCGIODLDzNk9VAcxnHdSYJXk+z7bNcdewy2ahTsTG8X8SOTvmNvtzSS4HuwY2BxNdy31KlVKFSqrCsrOxyXkZ0Bx4TXhTvmPvjNrqZ5apr/bBAN5jZ1IiKoalEd3/m83z9zqkk2s6et++4ymA0p3D5mgb1znTV4lGKjwKrKwvRW0T765cdfz1B8Ley2hpBmKe1XtnajkDrK1drndunT5/WDhE9hQY8Zo7SB51YgtKaGe62klXsdQECpCSeJCnhLAbD+TX/LKYG4pSbw86hoW1XeRpI8Hn50CxdgaJ3iXayWk3Tfags/AMzghOLCTxeGkxUMsCil9MG0AY2eHNJTvyEiZ4G0rS31UM9Hn/LKtaS1YWMsZRSr600eJoSkxnNNHc9H1iSZAi76FWimqyC3XqBJGQP6+Z7O2z7E0qpEqWUrHfQ2wWGrL/gvQZnXBmz2mhVAVgttdww47vMyn4qWtF1Cx/sfJhX8//Iucrx5+1LNjrYrYcxUFcRnplmues4abRw1GCJYqRCdK6oLy8aNoAifFtO4O98IC3aMYku4jFRg5VzCdXEq6ah162xWuq4atxfohhc93CqLJsjJ+dw1bgX6Zu+97z9tUYLfXU1Vd5k0kz+iuszAz/HDyyJDI9msEJ0IhkyJLqGBrxGdjCa+MTdJPu8TPQ0dHVU3U7L1YJbGhgYwn7COSi0bYjPzTCvkw9kvpXoRSRZia7hMQGKV9xzsCTuZ7q77oLN/Nr6/uza/wUOn7wmWhF2C6Y2hq4HjTUfZb9vEPHe5gMwZrnq2G5OwOmNjQnUoveTZCW6htc/ZD3fNBSXqZHZF+gCBCirGseGD59gx+77ohRg99ByafuWDEpzTGUynLN4w0oyzXLV0qgMFJ09b/aHED2SJCsRfYGqFYdVX0goAWDmBQZXQFPLwhgjpZaCQt2AbbSsAOJMDkzKx1FX08rKue56zNrHh6c+7PQYhYgGSVYi+nz+IevrvVNJSdrFaE8j/XyeC54SbFkEa+XFiraWCQl3pXU/VTqRBnfTRGAbmqvcDj46/VGnxyhENEiyEtHnMaHRPO+Zizv+9AVHAYZOCQwwiLWWVWbqAUYM2kRK4ok2j0k11vGpHsYgXdlsCPsMdz17K/dS1SizQETPJ8lKRJ/HhF3ZqEoow6c017UnWcVgEVuAK8e8wqL59zJ2xOsXPK7BaCJVOajypIS2TQ90rUrrSvQGkqxEdAUWWvzINx5b0sek+TxM8TguelqslltqryGWE3i14rSrqQr7BE8DSeYktp7e2oWRCREZkqxEdHn9Q9afd1+PIekAc101GNtzmtdfjSFW1rIK8ngt1Ddk0uBMueBx48xHKNYjmlVhNwLTBkxjy6kt6FhbZln0OpKsRHR5TLgxsD0+Hq/BwzznxbsAAWZc9Wse+cpwZk75ZefG183sLf0sv/trEe9s+8EFjzMozUmVyjBVhtfblP6nD5jOqfpTnKht+56XED2BJCsRPYEh6/sZhClpD/E+X+i+SnsYDD6MhguPGuxt2jN0PSjR7E/8R12DQ9umD5gOwJbTWzohOiGiR5KViJ7AQov/8E4nLulTZrtrsUpt8Atqa6Xg1lxl2csZnYrTYwttG5Y8jP4J/eW+lejxJFmJ6PGa0MDLpgl4TQ1c76pp96nv71jGi//8B6XH53ZefN2QyXTxeVZByUYHe/UQhujy0BB2pRTTB0xn25lteH2tL78iRE8gyUpEj8fEOZWMO6kEo9Zc244h60FVNVmcKb8Kpzu2FhW8lG5AAG3ykqicnHL1DW2bPmA61c5q9lXt65QYhYgGSVYiOgJD1t/1TsSa9AlXu+tI0uevftuW4KTgWBu6frGq6y2NtR7CpY2UuZuS1dUDrgZg6ynpChQ9lyQrER2BhRafVTPQFvsldQFC2DyrWCu3dJFCti0NMpVTrIeT4asPbcuMz2R02mgZZCF6tKgvvihilMeEAzPHkiqJ0zDnEroAoakbzBxj86xSEk/y2XlfI97a/pJJ1cY4snUFdk8yqYFt0wdMZ/W+1TR6GokztS/xCdGdSMtKdD4NeE0U6lFYk3eS466n70UK17YUbFkYY6wb0GKuZ8ywtxjSf1u7zxlgPg3AYefQ0LbpA6bj8rnYeW5nxGMUIhokWYnOF6ha8QdDLlgrudlpv+RLhO5ZxVg3YEeMtRzhuO6DyatC23L75WIymGQIu+ixpBtQdD6Pf6HFwiQPZg03XOL9KoAxw9+gtn7nJXWH9QY+n4GPPvkGXm1m9pRftOscpeCYyiBHl9DoqCXOloTNbGNyn8mSrESPJS0r0bkCVSsOMABD8qfMcNWTqi99vs/sKb/gptnfJtFWFvkYuzGlfBTs/DZbPn4YrdXFTwhIMNUQp9wc2PpGaNv0AdPZW7EXe6O9EyIVonNJshKdK7DQ4h9MV6LMNdzqquzqiHoUpZru03kCxXzbY5y1hGptw7rzT6Ft0wdMR6P56IwsGSJ6HklWonN5/T3N7yRaMPlgbjsL17Z0umwy5yrHE4vFw9uzWnBLcQY3m5jE2NqteA++DcDEzIkkmhOlK1D0SJKsROfymDhNEq6kg1zjcmCj/ROBg7RW/OVf/+T5v7/VCQF2f6Fk1c4qFkE2SzXHfH1ofP274PNiMpiY2n8qW07JfCvR80iyEp1HA14jf7KORZkcLHR17H5TePUK1f7bNr3GpRSzDXeddSe/5B4S7Pvg45cBf1fgybqTHK89HvE4hehMkqxE5/H4h6y/kZCI1Wdgtqv9y4E0u0yMlloKaqpi0b6SS0FxyoVr7G18whj0psfBWceMgTMApCtQ9DiSrETn8ZgoVxaqk46T11iLpYPLgQS7v4wxVr0iKCH+HEm2U3AJowGDPjNpID903o2qOwMf/prhycPpZ+snXYGix5F5VqJzaNBeE8/YslAGB19wnenwpWK1LmDQ4hvv7vC5c8b25Vum8XyaMpcrP/wVKudepg+Yzrsn3sXr82I0GC9+ESG6AWlZic7hM6C0gTeTrGS4TUzyNHT4UsHuL3OMdgNejniLkXnj+/JY3SK01w3vPM6MgTOodlazt3JvV4cnRLtJy0rgqve1OSTcaFGYLP7uJ69b43G23ZVn0Qql/Pu9rjiOmkxUx1fxNXs9LlfTOlQGgwdzoJWktcLlTmjzmiZTY6gbMFZbVgBujxWfz3zedqU0FnNThXWXO6H55OE6Hwuy+vPIjrOcyvkSg3Y+x4wpd6NQbD5cwOi4Ca2+nsWmUAb/ddwNPtpat9FgBHO8/zuv9mlcDv+/vyVBoWJxNIzoNJKsBM/efBpHRetDymc+mMysB1MAOFzQyGsPlbd5nQcWZ4YqTFTbs3gp04ryubG//Bq/qk8PHTdyyEY+n/dVAOocffn9K9vbvObn8+5l6IAP+fJtN2EwuC/5vfUGG7f8iI/3faXVfbb4c3zjrtzQ8z++uok6x4CmA146CcBSJvKyqy/fHvwa6e+uZKRlHH/b8A6OJZ9p9bpfzx9AUn//x8O/lldw6J3WvyhkXRPH7U/3AaC+0sfTc04BMP5mG7eszLi0NyrEBUiyElhsBjyNrbeYjOamb8cGo/8bc1uCrSp8iuTEY6xPG82gw9mkuMxgbpoMHD6qTymwmNueKBxshfXL2N3et9PrDO63nf2Hb8XbSsvKYnI0f26ub/7ztCQD0Oj2Ulyu8H5hOcYNj3L1uK/w8sDN6PQ6rM6k81807J/ZZFVt/rub4pq2K8BsU7gdmqNbY7cVLDqH0j24JEBubq4uLCzs6jB6pL9/qxx3g+amx9NJyIjQTfanAh9cbjPvqTS+0b8vP7af5TZPbNXz61Ye8f//3rD7DEtf3MFzX5rE3Ldv42OzkS/ZnDx53ZMsGL4gYi/nbvTxy9yTGC3wraIhEbuuiCyl1A6tde7Fj+w+ZIBFjDq21cnh9xtRnfAboD0mViemYfJauMnTdrehiJ45Y/uSZjPzt11lkPdfTDx7kCSDlQ9OfhDR1zFZFQYTeF3gcfXcL8Ki+5FkFYO01jjr/feorIkR/hXQUOaLoyDBzDSHAXMH51aJyLKYDNw6eSAb9pylZsSNmIbOZIajng9Ovk8ke1eUUqHfKVfdpZfWEqItkqxikLtBo73+b8Hh96Qiwmvkn0k2fAr+w70/stcWl+Xz2YNxeXy8WXwG5j/O7NpqzjWUc9B+MKKvY0n0/045JVmJCJJkFYNc9YHhxYmRH1rc4IljTVISmQ3JXOHrWIV10TkmD04hKzOBvxWdhME5zBp6PQAFJa9H9HWu+1Yqt6zMwJYmE45F5EQ9WSmlFiml8pRSyy9wTHY0Y4o1ztpO6gIENpvSOGk2cWdjbK3o2xMopfh89iC2Ha7keKWDvvN/zBiXmw/2/S2irzN2vo3xN9uwJsl3YRE5Uf1tCiYhrXU+YG8tKSml8oBnoxlXrAl2z1gj3bLyKf6VbCXeY+Krnn2RvbaIiM9eNQiAdTtPQupQZqVfQZHHTv0xqRUourdof/VZDNgDj0uBvJYHBBKZLCfbiawJBsbfbGPYjEtbcuJiir19eC8+jqvqbViUDKzojoak27h6RDqv7TyJ1prZuf+ORym2bfoekVrZ8ti2RrY9V8PZva6IXE8IiH6ySqV5IpIp7l0gY6SZW1ZmcO3DqRG97t/i01HAN1yRvWEvIuv27MGUltdTdKyKKYNnk2Aws7n2MOx/MyLXP7Cxgc1PVXOyKDar5IvOIZ3KIiIaHVVsSlSMd1iZrGQScHf2mUkDSLSaeGnrMcxGM7OHzOHdxER8G78P3ssvaWWV0YCiE0Q7WdmBYJG4VKDiUi+glFqqlCpUShWWlcmHYkfUl3upPOwODbSIhBfefopKk5G8+jYqnopuI8Fq4nNTBvGvT09TVe9i3tA8KgzwSd0x2PHny76+JTBwx1krXcEicqKdrFYDWYHHWUA+gFIqtb0X0Fqv0lrnaq1z+/TpE/kIY8DHr9Txx1vPsP35yAwt13VlbDjzGoNcPu5Glp3oCe6ZPhSXx8faHSe4ZvA1mAwmNg0YA+/+FBqrL+vawVGmwYnnQkRCVJOV1roIQiP+7MHnwNvBY5RSi4DcwN+iEwS7Zy5UlLbdvB62rb6L/RYD42r6YjPITfWeYFz/ZHKHpfHSR0dJMCUytd9UNiXY0I5KeP+py7p2cP6eK4ItdyGifs8q0DLK11qvCtuWE/Z4rdY6TWu9NtqxxQpXnb97JiLzYN7+If/nPILZa+Yb3j2Xfz0RNV+cPowjFQ4+LKlg3tB5HHWc4fDE22Dr76HqaIeva00ItqykG1BEjgywiEFN86wu85+/+G8c3/Y0b9ts9DEuYLTxXASiE9Fy05X9SU+w8JetR5kzZA4Am4ZN9q/b8vZ/d/i61iQDpjiFQT5dRATJr1MMaqpgcRndgGd3w9//nWf7ZqEx8h+5rS8OKLovq8nIHTmD2bj3LHhSmZgxkU3ndsCMf4fitXBiR4euOyjbwn8WDubzv5V7yiJyJFnFoKbagB3852+ogr/eQ3VcMn+3+Ih35nDzhLERjFBEy91XD8Xr07y87Rjzhs7j0/JPOZt9DyT0hQ0dmygsy9mLziDJKgZdVm1Anw9eXQrVJ/j9hM/jUy7uGvtF+YDqoYZlJJA3vi8vbjnCjAHXAvDu2e0w97twbAvs/WcXRyiEnySrGHTLzzO449k+pAzqQFXsd38KBzfgXPA4r5wrgIZRfH3GNZEPUkTN168bSZXDzfb9ZoYlD+PtY2/DlC9Bn3GQ///Ac2kjPLVP86fPnub3eafQPhlkISJDklUM6jfOwvAZcZjjL/Gff9/r8N5KuOqL/Mlkw4WdOf2+QILV1DmBiqjIHZ7O1OFp/KHgCHOHzGPbmW1Uumtg/uNQWQrb/3BJ11MGRc0pL7VnvLgbJFmJyJBkJdqn/CC8ej8MnIL7xp/x3O4/4WsYxvfm3drVkYkI+Pp1IzlpbyDRfTVe7eXNw2/CqDzImgubn/Dfp7wEwWkRkaySImKbJKsY43L42PDflXzwu0uoUuCshb/eAyYL3Pkif9n/Bg26gpkZd9I/Jb7zghVRM3dsX8b0S+S1j7yMTRvL66Wv+4ewz3/cX9HivScv6XrBCefOOmlZiciQZBVjGuw+dr1Sz6ev1rfvBK1h3QNQcQju+DOe5AE888kf8DUO4vvzbu/cYEXUGAyK+68dyb4ztYxPmsOn5Z9yuPow9J8IU+6Bj57xdwm2U6hlJcVsRYRIsooxlzzHquAX/hFhN/w3jLiWNXv/Rb3vDDnJixiakdCJkYpou+2qgQxMiaN4/0gMyuBvXQHMfQyMZsj/YbuvFRxp6pJkJSJEklWMuaQ5Vofy4e0fwcTbYcY38Gkfv9n5e3yN/fjB9Xd2cqQi2sxGA1+fM5KdR3yMSZ7Cv0r/hdYakgfArG/Cnr/DsY/ada1gfUCpvC4iRZJVjAm1rC5WF7DyMKz9KvS7Am77NSjFmn3/oMZ7kokJtzOqb3IUohXRdtfUoQxNt3H21BWcrDvJx2Uf+3fMfAgS+7d7ovDoefFcfV8SaSNkpKiIDElWMSZUF/BCFdddDlj9JUDD4hfBkoDL6+IXhb/C1ziQH91wd3SCFVFnMRl4ZP4Yjh0fidlg5Z8lgUnBlgSY9xic2A67X73odSbcksC1D6fSb5ylkyMWsUK+9sSYYMV1S1stK63hn/8BZ4vhnrWQ7l9+7Lc7XsThK2NW+qOM6ZcSrXDF5Xrq0iuL3KoVzxh/yRn7cN7a91e+8+EPsaBBA4YE+Nu9sH4RtPfSj0hXoLh80rKKMWabInO0mZSBbXxP2fo0fLoG5n0PRucBUOuq5YU9fwDHaH5yk4wA7O0MSrM84Xmq7bOoMRh52xLo8lWAtRG0AdwXbjHVOfpy+OQ1nK2Y0PkBi5ggySrGXHFrAkte68/0r7Vyz+lIAWx4DMbdArMfCW1+/P2n8ag67hh5P5mJ1ihGK7rKdeYicl0N4Erjhfiw6ukmLxjd4LSCr+2m1eETc1i74SWK9vxbFKIVsUCSlfCrPglr7oWMkbDwaYKLEZ2pO8ebx1djashm+dy8ro1RRI1S8N2EP+OsnEWxOY5PTWGTv61O/9+utltXFksdAE5XUmeGKWKIJKsY4/O2cv/A44RXvgTuRlj8EsQ1tboeyf8pPjx8M/sh4swdKHwreqzJ5oN8rrES7bXyG+uwph1GH5jd/q5AX+sfIVZzLQBOtyQrERmSrGLM3x8u5xdTjlOyuaFp4xvL4OQO+Nzvoc+Y0OaNJVv4pDqfTO98vjI1pwuiFV3tu7aXMFVfyYdxZk6psJaUJdC6crbeLWy11ADgkmQlIkSSVYxx1mq8bjDFBe43FD4HRS/ANctg/C2h41xeF997/7/Q7jR+f8t3ZL2qGJViqOdbzv1o4PumaU07DNqfsDxm8Jzf4raYg92AiVGKVPR2kqxijLM+bOHF49vhjW/7q2vP/W6z4x7N/x0N6iS3DX6Qcf0yuiJU0U18ybSFtPoBfJTg4rA3s2mHxQXKB844/7D2MFaLdAOKyJJkFWOCFSziDOf896lSBsHtfwBD07fjT88eYcOpF0nwTOZH8xd3Vaiim1AKvuPajTI5eFDdgk8HWtkK/2ALnxE8zadCWAL3rFwuqXQiIkOSVYxx1WsMyk3S+/f5l35Y/BLEp4X2+3w+vrH++2g0v8j7fxgN0v0n4GbfSfq7zBxLLeHXjrC5diY3GLznta7Mpgbuu/0a7r9zevSDFb2SJKsYorXGWetjzqSfYzy1xV/zr//EZsc8/MYzVPEx12Z+iZnDRndRpKK7UcB/OQ5gsFTx27gstrmuaNoRnCgcNpRdKUhLPootrrJL4hW9j5Rb6i3aUVbH67EybuBT5Ix+GcxO2HAHbGja/6r3Sjb1MZHWmMmvy74FB77ViQGLnmamp56rnQ62ZW7iodKHeNO0nHRDjX+isMkNLqt/SLtByiuJyJOWVSzRcNPUx6h1ZjRN7Aw46s3kh8n9MGgjLzgKMUrvn2jFMscpMDRQk7aL/6z5Fh4d+AgJDmV3NQ1l31z4HdZueJ7KI+4uiFT0NpKsYoVPYXKaMRg8JKUfaVaEtFGbucd8Azr+DCtqyhlBXZeFKbq3cd5GPuOsxprxPu/pUfyg7gH/iiGhicJm8Po/Vk6dy+HwybnUl3m7NmjRK0iyigUaaIwHrSDe0aybxq2N3O25F3taMdPrzdzjPdJlYYqe4SHHWQz4mDTgWV5uvIlfO+7y72gxUTg016pOugXF5ZNkFQtcVvCacBDPzgP3cOTUbAC82sDXnF/lQL8dDHCZ+VXDx10bp+gRBvrcfLGhgtLECq5LfYVfOL7I6oYbmiYKe/0ThYNVLJyytL2IAElWvZ3bFLjx7eJERTb5W3/Mzr1fQWv4VsNX2d6vmCSfj/+r+4T4ljM7hWjDg45zjPQ0cqzvNmZaP+S7df/O3xuvbTZR2GqpBiRZiciQZNWbeQ3+7j+DB6yNuNz+0jdmcx3L67/Oxr5HsBrreL52L5na08XBip4kDs0TtSeoNhhIH/Qy2ebdPFy7jBcaP+Mfyu4zMiSjCABXrXwJEpdPklVvpYGGeFAa4htAgTNQTeBd4wj+1eckJutp/remlDFe54WvJUQrxnob+abjLJutidze7xdcb9nOD+oe4H+cd6ANXrL6bMFkbAiV+BLickiy6o2CiUobIK4hNKCi3NUXZ1wt713zR8y2w/ys9jjXeGTkn+i4LzVUcLWrjl8k9uWRtCe53ZrP/zbcw9O+W7CYGliQ+wPSh8t0TnH55LeoN3JZ/Te5rQ3+CZvAJmcuL7mu48ji7+BKPcova48yz1XbxYGKns4A/LjuBHenjOSB1KH8iacZUFvOSseXmGQ5xswhb2LIqwOk+rq4PNKy6m08gQEVJheY3Ti0le/VPsh9zq+x79qV1Kae4pE9wyVRiYjp5/PwbM1hNIqlKcP5QtJq/pzyA37uvhOPNnLs/x5G15zu6jBFDyfJqjfxGfzdfwYv2trIu+5sbq76X16JSyVpxG8wm+q5Yc1PyHV0daCit8nyunim+ggOZeC+lBGMj/uE36f8hLfcMxh66k3UL8bh+sVk+Ps3YOdLUHkY/2xiIdpH6R78C5Obm6sLCwu7Oozu4UkFjgTQioOWdP7bcR8FvjGk91+NK/kgs121/KT2BKk+H1obMBikqoCIvE9M8XwteTiJ2sejJ03sXP0Gg8YWc2rSm0z27mGW+QA2r3/+FUkDYdgMGDYThs6EPuPAIN+fo0EptUNrndvVcVwKuWfVG2gNjfFon5Ff61v5n+rbSUp/j/Q+P8GrvDxcf5YlDeX+ZrQCpSRRic4xydPA89WHeSR5CMuGwKRpa0g6sZivLsvj5xv2c/+2I1xhOsPXR5xlbvwhbEc/hOK/+U+OT/MnrWEz/Ums/2QwykeU8JOWVU/l9UDtKRrOlXJy698YVfoCP3LfxSsJ/Ujq+wa1ZiezXLUsrz9DlgxNF1FWpwz8IH44G202Bp2Ywv8+8D3Gpo/l4Nlant5cwj8+PgXAjVf0455xmmlqH8bjW+Doh1BZ6r+IJRGGTGtKYINywBzXhe+q9+iJLauenazG9tOF+892XQDvPOz/e+4vI39traHuLNiPQdVRsB8J/H0UX+VRqDmJITCRt9xo4GeJYyhIdlJv8jLC08iy+jNc624+LP3/3ngFt8fG7Td8hYT4isjHLEQYj8/EAx//hh3XPoc7rp4bh9/Ig1c9yIiUEZyocvDHgsO8tvMkdoebzEQrt04ewLxxfZmW6cJ68iN/4jr6IZzb7b+g0eJPWMMCyWvI1WBNal8wnfl/tb26QwwA7zzM8Nv/99yRSt2vawO5NFFvYyulFgF2IFtrvfJS9/caWkNDlT8Z2Y+GElHob/sx8DQ2O6XOnM4J3Zf9zoEUm8azN8VHeXotpziJxsEsVy13V1cw213X6siZc5VX4HInYTK6ovMeRUwzGTxMKJ7LsH3XkPC7jfzfoZfYcHQDV/e/mptG3MR/Lrie79w0jnf2lfFq0Qle2nqM5z44QrzZyIyRQ8gd/nWmLHiUSRk+Es4WwtEP4OgWKPglvP8UKAP0nwTDZvm7DYfOhISMrn7bopNENVkppbIBtNb5SqkspVS21rqovft7HFd9WMuolYTkrGl2uNeaQoNtMBWWIZzKyOGQK50dNUnscps4Y9ZoazlpaafxWo7S4DsJwNi0sdzvHcHNR99ihLftJKS1wuX2fws1m+o77z0LEcZiqcXT0JevbfgpX04o5+X4DN44sZkfnN7Cjz54jGy3g8keB190O/hhupd9zit415XL+wensGnfIAAMeBluPMVoo2aUaRBjjB7GqJMM0pUknivEcHonbP2t/wUNXjB6wejx/x2+EGT2N7vgJyAiJdotq8XAxsDjUiAPKLqE/c24nWZO7mxxP0ZrQJORZSIuSQGa6lNu6s568Jd20KjAMaAxmhX9xpnQ2of2aU7vcaI9XrTWoT8APu3DlqmIT1d4tabB7qF6dyr6aD7G9dMwKhdm5cFscGI2NGI11WPCh0eBF4VHgQMzFb5EKnQKp/VITutUjhuSOGRN5KRKwqU0CfUufK4alOUMButePIPt+Ay+0D9UhtfJJIeDMfUWrqxIo7/7SGDPlZwMPDIaXfTP/DT0IzldNhlnIFFZzLUYDFL+RkSH1VyLo6EvTlciaXHlfP7wED6H5kCcZnOKj10JSfwhPhGfzX98kq+eod4NTHa9zdUNybhdadS7+lLt7sNRVz8+rr8Wny+O8iQP+MworRhd7WGK6SBXmfcz3nKIkcbjxBtcKKBO26g0xFNriMO7rxbvyb9iMhoxGEwYjAYMBhNGgxGDwUjqcAumOBMGg5H6s+BuMKCUAaWMKGVAKyPKYMCSaCZjuAVlNKJ9Bs7u84IyopUBlBEwgDKglYG04VZs6WZQBmqrEqmpSobU8+8hKyMMnNS0cOWZ3S68rtZv0ST2M5Iy0P+J0Fjjo6Kk7cUt+02wYLL6F6+rPOymwe4j/mxax/4xu1i0k1UqUBn2vGWb/WL7mzmoKrhlV07rOz+5hKg+vvDu0K9MSdNzDegkBRPDj1RAXOBP6gWu6AEqAn+aWACf20J8fTrx9WnEnx1PUnV/kisHkVw5mC9N+jGT+38A+Fdh3fTpg61ePSXxGEvvmB16vnbDizS6/PFYzTIZWETP/JnfRWsDSQmncbkTefmN10L7EoFZwDRzAxX9D9B/5kqcfQ5xzGjlE5VOVTJ4LGeAM+ddN7wexqnAn9dDW/qfd7zSGsVH4PkIFajZfN5i2JUtN1xAez9fils8NwK7Xmj92M7oQ9rVCdfsIlEdYKGUegZ4RmtdpJTKA27QWq9o7/7AMUuBpQAWI5Nc3ktKSxE1LI0htU7iKx0c6KoYgnEAHK3i+MWOTTMPHgJQ5T5xPPxxJGLo7J9Fe+K90M+iI++3I+cMS2NIjSMlFV+SvaM/20j821zK78Xlauv3qif+H+nMGLrLz6K8nuQ6p47vyjguVbRbVnYgPfA4lZZNi4vvR2u9CljVGcF1hFKqsKcNAe0s8rNo4v9Z2OVngfxehJOfRcdFe7r4aiAr8DgLyAdQSqVeaL8QQojYFtVkFRzZF+jis4eN9Hv7IvuFEELEsKjPswp047XclnOh/d1cT4u3M8nPoon8LJrIz6KJ/Cw6qEdXsOiulFLLe/WEZiFEh8nnQ8dIlcgIC3RhTu3qOLpaYNQmwMiWIzp7u5ipwtIOsfx70Br5fOg4qccvIi7wHzI/0KWbFXgeE8KrsAD24PNYFMu/ByLyJFlFUKA8lIxg9I/kDH4wldI0wjMWLMbfqoKmKiyxKpZ/D84jnw+XR7oBIyv94of0fi0GyWTjn5IQK1K5hCosvVmM/x60Rj4fLoMkq0sQ1v8erjRQeFe+NbUQ6ALbKFMQYpv8HkirKhIkWV2Ciwyrz1JKZYU97tkV4y/iQok77HleDA4wsHORKiwxKBZ/D1qKqc+HziDJKkK01msh9CGe2rXRdL6LzYdTSi0NfkAppfJi6FvlaiBYTifmq7DE8O9BM7H2+dAZZJ6ViLjAqK81+O/dpAN3xNKHVOADqRTI6oGT3CMm1n8PRGRJshJCCNHtydB1IYQQ3Z4kKyGEEN2eJCshhBDdniQrIYQQ3Z4kKyGEEN2eJCshhBDdniQrIYQQ3Z4kKyGEEN2eJCshhBDdniQrISJMKZWtlCpRSq0Je57axWEJ0aNJshIi8vKAHOCZYHV6rbW9SyMSooeT2oBCdJJAaypda13a1bEI0dNJshKiEwS7/aRFJURkSDegEBEWXGQvmKjCFt0TQnSQLL4oRAQFlnDPBSqVUvn471/Z8a9vJYToIGlZCREhYV1/q/CvEnwYmCoLDgpx+eSelRBCiG5PWlZCCCG6PUlWQgghuj1JVkIIIbo9SVZCCCG6PUlWQgghuj1JVkIIIbo9SVZCCCG6PUlWQgghuj1JVkIIIbq9/w98TlGvVxfG1wAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -16403,7 +16087,7 @@ Making mixmod
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># for a single pair of pdfs. (the 15th in each ensemble)</span>
-<span class="n">klds</span> <span class="o">=</span> <span class="n">ens_n</span><span class="o">.</span><span class="n">kld</span><span class="p">(</span><span class="n">ens_s</span><span class="p">,</span> <span class="n">limits</span><span class="o">=</span><span class="n">all_lims</span><span class="p">[</span><span class="mi">0</span><span class="p">])[</span><span class="mi">15</span><span class="p">]</span>
+<span class="n">klds</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">metrics</span><span class="o">.</span><span class="n">calculate_kld</span><span class="p">(</span><span class="n">ens_n</span><span class="p">,</span> <span class="n">ens_s</span><span class="p">,</span> <span class="n">limits</span><span class="o">=</span><span class="n">symm_lims</span><span class="p">)</span>
 <span class="nb">print</span><span class="p">(</span><span class="n">klds</span><span class="p">)</span>
 </pre></div>
 
@@ -16424,56 +16108,23 @@ Making mixmod
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>[-2.26209442e-06 -5.22381128e-06 -8.21403501e-06 -1.12278108e-05
- -1.42602342e-05 -1.73064535e-05 -2.03616734e-05 -2.34211569e-05
- -2.64802286e-05 -2.95342775e-05 -3.25787589e-05 -3.56091979e-05
- -3.86211912e-05 -4.16104100e-05 -4.45726023e-05 -4.75035953e-05
- -5.03992978e-05 -5.32557025e-05 -5.60688882e-05 -5.88350221e-05
- -6.15503620e-05 -6.42112586e-05 -6.68141571e-05 -6.93556000e-05
- -7.18322286e-05 -7.42407851e-05 -7.65781150e-05 -7.88411683e-05
- -8.10270020e-05 -8.31327817e-05 -8.51557837e-05 -8.70933963e-05
- -8.89431221e-05 -9.07025793e-05 -9.23695038e-05 -9.39417505e-05
- -9.54172952e-05 -9.67942361e-05 -9.80707954e-05 -9.92453205e-05
- -1.00316286e-04 -1.01282296e-04 -1.02142082e-04 -1.02894509e-04
- -1.03538574e-04 -1.04073407e-04 -1.04498276e-04 -1.04812582e-04
- -1.05015867e-04 -1.05107809e-04 -1.05088229e-04 -1.04957087e-04
- -1.04714485e-04 -1.04360671e-04 -1.03896036e-04 -1.03321114e-04
- -1.02636589e-04 -1.01843289e-04 -1.00942192e-04 -9.99344224e-05
- -9.88212567e-05 -9.76041198e-05 -9.62845877e-05 -9.48643879e-05
- -9.33453995e-05 -9.17296544e-05 -9.00193372e-05 -8.82167856e-05
- -8.63244912e-05 -8.43450992e-05 -8.22814089e-05 -8.01363742e-05
- -7.79131029e-05 -7.56148575e-05 -7.32450547e-05 -7.08072655e-05
- -6.83052151e-05 -6.57427824e-05 -6.31239999e-05 -6.04530531e-05
- -5.77342804e-05 -5.49721720e-05 -5.21713696e-05 -4.93366658e-05
- -4.64730026e-05 -4.35854713e-05 -4.06793110e-05 -3.77599071e-05
- -3.48327911e-05 -3.19036380e-05 -2.89782657e-05 -2.60626330e-05
- -2.31628380e-05 -2.02851158e-05 -1.74358373e-05 -1.46215061e-05
- -1.18487569e-05 -9.12435256e-06 -6.45518163e-06 -3.84825547e-06
- -1.31052154e-06  1.15518502e-06  3.55015792e-06  5.87578596e-06
-  8.13337174e-06  1.03241341e-05  1.24492106e-05  1.45096601e-05
-  1.65064654e-05  1.84405359e-05  2.03127102e-05  2.21237593e-05
-  2.38743891e-05  2.55652432e-05  2.71969063e-05  2.87699070e-05
-  3.02847204e-05  3.17417718e-05  3.31414393e-05  3.44840571e-05
-  3.57699188e-05  3.69992802e-05  3.81723626e-05  3.92893563e-05
-  4.03504231e-05  4.13557004e-05  4.23053037e-05  4.31993301e-05
-  4.40378616e-05  4.48209681e-05  4.55487107e-05  4.62211453e-05
-  4.68383249e-05  4.74003038e-05  4.79071400e-05  4.83588989e-05
-  4.87556561e-05  4.90975005e-05  4.93845378e-05  4.96168928e-05
-  4.97947135e-05  4.99181729e-05  4.99874731e-05  5.00028473e-05
-  4.99645632e-05  4.98729258e-05  4.97282800e-05  4.95310137e-05
-  4.92815599e-05  4.89804001e-05  4.86280662e-05  4.82251436e-05
-  4.77722733e-05  4.72701544e-05  4.67195466e-05  4.61212721e-05
-  4.54762184e-05  4.47853399e-05  4.40496601e-05  4.32702738e-05
-  4.24483487e-05  4.15851274e-05  4.06819290e-05  3.97401512e-05
-  3.87612710e-05  3.77468469e-05  3.66985203e-05  3.56180161e-05
-  3.45071446e-05  3.33678022e-05  3.22019728e-05  3.10117281e-05
-  2.97992291e-05  2.85667260e-05  2.73165598e-05  2.60511620e-05
-  2.47730553e-05  2.34848542e-05  2.21892647e-05  2.08890849e-05
-  1.95872051e-05  1.82866073e-05  1.69903656e-05  1.57016459e-05
-  1.44237056e-05  1.31598936e-05  1.19136496e-05  1.06885041e-05
-  9.48807783e-06  8.31608155e-06  7.17631562e-06  6.07266971e-06
-  5.00912249e-06  3.98974147e-06  3.01868288e-06  2.10019170e-06
-  1.23860183e-06  4.38336438e-07 -2.96091428e-07 -9.60078005e-07]
+<pre>[0.00328146 0.00054128 0.00336019 0.00313608 0.00309157 0.00439593
+ 0.00351473 0.00401957 0.00307561 0.00071542 0.00399572 0.00071199
+ 0.00020325 0.00094967 0.00241168 0.00375948 0.00220818 0.0030863
+ 0.00087861 0.00405013 0.00232632 0.00215408 0.00367854 0.00158009
+ 0.00425325 0.00375375 0.00304016 0.00358496 0.0018729  0.00274755
+ 0.00328138 0.00191869 0.00110029 0.00266608 0.00426591 0.0032709
+ 0.00099753 0.00148295 0.004339   0.00128665 0.0034808  0.00202899
+ 0.00317622 0.00062753 0.00030643 0.00220329 0.00193671 0.0026318
+ 0.00346929 0.00288634 0.00097727 0.00379207 0.00123326 0.00201153
+ 0.00345742 0.00339039 0.00340414 0.00334835 0.00324942 0.00234062
+ 0.00291409 0.00192987 0.00339078 0.00449794 0.0016507  0.00100137
+ 0.00282526 0.00433243 0.0037402  0.00143214 0.00249251 0.00273985
+ 0.00383852 0.00032115 0.00387173 0.00048201 0.00359615 0.00135482
+ 0.00343967 0.00069775 0.00178008 0.00276994 0.0044026  0.0042397
+ 0.00361834 0.00195354 0.00372586 0.00249882 0.00290852 0.00372111
+ 0.001671   0.001206   0.00316984 0.00365273 0.00424861 0.00378746
+ 0.00405003 0.00343775 0.00375975 0.00236313]
 </pre>
 </div>
 </div>
@@ -16493,7 +16144,7 @@ Making mixmod
 <span class="k">for</span> <span class="n">ensemble</span> <span class="ow">in</span> <span class="n">ensembles</span><span class="p">[</span><span class="mi">1</span><span class="p">:]:</span>
     <span class="n">D</span> <span class="o">=</span> <span class="p">[]</span>
     <span class="k">for</span> <span class="n">lims</span> <span class="ow">in</span> <span class="n">all_lims</span><span class="p">:</span>
-        <span class="n">klds</span> <span class="o">=</span> <span class="n">ens_n</span><span class="o">.</span><span class="n">kld</span><span class="p">(</span><span class="n">ensemble</span><span class="p">,</span> <span class="n">limits</span><span class="o">=</span><span class="n">lims</span><span class="p">)</span>
+        <span class="n">klds</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">metrics</span><span class="o">.</span><span class="n">calculate_kld</span><span class="p">(</span><span class="n">ens_n</span><span class="p">,</span> <span class="n">ensemble</span><span class="p">,</span> <span class="n">limits</span><span class="o">=</span><span class="n">lims</span><span class="p">)</span>
         <span class="n">D</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="s2">&quot;</span><span class="si">%.2e</span><span class="s2"> +- </span><span class="si">%.2e</span><span class="s2">&quot;</span> <span class="o">%</span> <span class="p">(</span><span class="n">klds</span><span class="o">.</span><span class="n">mean</span><span class="p">(),</span> <span class="n">klds</span><span class="o">.</span><span class="n">std</span><span class="p">()))</span>
     <span class="nb">print</span><span class="p">(</span><span class="n">ensemble</span><span class="o">.</span><span class="n">gen_class</span><span class="o">.</span><span class="n">name</span> <span class="o">+</span> <span class="s1">&#39; approximation: KLD over 1, 2, 3, sigma ranges = &#39;</span> <span class="o">+</span> <span class="nb">str</span><span class="p">(</span><span class="n">D</span><span class="p">))</span>
 </pre></div>
@@ -16515,11 +16166,11 @@ Making mixmod
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>hist approximation: KLD over 1, 2, 3, sigma ranges = [&#39;5.15e-05 +- 5.32e-04&#39;, &#39;7.61e-05 +- 5.39e-04&#39;, &#39;7.15e-05 +- 4.69e-04&#39;]
-interp approximation: KLD over 1, 2, 3, sigma ranges = [&#39;-1.41e-04 +- 1.79e-04&#39;, &#39;-4.01e-05 +- 1.84e-04&#39;, &#39;3.97e-06 +- 1.68e-04&#39;]
-spline approximation: KLD over 1, 2, 3, sigma ranges = [&#39;-1.27e-05 +- 4.25e-05&#39;, &#39;-1.27e-06 +- 3.63e-05&#39;, &#39;-1.10e-06 +- 3.05e-05&#39;]
-quant approximation: KLD over 1, 2, 3, sigma ranges = [&#39;-1.16e-04 +- 3.49e-04&#39;, &#39;2.52e-05 +- 5.49e-04&#39;, &#39;1.36e-04 +- 5.87e-04&#39;]
-mixmod approximation: KLD over 1, 2, 3, sigma ranges = [&#39;-4.07e-06 +- 2.45e-04&#39;, &#39;3.21e-06 +- 2.12e-04&#39;, &#39;1.23e-05 +- 1.80e-04&#39;]
+<pre>hist approximation: KLD over 1, 2, 3, sigma ranges = [&#39;1.16e-02 +- 3.49e-03&#39;, &#39;2.76e-02 +- 5.08e-03&#39;, &#39;3.72e-02 +- 5.09e-03&#39;]
+interp approximation: KLD over 1, 2, 3, sigma ranges = [&#39;3.16e-02 +- 1.09e-02&#39;, &#39;2.33e-02 +- 2.57e-03&#39;, &#39;1.01e-02 +- 1.84e-03&#39;]
+spline approximation: KLD over 1, 2, 3, sigma ranges = [&#39;2.68e-03 +- 1.17e-03&#39;, &#39;7.57e-04 +- 2.08e-03&#39;, &#39;1.06e-03 +- 2.69e-04&#39;]
+quant_piecewise approximation: KLD over 1, 2, 3, sigma ranges = [&#39;4.72e-02 +- 1.21e-02&#39;, &#39;1.60e-01 +- 7.84e-02&#39;, &#39;3.76e-01 +- 7.41e-02&#39;]
+mixmod approximation: KLD over 1, 2, 3, sigma ranges = [&#39;4.96e-03 +- 1.52e-02&#39;, &#39;6.73e-03 +- 7.95e-03&#39;, &#39;4.07e-03 +- 3.79e-03&#39;]
 </pre>
 </div>
 </div>
@@ -16543,7 +16194,7 @@ mixmod approximation: KLD over 1, 2, 3, sigma ranges = [&#39;-4.07e-06 +- 2.45e-
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">ensemble</span> <span class="ow">in</span> <span class="n">ensembles</span><span class="p">[</span><span class="mi">1</span><span class="p">:]:</span>
     <span class="n">D</span> <span class="o">=</span> <span class="p">[]</span>
     <span class="k">for</span> <span class="n">lims</span> <span class="ow">in</span> <span class="n">all_lims</span><span class="p">:</span>
-        <span class="n">rmses</span> <span class="o">=</span> <span class="n">ens_n</span><span class="o">.</span><span class="n">rmse</span><span class="p">(</span><span class="n">ensemble</span><span class="p">,</span> <span class="n">limits</span><span class="o">=</span><span class="n">lims</span><span class="p">)</span>
+        <span class="n">rmses</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">metrics</span><span class="o">.</span><span class="n">calculate_rmse</span><span class="p">(</span><span class="n">ens_n</span><span class="p">,</span> <span class="n">ensemble</span><span class="p">,</span> <span class="n">limits</span><span class="o">=</span><span class="n">lims</span><span class="p">)</span>
         <span class="n">D</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="s2">&quot;</span><span class="si">%.2e</span><span class="s2"> +- </span><span class="si">%.2e</span><span class="s2">&quot;</span> <span class="o">%</span> <span class="p">(</span><span class="n">rmses</span><span class="o">.</span><span class="n">mean</span><span class="p">(),</span> <span class="n">rmses</span><span class="o">.</span><span class="n">std</span><span class="p">()))</span>
     <span class="nb">print</span><span class="p">(</span><span class="n">ensemble</span><span class="o">.</span><span class="n">gen_class</span><span class="o">.</span><span class="n">name</span> <span class="o">+</span> <span class="s1">&#39; approximation: RMSE over 1, 2, 3, sigma ranges = &#39;</span> <span class="o">+</span> <span class="nb">str</span><span class="p">(</span><span class="n">D</span><span class="p">))</span>
 </pre></div>
@@ -16565,11 +16216,11 @@ mixmod approximation: KLD over 1, 2, 3, sigma ranges = [&#39;-4.07e-06 +- 2.45e-
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>hist approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;2.86e-03 +- 2.10e-03&#39;, &#39;2.04e-03 +- 1.49e-03&#39;, &#39;1.34e-03 +- 1.19e-03&#39;]
-interp approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;1.33e-03 +- 1.04e-03&#39;, &#39;7.37e-04 +- 6.08e-04&#39;, &#39;5.08e-04 +- 4.53e-04&#39;]
-spline approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;2.44e-04 +- 1.99e-04&#39;, &#39;1.33e-04 +- 1.24e-04&#39;, &#39;8.43e-05 +- 9.18e-05&#39;]
-quant approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;2.22e-03 +- 2.38e-03&#39;, &#39;1.96e-03 +- 1.75e-03&#39;, &#39;1.48e-03 +- 1.39e-03&#39;]
-mixmod approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;1.41e-03 +- 1.02e-03&#39;, &#39;8.22e-04 +- 6.72e-04&#39;, &#39;5.21e-04 +- 5.16e-04&#39;]
+<pre>hist approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;4.98e-02 +- 6.10e-03&#39;, &#39;5.02e-02 +- 5.34e-03&#39;, &#39;4.36e-02 +- 3.81e-03&#39;]
+interp approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;2.35e-02 +- 3.98e-03&#39;, &#39;1.89e-02 +- 2.86e-03&#39;, &#39;1.65e-02 +- 2.40e-03&#39;]
+spline approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;4.09e-03 +- 1.76e-03&#39;, &#39;3.40e-03 +- 1.26e-03&#39;, &#39;2.88e-03 +- 1.02e-03&#39;]
+quant_piecewise approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;4.57e-02 +- 5.57e-03&#39;, &#39;5.28e-02 +- 3.77e-03&#39;, &#39;5.02e-02 +- 2.62e-03&#39;]
+mixmod approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;2.33e-02 +- 8.14e-03&#39;, &#39;2.04e-02 +- 5.86e-03&#39;, &#39;1.73e-02 +- 4.71e-03&#39;]
 </pre>
 </div>
 </div>
@@ -16627,36 +16278,208 @@ mixmod approximation: RMSE over 1, 2, 3, sigma ranges = [&#39;1.41e-03 +- 1.02e-
 <pre>dict_keys([&#39;meta&#39;, &#39;data&#39;])
 
 Meta Data
-pdf_name pdf_version
--------- -----------
-    norm           0
+{&#39;pdf_name&#39;: [&#39;norm&#39;], &#39;pdf_version&#39;: [0]}
 
 Object Data
-       loc [1]            scale [1]     
---------------------- ------------------
-  0.21890181476361925  1.056285515199821
-  -0.9353465163053121  1.026997357837372
-   0.0790311297883819 1.0650292686359373
-   0.2817677311967628 1.0609266256396983
- -0.24968255449689325  1.074816209393585
- -0.26335093519888186 0.9037322517071256
- -0.42948520774760524 0.9612918688186005
-  -0.4387296971766421 0.9016267220210851
-  -0.5721718878022877 0.9456574782851268
-  -0.9245553404486575 0.9837884735516019
-                  ...                ...
- -0.11981840164786872 1.0142932436528753
-   -0.807956492346696 0.9467640761369589
-  -0.8460750962310981 0.9940399193900734
-   0.3498014730068775 1.0359665513079788
-  0.08250538556297093 1.0266698031123653
- -0.18080125328979002 0.9367304078396651
--0.024151853833798587 1.0119490615751972
-   0.2985208224451117 0.9384862752521598
-  0.16449944543187622 1.0453962103896604
- -0.12600999108425714 1.0085541146917858
-  -0.7155224408919922 0.9351607298580357
-Length = 100 rows
+{&#39;loc&#39;: array([[ 0.21890181],
+       [-0.93534652],
+       [ 0.07903113],
+       [ 0.28176773],
+       [-0.24968255],
+       [-0.26335094],
+       [-0.42948521],
+       [-0.4387297 ],
+       [-0.57217189],
+       [-0.92455534],
+       [ 0.34858641],
+       [-0.91406855],
+       [-0.98414987],
+       [-0.86060038],
+       [-0.69508709],
+       [-0.38516899],
+       [ 0.75300729],
+       [-0.27768773],
+       [ 0.89066815],
+       [ 0.07691531],
+       [-0.60425626],
+       [ 0.70749606],
+       [ 0.12587212],
+       [-0.82361134],
+       [-0.11546958],
+       [ 0.49798422],
+       [-0.26760305],
+       [ 0.20776273],
+       [ 0.6291673 ],
+       [-0.59647901],
+       [-0.00848918],
+       [-0.76643467],
+       [-0.79806762],
+       [-0.4022234 ],
+       [-0.08351926],
+       [-0.0671515 ],
+       [-0.91445451],
+       [ 0.71709338],
+       [-0.17404626],
+       [ 0.85493452],
+       [-0.50612038],
+       [ 0.58551973],
+       [ 0.12310108],
+       [ 0.89065211],
+       [ 0.98553825],
+       [-0.54523168],
+       [-0.64930249],
+       [-0.6904524 ],
+       [ 0.10365389],
+       [ 0.48165105],
+       [-0.81445327],
+       [ 0.50516354],
+       [-0.84387341],
+       [-0.7536708 ],
+       [-0.02983834],
+       [ 0.52625015],
+       [ 0.0251668 ],
+       [-0.53713988],
+       [-0.19856034],
+       [ 0.64554989],
+       [ 0.5297811 ],
+       [-0.69668053],
+       [-0.29724201],
+       [-0.07584431],
+       [ 0.67563132],
+       [-0.89806725],
+       [-0.5085701 ],
+       [-0.00230427],
+       [ 0.24542697],
+       [-0.85116672],
+       [ 0.7220289 ],
+       [ 0.4094468 ],
+       [ 0.36862184],
+       [ 0.95756083],
+       [-0.34470474],
+       [-0.92832706],
+       [-0.33563417],
+       [ 0.8647574 ],
+       [ 0.36856708],
+       [-0.9321885 ],
+       [-0.80126137],
+       [ 0.36804869],
+       [ 0.06692571],
+       [ 0.2286091 ],
+       [ 0.29082508],
+       [ 0.7435764 ],
+       [ 0.12353467],
+       [-0.70184026],
+       [-0.5470406 ],
+       [-0.1198184 ],
+       [-0.80795649],
+       [-0.8460751 ],
+       [ 0.34980147],
+       [ 0.08250539],
+       [-0.18080125],
+       [-0.02415185],
+       [ 0.29852082],
+       [ 0.16449945],
+       [-0.12600999],
+       [-0.71552244]]), &#39;scale&#39;: array([[1.05628552],
+       [1.02699736],
+       [1.06502927],
+       [1.06092663],
+       [1.07481621],
+       [0.90373225],
+       [0.96129187],
+       [0.90162672],
+       [0.94565748],
+       [0.98378847],
+       [0.93155093],
+       [1.012214  ],
+       [1.04801547],
+       [1.03997191],
+       [0.94610651],
+       [0.94807385],
+       [0.92175172],
+       [1.06866137],
+       [1.00618853],
+       [0.97491666],
+       [1.03004701],
+       [0.97416184],
+       [1.01915825],
+       [0.94269106],
+       [0.94427332],
+       [0.90704054],
+       [1.0774135 ],
+       [1.01872588],
+       [1.08736909],
+       [0.97311218],
+       [1.07810052],
+       [0.95297913],
+       [1.08745088],
+       [1.0863323 ],
+       [0.94525947],
+       [1.07747709],
+       [0.90734377],
+       [1.08832187],
+       [0.92557912],
+       [0.95820683],
+       [0.9323448 ],
+       [1.09059329],
+       [1.08510689],
+       [1.08773728],
+       [0.96730724],
+       [1.08696857],
+       [1.06120851],
+       [0.92081073],
+       [1.04875741],
+       [1.02002314],
+       [1.09783552],
+       [0.90057407],
+       [0.99066761],
+       [0.95133835],
+       [1.05478905],
+       [0.93307612],
+       [1.06184084],
+       [0.93248613],
+       [1.06442614],
+       [0.99735603],
+       [0.9907961 ],
+       [1.02248052],
+       [1.0229267 ],
+       [0.91247745],
+       [1.0917688 ],
+       [0.94950303],
+       [1.01468626],
+       [0.93893304],
+       [0.99063856],
+       [0.93046741],
+       [0.91248718],
+       [1.07302298],
+       [0.94408806],
+       [1.06640794],
+       [0.94751646],
+       [1.06756101],
+       [0.98475575],
+       [0.92380544],
+       [0.99388315],
+       [0.9683748 ],
+       [0.93527174],
+       [1.08436163],
+       [0.92703754],
+       [0.92987075],
+       [0.99505897],
+       [0.97200232],
+       [1.01325771],
+       [0.9285457 ],
+       [0.98174109],
+       [1.01429324],
+       [0.94676408],
+       [0.99403992],
+       [1.03596655],
+       [1.0266698 ],
+       [0.93673041],
+       [1.01194906],
+       [0.93848628],
+       [1.04539621],
+       [1.00855411],
+       [0.93516073]])}
 </pre>
 </div>
 </div>
@@ -16678,7 +16501,7 @@ Length = 100 rows
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">suffix_list</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;_n&#39;</span><span class="p">,</span> <span class="s1">&#39;_h&#39;</span><span class="p">,</span> <span class="s1">&#39;_i&#39;</span><span class="p">,</span> <span class="s1">&#39;_s&#39;</span><span class="p">,</span> <span class="s1">&#39;_q&#39;</span><span class="p">,</span> <span class="s1">&#39;_m&#39;</span><span class="p">]</span>
-<span class="n">filetypes</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;fits&#39;</span><span class="p">,</span> <span class="s1">&#39;hdf5&#39;</span><span class="p">]</span>
+<span class="n">filetypes</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;fits&#39;</span><span class="p">,</span> <span class="s1">&#39;hf5&#39;</span><span class="p">]</span>
 <span class="k">for</span> <span class="n">ens</span><span class="p">,</span> <span class="n">suffix</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span><span class="n">ensembles</span><span class="p">,</span> <span class="n">suffix_list</span><span class="p">):</span>
     <span class="k">for</span> <span class="n">ft</span> <span class="ow">in</span> <span class="n">filetypes</span><span class="p">:</span>
 
@@ -16718,70 +16541,17 @@ Length = 100 rows
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
 <pre>_n fits 0.0 0.0
-_n hdf5 0.0 0.0
+_n hf5 0.0 0.0
 _h fits -1.1102230246251565e-16 5.551115123125783e-17
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/Users/echarles/miniconda3/envs/qp-py39/lib/python3.9/site-packages/astropy/io/misc/hdf5.py:283: UserWarning: table path was not set via the path= argument; using default path __astropy_table__
-  warnings.warn(&#34;table path was not set via the path= argument; &#34;
-/Users/echarles/miniconda3/envs/qp-py39/lib/python3.9/site-packages/astropy/io/misc/hdf5.py:283: UserWarning: table path was not set via the path= argument; using default path __astropy_table__
-  warnings.warn(&#34;table path was not set via the path= argument; &#34;
-/Users/echarles/miniconda3/envs/qp-py39/lib/python3.9/site-packages/astropy/io/misc/hdf5.py:283: UserWarning: table path was not set via the path= argument; using default path __astropy_table__
-  warnings.warn(&#34;table path was not set via the path= argument; &#34;
-/Users/echarles/miniconda3/envs/qp-py39/lib/python3.9/site-packages/astropy/io/misc/hdf5.py:283: UserWarning: table path was not set via the path= argument; using default path __astropy_table__
-  warnings.warn(&#34;table path was not set via the path= argument; &#34;
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>_h hdf5 -1.1102230246251565e-16 5.551115123125783e-17
+_h hf5 -1.1102230246251565e-16 5.551115123125783e-17
 _i fits -1.1102230246251565e-16 5.551115123125783e-17
-_i hdf5 -1.1102230246251565e-16 5.551115123125783e-17
+_i hf5 -1.1102230246251565e-16 5.551115123125783e-17
 _s fits 0.0 0.0
-_s hdf5 0.0 0.0
-(9,)
-(100, 9)
-(9,)
-(100, 9)
+_s hf5 0.0 0.0
 _q fits 0.0 0.0
-(9,)
-(100, 9)
-(9,)
-(100, 9)
-_q hdf5 0.0 0.0
+_q hf5 0.0 0.0
 _m fits 0.0 0.0
-_m hdf5 0.0 0.0
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/Users/echarles/miniconda3/envs/qp-py39/lib/python3.9/site-packages/astropy/io/misc/hdf5.py:283: UserWarning: table path was not set via the path= argument; using default path __astropy_table__
-  warnings.warn(&#34;table path was not set via the path= argument; &#34;
-/Users/echarles/miniconda3/envs/qp-py39/lib/python3.9/site-packages/astropy/io/misc/hdf5.py:283: UserWarning: table path was not set via the path= argument; using default path __astropy_table__
-  warnings.warn(&#34;table path was not set via the path= argument; &#34;
+_m hf5 0.0 0.0
 </pre>
 </div>
 </div>
@@ -16838,7 +16608,7 @@ norm: [&#39;9.92e-01 +- 6.50e-03&#39;, &#39;-1.02e-01 +- 5.32e-01&#39;, &#39;1.2
 hist: [&#39;9.93e-01 +- 6.63e-03&#39;, &#39;-1.03e-01 +- 5.31e-01&#39;, &#39;1.39e+00 +- 2.36e-01&#39;]
 interp: [&#39;9.87e-01 +- 8.52e-03&#39;, &#39;-9.91e-02 +- 5.18e-01&#39;, &#39;1.34e+00 +- 2.16e-01&#39;]
 spline: [&#39;9.91e-01 +- 6.62e-03&#39;, &#39;-1.02e-01 +- 5.33e-01&#39;, &#39;1.23e+00 +- 2.48e-01&#39;]
-quant: [&#39;9.90e-01 +- 1.62e-02&#39;, &#39;-9.92e-02 +- 5.20e-01&#39;, &#39;1.44e+00 +- 1.93e-01&#39;]
+quant_piecewise: [&#39;9.90e-01 +- 1.63e-02&#39;, &#39;-9.93e-02 +- 5.20e-01&#39;, &#39;1.44e+00 +- 1.94e-01&#39;]
 mixmod: [&#39;9.93e-01 +- 6.73e-03&#39;, &#39;-1.05e-01 +- 5.37e-01&#39;, &#39;1.26e+00 +- 2.52e-01&#39;]
 </pre>
 </div>
@@ -16846,34 +16616,6 @@ mixmod: [&#39;9.93e-01 +- 6.73e-03&#39;, &#39;-1.05e-01 +- 5.37e-01&#39;, &#39;1
 
 </div>
 
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span> 
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span> 
-</pre></div>
-
-     </div>
-</div>
-</div>
 </div>
 
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">

--- a/docs/practical_example.html
+++ b/docs/practical_example.html
@@ -83,6 +83,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;
 }
 
+/* tiny scrollbar */
+
+.jp-scrollbar-tiny {
+  scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;
+  scrollbar-width: thin;
+}
+
 /*
  * Webkit scrollbar styling
  */
@@ -146,6 +153,29 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   .CodeMirror-vscrollbar::-webkit-scrollbar-track:vertical {
   border-top: var(--jp-scrollbar-endpad) solid transparent;
   border-bottom: var(--jp-scrollbar-endpad) solid transparent;
+}
+
+/* tiny scrollbar */
+
+.jp-scrollbar-tiny::-webkit-scrollbar,
+.jp-scrollbar-tiny::-webkit-scrollbar-corner {
+  background-color: transparent;
+  height: 4px;
+  width: 4px;
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-thumb {
+  background: rgba(var(--jp-scrollbar-thumb-color), 0.5);
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-track:horizontal {
+  border-left: 0px solid transparent;
+  border-right: 0px solid transparent;
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-track:vertical {
+  border-top: 0px solid transparent;
+  border-bottom: 0px solid transparent;
 }
 
 /*
@@ -338,6 +368,33 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.lm-close-icon {
+	border:1px solid transparent;
+  background-color: transparent;
+  position: absolute;
+	z-index:1;
+	right:3%;
+	top: 0;
+	bottom: 0;
+	margin: auto;
+	padding: 7px 0;
+	display: none;
+	vertical-align: middle;
+  outline: 0;
+  cursor: pointer;
+}
+.lm-close-icon:after {
+	content: "X";
+	display: block;
+	width: 15px;
+	height: 15px;
+	text-align: center;
+	color:#000;
+	font-weight: normal;
+	font-size: 12px;
+	cursor: pointer;
 }
 
 /*-----------------------------------------------------------------------------
@@ -776,6 +833,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 }
 
 
+.lm-TabBar-tabInput {
+  user-select: all;
+  width: 100%;
+  box-sizing : border-box;
+}
+
+
 /* <DEPRECATED> */ .p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-hidden {
   display: none !important;
@@ -807,7 +871,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 
 
 /* <DEPRECATED> */
-.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging
+.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging,
 /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
   transition: none;
@@ -844,12 +908,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 |----------------------------------------------------------------------------*/
 
 @charset "UTF-8";
-/*!
-
-Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
-Licensed under the Apache License, Version 2.0.
-
-*/
 html{
   -webkit-box-sizing:border-box;
           box-sizing:border-box; }
@@ -861,17 +919,17 @@ html{
           box-sizing:inherit; }
 
 body{
-  text-transform:none;
-  line-height:1.28581;
-  letter-spacing:0;
   font-size:14px;
   font-weight:400;
+  letter-spacing:0;
+  line-height:1.28581;
+  text-transform:none;
   color:#182026;
   font-family:-apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", "Icons16", sans-serif; }
 
 p{
-  margin-top:0;
-  margin-bottom:10px; }
+  margin-bottom:10px;
+  margin-top:0; }
 
 small{
   font-size:12px; }
@@ -893,38 +951,38 @@ strong{
     color:#f5f8fa; }
 
 h1.bp3-heading, .bp3-running-text h1{
-  line-height:40px;
-  font-size:36px; }
+  font-size:36px;
+  line-height:40px; }
 
 h2.bp3-heading, .bp3-running-text h2{
-  line-height:32px;
-  font-size:28px; }
+  font-size:28px;
+  line-height:32px; }
 
 h3.bp3-heading, .bp3-running-text h3{
-  line-height:25px;
-  font-size:22px; }
+  font-size:22px;
+  line-height:25px; }
 
 h4.bp3-heading, .bp3-running-text h4{
-  line-height:21px;
-  font-size:18px; }
+  font-size:18px;
+  line-height:21px; }
 
 h5.bp3-heading, .bp3-running-text h5{
-  line-height:19px;
-  font-size:16px; }
+  font-size:16px;
+  line-height:19px; }
 
 h6.bp3-heading, .bp3-running-text h6{
-  line-height:16px;
-  font-size:14px; }
-.bp3-ui-text{
-  text-transform:none;
-  line-height:1.28581;
-  letter-spacing:0;
   font-size:14px;
-  font-weight:400; }
+  line-height:16px; }
+.bp3-ui-text{
+  font-size:14px;
+  font-weight:400;
+  letter-spacing:0;
+  line-height:1.28581;
+  text-transform:none; }
 
 .bp3-monospace-text{
-  text-transform:none;
-  font-family:monospace; }
+  font-family:monospace;
+  text-transform:none; }
 
 .bp3-text-muted{
   color:#5c7080; }
@@ -942,54 +1000,54 @@ h6.bp3-heading, .bp3-running-text h6{
   white-space:nowrap;
   word-wrap:normal; }
 .bp3-running-text{
-  line-height:1.5;
-  font-size:14px; }
+  font-size:14px;
+  line-height:1.5; }
   .bp3-running-text h1{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h1{
       color:#f5f8fa; }
   .bp3-running-text h2{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h2{
       color:#f5f8fa; }
   .bp3-running-text h3{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h3{
       color:#f5f8fa; }
   .bp3-running-text h4{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h4{
       color:#f5f8fa; }
   .bp3-running-text h5{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h5{
       color:#f5f8fa; }
   .bp3-running-text h6{
     color:#182026;
     font-weight:600;
-    margin-top:40px;
-    margin-bottom:20px; }
+    margin-bottom:20px;
+    margin-top:40px; }
     .bp3-dark .bp3-running-text h6{
       color:#f5f8fa; }
   .bp3-running-text hr{
-    margin:20px 0;
     border:none;
-    border-bottom:1px solid rgba(16, 22, 26, 0.15); }
+    border-bottom:1px solid rgba(16, 22, 26, 0.15);
+    margin:20px 0; }
     .bp3-dark .bp3-running-text hr{
       border-color:rgba(255, 255, 255, 0.15); }
   .bp3-running-text p{
@@ -1002,12 +1060,12 @@ h6.bp3-heading, .bp3-running-text h6{
 .bp3-text-small{
   font-size:12px; }
 a{
-  text-decoration:none;
-  color:#106ba3; }
+  color:#106ba3;
+  text-decoration:none; }
   a:hover{
+    color:#106ba3;
     cursor:pointer;
-    text-decoration:underline;
-    color:#106ba3; }
+    text-decoration:underline; }
   a .bp3-icon, a .bp3-icon-standard, a .bp3-icon-large{
     color:inherit; }
   a code,
@@ -1022,19 +1080,19 @@ a{
     .bp3-dark a:hover .bp3-icon-large{
       color:inherit; }
 .bp3-running-text code, .bp3-code{
-  text-transform:none;
   font-family:monospace;
+  text-transform:none;
+  background:rgba(255, 255, 255, 0.7);
   border-radius:3px;
   -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
           box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2);
-  background:rgba(255, 255, 255, 0.7);
-  padding:2px 5px;
   color:#5c7080;
-  font-size:smaller; }
+  font-size:smaller;
+  padding:2px 5px; }
   .bp3-dark .bp3-running-text code, .bp3-running-text .bp3-dark code, .bp3-dark .bp3-code{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#a7b6c2; }
   .bp3-running-text a > code, a > .bp3-code{
     color:#137cbd; }
@@ -1042,65 +1100,65 @@ a{
       color:inherit; }
 
 .bp3-running-text pre, .bp3-code-block{
-  text-transform:none;
   font-family:monospace;
-  display:block;
-  margin:10px 0;
+  text-transform:none;
+  background:rgba(255, 255, 255, 0.7);
   border-radius:3px;
   -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
           box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
-  background:rgba(255, 255, 255, 0.7);
-  padding:13px 15px 12px;
-  line-height:1.4;
   color:#182026;
+  display:block;
   font-size:13px;
+  line-height:1.4;
+  margin:10px 0;
+  padding:13px 15px 12px;
   word-break:break-all;
   word-wrap:break-word; }
   .bp3-dark .bp3-running-text pre, .bp3-running-text .bp3-dark pre, .bp3-dark .bp3-code-block{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa; }
   .bp3-running-text pre > code, .bp3-code-block > code{
+    background:none;
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:none;
-    padding:0;
     color:inherit;
-    font-size:inherit; }
+    font-size:inherit;
+    padding:0; }
 
 .bp3-running-text kbd, .bp3-key{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
+  background:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  min-width:24px;
-  height:24px;
-  padding:3px 6px;
-  vertical-align:middle;
-  line-height:24px;
   color:#5c7080;
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
   font-family:inherit;
-  font-size:12px; }
+  font-size:12px;
+  height:24px;
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  line-height:24px;
+  min-width:24px;
+  padding:3px 6px;
+  vertical-align:middle; }
   .bp3-running-text kbd .bp3-icon, .bp3-key .bp3-icon, .bp3-running-text kbd .bp3-icon-standard, .bp3-key .bp3-icon-standard, .bp3-running-text kbd .bp3-icon-large, .bp3-key .bp3-icon-large{
     margin-right:5px; }
   .bp3-dark .bp3-running-text kbd, .bp3-running-text .bp3-dark kbd, .bp3-dark .bp3-key{
+    background:#394b59;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:#394b59;
     color:#a7b6c2; }
 .bp3-running-text blockquote, .bp3-blockquote{
-  margin:0 0 10px;
   border-left:solid 4px rgba(167, 182, 194, 0.5);
+  margin:0 0 10px;
   padding:0 20px; }
   .bp3-dark .bp3-running-text blockquote, .bp3-running-text .bp3-dark blockquote, .bp3-dark .bp3-blockquote{
     border-color:rgba(115, 134, 148, 0.5); }
@@ -1117,9 +1175,9 @@ a{
     margin-top:5px; }
 
 .bp3-list-unstyled{
+  list-style:none;
   margin:0;
-  padding:0;
-  list-style:none; }
+  padding:0; }
   .bp3-list-unstyled li{
     padding:0; }
 .bp3-rtl{
@@ -1147,9 +1205,12 @@ a{
   display:-ms-flexbox;
   display:flex; }
   .bp3-alert-body .bp3-icon{
-    margin-top:0;
+    font-size:40px;
     margin-right:20px;
-    font-size:40px; }
+    margin-top:0; }
+
+.bp3-alert-contents{
+  word-break:break-word; }
 
 .bp3-alert-footer{
   display:-webkit-box;
@@ -1163,45 +1224,45 @@ a{
   .bp3-alert-footer .bp3-button{
     margin-left:10px; }
 .bp3-breadcrumbs{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  cursor:default;
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -ms-flex-wrap:wrap;
       flex-wrap:wrap;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  margin:0;
-  cursor:default;
   height:30px;
-  padding:0;
-  list-style:none; }
+  list-style:none;
+  margin:0;
+  padding:0; }
   .bp3-breadcrumbs > li{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
     -webkit-box-align:center;
         -ms-flex-align:center;
-            align-items:center; }
+            align-items:center;
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex; }
     .bp3-breadcrumbs > li::after{
+      background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z' fill='%235C7080'/%3e%3c/svg%3e");
+      content:"";
       display:block;
-      margin:0 5px;
-      background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.71 7.29l-4-4a1.003 1.003 0 0 0-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z' fill='%235C7080'/%3e%3c/svg%3e");
-      width:16px;
       height:16px;
-      content:""; }
+      margin:0 5px;
+      width:16px; }
     .bp3-breadcrumbs > li:last-of-type::after{
       display:none; }
 
 .bp3-breadcrumb,
 .bp3-breadcrumb-current,
 .bp3-breadcrumbs-collapsed{
-  display:-webkit-inline-box;
-  display:-ms-inline-flexbox;
-  display:inline-flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-inline-box;
+  display:-ms-inline-flexbox;
+  display:inline-flex;
   font-size:16px; }
 
 .bp3-breadcrumb,
@@ -1212,8 +1273,8 @@ a{
   text-decoration:none; }
 
 .bp3-breadcrumb.bp3-disabled{
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-breadcrumb .bp3-icon{
   margin-right:5px; }
@@ -1222,28 +1283,28 @@ a{
   color:inherit;
   font-weight:600; }
   .bp3-breadcrumb-current .bp3-input{
-    vertical-align:baseline;
     font-size:inherit;
-    font-weight:inherit; }
+    font-weight:inherit;
+    vertical-align:baseline; }
 
 .bp3-breadcrumbs-collapsed{
-  margin-right:2px;
+  background:#ced9e0;
   border:none;
   border-radius:3px;
-  background:#ced9e0;
   cursor:pointer;
+  margin-right:2px;
   padding:1px 5px;
   vertical-align:text-bottom; }
   .bp3-breadcrumbs-collapsed::before{
-    display:block;
     background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cg fill='%235C7080'%3e%3ccircle cx='2' cy='8.03' r='2'/%3e%3ccircle cx='14' cy='8.03' r='2'/%3e%3ccircle cx='8' cy='8.03' r='2'/%3e%3c/g%3e%3c/svg%3e") center no-repeat;
-    width:16px;
+    content:"";
+    display:block;
     height:16px;
-    content:""; }
+    width:16px; }
   .bp3-breadcrumbs-collapsed:hover{
     background:#bfccd6;
-    text-decoration:none;
-    color:#182026; }
+    color:#182026;
+    text-decoration:none; }
 
 .bp3-dark .bp3-breadcrumb,
 .bp3-dark .bp3-breadcrumbs-collapsed{
@@ -1274,18 +1335,18 @@ a{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
   border:none;
   border-radius:3px;
   cursor:pointer;
-  padding:5px 10px;
-  vertical-align:middle;
-  text-align:left;
   font-size:14px;
-  min-width:30px;
-  min-height:30px; }
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  padding:5px 10px;
+  text-align:left;
+  vertical-align:middle;
+  min-height:30px;
+  min-width:30px; }
   .bp3-button > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -1320,140 +1381,140 @@ a{
   .bp3-align-left .bp3-button{
     text-align:left; }
   .bp3-button:not([class*="bp3-intent-"]){
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-color:#f5f8fa;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     color:#182026; }
     .bp3-button:not([class*="bp3-intent-"]):hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
       background-clip:padding-box;
-      background-color:#ebf1f5; }
+      background-color:#ebf1f5;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
     .bp3-button:not([class*="bp3-intent-"]):active, .bp3-button:not([class*="bp3-intent-"]).bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#d8e1e8;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
-      outline:none;
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(206, 217, 224, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:rgba(92, 112, 128, 0.6);
       cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      outline:none; }
       .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active:hover, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active, .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active:hover{
         background:rgba(206, 217, 224, 0.7); }
   .bp3-button.bp3-intent-primary{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#137cbd;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-primary:hover, .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-primary:hover{
+      background-color:#106ba3;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#106ba3; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-primary:active, .bp3-button.bp3-intent-primary.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#0e5a8a;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-primary:disabled, .bp3-button.bp3-intent-primary.bp3-disabled{
+      background-color:rgba(19, 124, 189, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(19, 124, 189, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button.bp3-intent-success{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#0f9960;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-success:hover, .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-success:hover{
+      background-color:#0d8050;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#0d8050; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-success:active, .bp3-button.bp3-intent-success.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#0a6640;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-success:disabled, .bp3-button.bp3-intent-success.bp3-disabled{
+      background-color:rgba(15, 153, 96, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(15, 153, 96, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button.bp3-intent-warning{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#d9822b;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-warning:hover, .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-warning:hover{
+      background-color:#bf7326;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#bf7326; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-warning:active, .bp3-button.bp3-intent-warning.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#a66321;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-warning:disabled, .bp3-button.bp3-intent-warning.bp3-disabled{
+      background-color:rgba(217, 130, 43, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(217, 130, 43, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button.bp3-intent-danger{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#db3737;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     color:#ffffff; }
     .bp3-button.bp3-intent-danger:hover, .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
       color:#ffffff; }
     .bp3-button.bp3-intent-danger:hover{
+      background-color:#c23030;
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-      background-color:#c23030; }
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-danger:active, .bp3-button.bp3-intent-danger.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#a82a2a;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-button.bp3-intent-danger:disabled, .bp3-button.bp3-intent-danger.bp3-disabled{
+      background-color:rgba(219, 55, 55, 0.5);
+      background-image:none;
       border-color:transparent;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-color:rgba(219, 55, 55, 0.5);
-      background-image:none;
       color:rgba(255, 255, 255, 0.6); }
   .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
     stroke:#ffffff; }
   .bp3-button.bp3-large,
   .bp3-large .bp3-button{
-    min-width:40px;
     min-height:40px;
-    padding:5px 15px;
-    font-size:16px; }
+    min-width:40px;
+    font-size:16px;
+    padding:5px 15px; }
     .bp3-button.bp3-large::before,
     .bp3-button.bp3-large > *,
     .bp3-large .bp3-button::before,
@@ -1466,24 +1527,24 @@ a{
       margin-right:0; }
   .bp3-button.bp3-small,
   .bp3-small .bp3-button{
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     padding:0 7px; }
   .bp3-button.bp3-loading{
     position:relative; }
     .bp3-button.bp3-loading[class*="bp3-icon-"]::before{
       visibility:hidden; }
     .bp3-button.bp3-loading .bp3-button-spinner{
-      position:absolute;
-      margin:0; }
+      margin:0;
+      position:absolute; }
     .bp3-button.bp3-loading > :not(.bp3-button-spinner){
       visibility:hidden; }
   .bp3-button[class*="bp3-icon-"]::before{
-    line-height:1;
     font-family:"Icons16", sans-serif;
     font-size:16px;
-    font-weight:400;
     font-style:normal;
+    font-weight:400;
+    line-height:1;
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased;
     color:#5c7080; }
@@ -1495,28 +1556,28 @@ a{
   .bp3-button .bp3-spinner + .bp3-icon:last-child{
     margin:0 -7px; }
   .bp3-dark .bp3-button:not([class*="bp3-intent-"]){
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     background-color:#394b59;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     color:#f5f8fa; }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover, .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
       color:#f5f8fa; }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover{
+      background-color:#30404d;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-active{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#202b33;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(57, 75, 89, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:rgba(167, 182, 194, 0.6); }
       .bp3-dark .bp3-button:not([class*="bp3-intent-"]):disabled.bp3-active, .bp3-dark .bp3-button:not([class*="bp3-intent-"]).bp3-disabled.bp3-active{
         background:rgba(57, 75, 89, 0.7); }
@@ -1537,9 +1598,9 @@ a{
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-button[class*="bp3-intent-"]:disabled, .bp3-dark .bp3-button[class*="bp3-intent-"].bp3-disabled{
+      background-image:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background-image:none;
       color:rgba(255, 255, 255, 0.3); }
     .bp3-dark .bp3-button[class*="bp3-intent-"] .bp3-button-spinner .bp3-spinner-head{
       stroke:#8a9ba8; }
@@ -1549,35 +1610,35 @@ a{
   .bp3-button[class*="bp3-intent-"] .bp3-icon, .bp3-button[class*="bp3-intent-"] .bp3-icon-standard, .bp3-button[class*="bp3-intent-"] .bp3-icon-large{
     color:inherit !important; }
   .bp3-button.bp3-minimal{
+    background:none;
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none; }
+            box-shadow:none; }
     .bp3-button.bp3-minimal:hover{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background:rgba(167, 182, 194, 0.3);
-      text-decoration:none;
-      color:#182026; }
-    .bp3-button.bp3-minimal:active, .bp3-button.bp3-minimal.bp3-active{
       -webkit-box-shadow:none;
               box-shadow:none;
+      color:#182026;
+      text-decoration:none; }
+    .bp3-button.bp3-minimal:active, .bp3-button.bp3-minimal.bp3-active{
       background:rgba(115, 134, 148, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:#182026; }
     .bp3-button.bp3-minimal:disabled, .bp3-button.bp3-minimal:disabled:hover, .bp3-button.bp3-minimal.bp3-disabled, .bp3-button.bp3-minimal.bp3-disabled:hover{
       background:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed; }
       .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
         background:rgba(115, 134, 148, 0.3); }
     .bp3-dark .bp3-button.bp3-minimal{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:inherit; }
       .bp3-dark .bp3-button.bp3-minimal:hover, .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none; }
+                box-shadow:none; }
       .bp3-dark .bp3-button.bp3-minimal:hover{
         background:rgba(138, 155, 168, 0.15); }
       .bp3-dark .bp3-button.bp3-minimal:active, .bp3-dark .bp3-button.bp3-minimal.bp3-active{
@@ -1585,16 +1646,16 @@ a{
         color:#f5f8fa; }
       .bp3-dark .bp3-button.bp3-minimal:disabled, .bp3-dark .bp3-button.bp3-minimal:disabled:hover, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover{
         background:none;
-        cursor:not-allowed;
-        color:rgba(167, 182, 194, 0.6); }
+        color:rgba(167, 182, 194, 0.6);
+        cursor:not-allowed; }
         .bp3-dark .bp3-button.bp3-minimal:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal:disabled:hover.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-disabled:hover.bp3-active{
           background:rgba(138, 155, 168, 0.3); }
     .bp3-button.bp3-minimal.bp3-intent-primary{
       color:#106ba3; }
       .bp3-button.bp3-minimal.bp3-intent-primary:hover, .bp3-button.bp3-minimal.bp3-intent-primary:active, .bp3-button.bp3-minimal.bp3-intent-primary.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#106ba3; }
       .bp3-button.bp3-minimal.bp3-intent-primary:hover{
         background:rgba(19, 124, 189, 0.15);
@@ -1625,9 +1686,9 @@ a{
     .bp3-button.bp3-minimal.bp3-intent-success{
       color:#0d8050; }
       .bp3-button.bp3-minimal.bp3-intent-success:hover, .bp3-button.bp3-minimal.bp3-intent-success:active, .bp3-button.bp3-minimal.bp3-intent-success.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#0d8050; }
       .bp3-button.bp3-minimal.bp3-intent-success:hover{
         background:rgba(15, 153, 96, 0.15);
@@ -1658,9 +1719,9 @@ a{
     .bp3-button.bp3-minimal.bp3-intent-warning{
       color:#bf7326; }
       .bp3-button.bp3-minimal.bp3-intent-warning:hover, .bp3-button.bp3-minimal.bp3-intent-warning:active, .bp3-button.bp3-minimal.bp3-intent-warning.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#bf7326; }
       .bp3-button.bp3-minimal.bp3-intent-warning:hover{
         background:rgba(217, 130, 43, 0.15);
@@ -1691,9 +1752,9 @@ a{
     .bp3-button.bp3-minimal.bp3-intent-danger{
       color:#c23030; }
       .bp3-button.bp3-minimal.bp3-intent-danger:hover, .bp3-button.bp3-minimal.bp3-intent-danger:active, .bp3-button.bp3-minimal.bp3-intent-danger.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#c23030; }
       .bp3-button.bp3-minimal.bp3-intent-danger:hover{
         background:rgba(219, 55, 55, 0.15);
@@ -1721,6 +1782,220 @@ a{
           color:rgba(255, 115, 115, 0.5); }
           .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button.bp3-minimal.bp3-intent-danger.bp3-disabled.bp3-active{
             background:rgba(219, 55, 55, 0.3); }
+  .bp3-button.bp3-outlined{
+    background:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    border:1px solid rgba(24, 32, 38, 0.2);
+    -webkit-box-sizing:border-box;
+            box-sizing:border-box; }
+    .bp3-button.bp3-outlined:hover{
+      background:rgba(167, 182, 194, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:#182026;
+      text-decoration:none; }
+    .bp3-button.bp3-outlined:active, .bp3-button.bp3-outlined.bp3-active{
+      background:rgba(115, 134, 148, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:#182026; }
+    .bp3-button.bp3-outlined:disabled, .bp3-button.bp3-outlined:disabled:hover, .bp3-button.bp3-outlined.bp3-disabled, .bp3-button.bp3-outlined.bp3-disabled:hover{
+      background:none;
+      color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed; }
+      .bp3-button.bp3-outlined:disabled.bp3-active, .bp3-button.bp3-outlined:disabled:hover.bp3-active, .bp3-button.bp3-outlined.bp3-disabled.bp3-active, .bp3-button.bp3-outlined.bp3-disabled:hover.bp3-active{
+        background:rgba(115, 134, 148, 0.3); }
+    .bp3-dark .bp3-button.bp3-outlined{
+      background:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:inherit; }
+      .bp3-dark .bp3-button.bp3-outlined:hover, .bp3-dark .bp3-button.bp3-outlined:active, .bp3-dark .bp3-button.bp3-outlined.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none; }
+      .bp3-dark .bp3-button.bp3-outlined:hover{
+        background:rgba(138, 155, 168, 0.15); }
+      .bp3-dark .bp3-button.bp3-outlined:active, .bp3-dark .bp3-button.bp3-outlined.bp3-active{
+        background:rgba(138, 155, 168, 0.3);
+        color:#f5f8fa; }
+      .bp3-dark .bp3-button.bp3-outlined:disabled, .bp3-dark .bp3-button.bp3-outlined:disabled:hover, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled:hover{
+        background:none;
+        color:rgba(167, 182, 194, 0.6);
+        cursor:not-allowed; }
+        .bp3-dark .bp3-button.bp3-outlined:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined:disabled:hover.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled:hover.bp3-active{
+          background:rgba(138, 155, 168, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-primary{
+      color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:hover, .bp3-button.bp3-outlined.bp3-intent-primary:active, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:hover{
+        background:rgba(19, 124, 189, 0.15);
+        color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:active, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-active{
+        background:rgba(19, 124, 189, 0.3);
+        color:#106ba3; }
+      .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+        background:none;
+        color:rgba(16, 107, 163, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-primary:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled.bp3-active{
+          background:rgba(19, 124, 189, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-primary .bp3-button-spinner .bp3-spinner-head{
+        stroke:#106ba3; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary{
+        color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:hover{
+          background:rgba(19, 124, 189, 0.2);
+          color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-active{
+          background:rgba(19, 124, 189, 0.3);
+          color:#48aff0; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+          background:none;
+          color:rgba(72, 175, 240, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled.bp3-active{
+            background:rgba(19, 124, 189, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-success{
+      color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:hover, .bp3-button.bp3-outlined.bp3-intent-success:active, .bp3-button.bp3-outlined.bp3-intent-success.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:hover{
+        background:rgba(15, 153, 96, 0.15);
+        color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:active, .bp3-button.bp3-outlined.bp3-intent-success.bp3-active{
+        background:rgba(15, 153, 96, 0.3);
+        color:#0d8050; }
+      .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+        background:none;
+        color:rgba(13, 128, 80, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-success:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled.bp3-active{
+          background:rgba(15, 153, 96, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-success .bp3-button-spinner .bp3-spinner-head{
+        stroke:#0d8050; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success{
+        color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:hover{
+          background:rgba(15, 153, 96, 0.2);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-active{
+          background:rgba(15, 153, 96, 0.3);
+          color:#3dcc91; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+          background:none;
+          color:rgba(61, 204, 145, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled.bp3-active{
+            background:rgba(15, 153, 96, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-warning{
+      color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:hover, .bp3-button.bp3-outlined.bp3-intent-warning:active, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:hover{
+        background:rgba(217, 130, 43, 0.15);
+        color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:active, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-active{
+        background:rgba(217, 130, 43, 0.3);
+        color:#bf7326; }
+      .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+        background:none;
+        color:rgba(191, 115, 38, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-warning:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled.bp3-active{
+          background:rgba(217, 130, 43, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-warning .bp3-button-spinner .bp3-spinner-head{
+        stroke:#bf7326; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning{
+        color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:hover{
+          background:rgba(217, 130, 43, 0.2);
+          color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-active{
+          background:rgba(217, 130, 43, 0.3);
+          color:#ffb366; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+          background:none;
+          color:rgba(255, 179, 102, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled.bp3-active{
+            background:rgba(217, 130, 43, 0.3); }
+    .bp3-button.bp3-outlined.bp3-intent-danger{
+      color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:hover, .bp3-button.bp3-outlined.bp3-intent-danger:active, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-active{
+        background:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:hover{
+        background:rgba(219, 55, 55, 0.15);
+        color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:active, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-active{
+        background:rgba(219, 55, 55, 0.3);
+        color:#c23030; }
+      .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+        background:none;
+        color:rgba(194, 48, 48, 0.5); }
+        .bp3-button.bp3-outlined.bp3-intent-danger:disabled.bp3-active, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled.bp3-active{
+          background:rgba(219, 55, 55, 0.3); }
+      .bp3-button.bp3-outlined.bp3-intent-danger .bp3-button-spinner .bp3-spinner-head{
+        stroke:#c23030; }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger{
+        color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:hover{
+          background:rgba(219, 55, 55, 0.2);
+          color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-active{
+          background:rgba(219, 55, 55, 0.3);
+          color:#ff7373; }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+          background:none;
+          color:rgba(255, 115, 115, 0.5); }
+          .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:disabled.bp3-active, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled.bp3-active{
+            background:rgba(219, 55, 55, 0.3); }
+    .bp3-button.bp3-outlined:disabled, .bp3-button.bp3-outlined.bp3-disabled, .bp3-button.bp3-outlined:disabled:hover, .bp3-button.bp3-outlined.bp3-disabled:hover{
+      border-color:rgba(92, 112, 128, 0.1); }
+    .bp3-dark .bp3-button.bp3-outlined{
+      border-color:rgba(255, 255, 255, 0.4); }
+      .bp3-dark .bp3-button.bp3-outlined:disabled, .bp3-dark .bp3-button.bp3-outlined:disabled:hover, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-disabled:hover{
+        border-color:rgba(255, 255, 255, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-primary{
+      border-color:rgba(16, 107, 163, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+        border-color:rgba(16, 107, 163, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary{
+        border-color:rgba(72, 175, 240, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-primary.bp3-disabled{
+          border-color:rgba(72, 175, 240, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-success{
+      border-color:rgba(13, 128, 80, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+        border-color:rgba(13, 128, 80, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success{
+        border-color:rgba(61, 204, 145, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-success.bp3-disabled{
+          border-color:rgba(61, 204, 145, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-warning{
+      border-color:rgba(191, 115, 38, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+        border-color:rgba(191, 115, 38, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning{
+        border-color:rgba(255, 179, 102, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-warning.bp3-disabled{
+          border-color:rgba(255, 179, 102, 0.2); }
+    .bp3-button.bp3-outlined.bp3-intent-danger{
+      border-color:rgba(194, 48, 48, 0.6); }
+      .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+        border-color:rgba(194, 48, 48, 0.2); }
+      .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger{
+        border-color:rgba(255, 115, 115, 0.6); }
+        .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger:disabled, .bp3-dark .bp3-button.bp3-outlined.bp3-intent-danger.bp3-disabled{
+          border-color:rgba(255, 115, 115, 0.2); }
 
 a.bp3-button{
   text-align:center;
@@ -1773,43 +2048,43 @@ a.bp3-button{
         z-index:8; }
   .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:first-child) .bp3-button,
   .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:first-child){
-    border-top-left-radius:0;
-    border-bottom-left-radius:0; }
+    border-bottom-left-radius:0;
+    border-top-left-radius:0; }
   .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button,
   .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child){
-    margin-right:-1px;
+    border-bottom-right-radius:0;
     border-top-right-radius:0;
-    border-bottom-right-radius:0; }
+    margin-right:-1px; }
   .bp3-button-group.bp3-minimal .bp3-button{
+    background:none;
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:none; }
+            box-shadow:none; }
     .bp3-button-group.bp3-minimal .bp3-button:hover{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background:rgba(167, 182, 194, 0.3);
-      text-decoration:none;
-      color:#182026; }
-    .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
       -webkit-box-shadow:none;
               box-shadow:none;
+      color:#182026;
+      text-decoration:none; }
+    .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
       background:rgba(115, 134, 148, 0.3);
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:#182026; }
     .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
       background:none;
-      cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed; }
       .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
         background:rgba(115, 134, 148, 0.3); }
     .bp3-dark .bp3-button-group.bp3-minimal .bp3-button{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:inherit; }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
-                box-shadow:none;
-        background:none; }
+                box-shadow:none; }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:hover{
         background:rgba(138, 155, 168, 0.15); }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-active{
@@ -1817,16 +2092,16 @@ a.bp3-button{
         color:#f5f8fa; }
       .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover{
         background:none;
-        cursor:not-allowed;
-        color:rgba(167, 182, 194, 0.6); }
+        color:rgba(167, 182, 194, 0.6);
+        cursor:not-allowed; }
         .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button:disabled:hover.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled.bp3-active, .bp3-dark .bp3-button-group.bp3-minimal .bp3-button.bp3-disabled:hover.bp3-active{
           background:rgba(138, 155, 168, 0.3); }
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary{
       color:#106ba3; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#106ba3; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-primary:hover{
         background:rgba(19, 124, 189, 0.15);
@@ -1857,9 +2132,9 @@ a.bp3-button{
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success{
       color:#0d8050; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#0d8050; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-success:hover{
         background:rgba(15, 153, 96, 0.15);
@@ -1890,9 +2165,9 @@ a.bp3-button{
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning{
       color:#bf7326; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#bf7326; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-warning:hover{
         background:rgba(217, 130, 43, 0.15);
@@ -1923,9 +2198,9 @@ a.bp3-button{
     .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger{
       color:#c23030; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:active, .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger.bp3-active{
+        background:none;
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:none;
         color:#c23030; }
       .bp3-button-group.bp3-minimal .bp3-button.bp3-intent-danger:hover{
         background:rgba(219, 55, 55, 0.15);
@@ -1972,17 +2247,17 @@ a.bp3-button{
         -ms-flex:1 1 auto;
             flex:1 1 auto; }
   .bp3-button-group.bp3-vertical{
+    -webkit-box-align:stretch;
+        -ms-flex-align:stretch;
+            align-items:stretch;
     -webkit-box-orient:vertical;
     -webkit-box-direction:normal;
         -ms-flex-direction:column;
             flex-direction:column;
-    -webkit-box-align:stretch;
-        -ms-flex-align:stretch;
-            align-items:stretch;
     vertical-align:top; }
     .bp3-button-group.bp3-vertical.bp3-fill{
-      width:unset;
-      height:100%; }
+      height:100%;
+      width:unset; }
     .bp3-button-group.bp3-vertical .bp3-button{
       margin-right:0 !important;
       width:100%; }
@@ -2004,38 +2279,38 @@ a.bp3-button{
   .bp3-dark .bp3-button-group.bp3-vertical > .bp3-button:not(:last-child){
     margin-bottom:1px; }
 .bp3-callout{
-  line-height:1.5;
   font-size:14px;
-  position:relative;
-  border-radius:3px;
+  line-height:1.5;
   background-color:rgba(138, 155, 168, 0.15);
-  width:100%;
-  padding:10px 12px 9px; }
+  border-radius:3px;
+  padding:10px 12px 9px;
+  position:relative;
+  width:100%; }
   .bp3-callout[class*="bp3-icon-"]{
     padding-left:40px; }
     .bp3-callout[class*="bp3-icon-"]::before{
-      line-height:1;
       font-family:"Icons20", sans-serif;
       font-size:20px;
-      font-weight:400;
       font-style:normal;
+      font-weight:400;
+      line-height:1;
       -moz-osx-font-smoothing:grayscale;
       -webkit-font-smoothing:antialiased;
-      position:absolute;
-      top:10px;
+      color:#5c7080;
       left:10px;
-      color:#5c7080; }
+      position:absolute;
+      top:10px; }
   .bp3-callout.bp3-callout-icon{
     padding-left:40px; }
     .bp3-callout.bp3-callout-icon > .bp3-icon:first-child{
-      position:absolute;
-      top:10px;
+      color:#5c7080;
       left:10px;
-      color:#5c7080; }
+      position:absolute;
+      top:10px; }
   .bp3-callout .bp3-heading{
-    margin-top:0;
+    line-height:20px;
     margin-bottom:5px;
-    line-height:20px; }
+    margin-top:0; }
     .bp3-callout .bp3-heading:last-child{
       margin-bottom:0; }
   .bp3-dark .bp3-callout{
@@ -2093,10 +2368,10 @@ a.bp3-button{
   .bp3-running-text .bp3-callout{
     margin:20px 0; }
 .bp3-card{
+  background-color:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-  background-color:#ffffff;
   padding:20px;
   -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
@@ -2104,9 +2379,9 @@ a.bp3-button{
   transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-card.bp3-dark,
   .bp3-dark .bp3-card{
+    background-color:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
-    background-color:#30404d; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0); }
 
 .bp3-elevation-0{
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.15), 0 0 0 rgba(16, 22, 26, 0), 0 0 0 rgba(16, 22, 26, 0);
@@ -2158,9 +2433,9 @@ a.bp3-button{
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
 
 .bp3-card.bp3-interactive:active{
-  opacity:0.9;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
+  opacity:0.9;
   -webkit-transition-duration:0;
           transition-duration:0; }
   .bp3-card.bp3-interactive:active.bp3-dark,
@@ -2188,31 +2463,31 @@ a.bp3-button{
   position:fixed; }
 
 .bp3-divider{
-  margin:5px;
+  border-bottom:1px solid rgba(16, 22, 26, 0.15);
   border-right:1px solid rgba(16, 22, 26, 0.15);
-  border-bottom:1px solid rgba(16, 22, 26, 0.15); }
+  margin:5px; }
   .bp3-dark .bp3-divider{
     border-color:rgba(16, 22, 26, 0.4); }
 .bp3-dialog-container{
   opacity:1;
   -webkit-transform:scale(1);
           transform:scale(1);
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   -webkit-box-pack:center;
       -ms-flex-pack:center;
           justify-content:center;
-  width:100%;
   min-height:100%;
   pointer-events:none;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
-          user-select:none; }
+          user-select:none;
+  width:100%; }
   .bp3-dialog-container.bp3-overlay-enter > .bp3-dialog, .bp3-dialog-container.bp3-overlay-appear > .bp3-dialog{
     opacity:0;
     -webkit-transform:scale(0.5);
@@ -2221,16 +2496,16 @@ a.bp3-button{
     opacity:1;
     -webkit-transform:scale(1);
             transform:scale(1);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:opacity, -webkit-transform;
     transition-property:opacity, -webkit-transform;
     transition-property:opacity, transform;
     transition-property:opacity, transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-dialog-container.bp3-overlay-exit > .bp3-dialog{
     opacity:1;
     -webkit-transform:scale(1);
@@ -2239,18 +2514,22 @@ a.bp3-button{
     opacity:0;
     -webkit-transform:scale(0.5);
             transform:scale(0.5);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:opacity, -webkit-transform;
     transition-property:opacity, -webkit-transform;
     transition-property:opacity, transform;
     transition-property:opacity, transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
 
 .bp3-dialog{
+  background:#ebf1f5;
+  border-radius:6px;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
@@ -2259,50 +2538,46 @@ a.bp3-button{
       -ms-flex-direction:column;
           flex-direction:column;
   margin:30px 0;
-  border-radius:6px;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background:#ebf1f5;
-  width:500px;
   padding-bottom:20px;
   pointer-events:all;
   -webkit-user-select:text;
      -moz-user-select:text;
       -ms-user-select:text;
-          user-select:text; }
+          user-select:text;
+  width:500px; }
   .bp3-dialog:focus{
     outline:0; }
   .bp3-dialog.bp3-dark,
   .bp3-dark .bp3-dialog{
+    background:#293742;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background:#293742;
     color:#f5f8fa; }
 
 .bp3-dialog-header{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  background:#ffffff;
+  border-radius:6px 6px 0 0;
+  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  border-radius:6px 6px 0 0;
-  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-  background:#ffffff;
   min-height:40px;
-  padding-right:5px;
-  padding-left:20px; }
+  padding-left:20px;
+  padding-right:5px; }
   .bp3-dialog-header .bp3-icon-large,
   .bp3-dialog-header .bp3-icon{
+    color:#5c7080;
     -webkit-box-flex:0;
         -ms-flex:0 0 auto;
             flex:0 0 auto;
-    margin-right:10px;
-    color:#5c7080; }
+    margin-right:10px; }
   .bp3-dialog-header .bp3-heading{
     overflow:hidden;
     text-overflow:ellipsis;
@@ -2311,14 +2586,14 @@ a.bp3-button{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
             flex:1 1 auto;
-    margin:0;
-    line-height:inherit; }
+    line-height:inherit;
+    margin:0; }
     .bp3-dialog-header .bp3-heading:last-child{
       margin-right:20px; }
   .bp3-dark .bp3-dialog-header{
+    background:#30404d;
     -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
-            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4);
-    background:#30404d; }
+            box-shadow:0 1px 0 rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-dialog-header .bp3-icon-large,
     .bp3-dark .bp3-dialog-header .bp3-icon{
       color:#a7b6c2; }
@@ -2327,8 +2602,8 @@ a.bp3-button{
   -webkit-box-flex:1;
       -ms-flex:1 1 auto;
           flex:1 1 auto;
-  margin:20px;
-  line-height:18px; }
+  line-height:18px;
+  margin:20px; }
 
 .bp3-dialog-footer{
   -webkit-box-flex:0;
@@ -2346,6 +2621,9 @@ a.bp3-button{
   .bp3-dialog-footer-actions .bp3-button{
     margin-left:10px; }
 .bp3-drawer{
+  background:#ffffff;
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
@@ -2354,90 +2632,87 @@ a.bp3-button{
       -ms-flex-direction:column;
           flex-direction:column;
   margin:0;
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
   padding:0; }
   .bp3-drawer:focus{
     outline:0; }
   .bp3-drawer.bp3-position-top{
-    top:0;
-    right:0;
+    height:50%;
     left:0;
-    height:50%; }
+    right:0;
+    top:0; }
     .bp3-drawer.bp3-position-top.bp3-overlay-enter, .bp3-drawer.bp3-position-top.bp3-overlay-appear{
       -webkit-transform:translateY(-100%);
               transform:translateY(-100%); }
     .bp3-drawer.bp3-position-top.bp3-overlay-enter-active, .bp3-drawer.bp3-position-top.bp3-overlay-appear-active{
       -webkit-transform:translateY(0);
               transform:translateY(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-top.bp3-overlay-exit{
       -webkit-transform:translateY(0);
               transform:translateY(0); }
     .bp3-drawer.bp3-position-top.bp3-overlay-exit-active{
       -webkit-transform:translateY(-100%);
               transform:translateY(-100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-position-bottom{
-    right:0;
     bottom:0;
+    height:50%;
     left:0;
-    height:50%; }
+    right:0; }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-enter, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear{
       -webkit-transform:translateY(100%);
               transform:translateY(100%); }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-enter-active, .bp3-drawer.bp3-position-bottom.bp3-overlay-appear-active{
       -webkit-transform:translateY(0);
               transform:translateY(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-exit{
       -webkit-transform:translateY(0);
               transform:translateY(0); }
     .bp3-drawer.bp3-position-bottom.bp3-overlay-exit-active{
       -webkit-transform:translateY(100%);
               transform:translateY(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-position-left{
-    top:0;
     bottom:0;
     left:0;
+    top:0;
     width:50%; }
     .bp3-drawer.bp3-position-left.bp3-overlay-enter, .bp3-drawer.bp3-position-left.bp3-overlay-appear{
       -webkit-transform:translateX(-100%);
@@ -2445,36 +2720,36 @@ a.bp3-button{
     .bp3-drawer.bp3-position-left.bp3-overlay-enter-active, .bp3-drawer.bp3-position-left.bp3-overlay-appear-active{
       -webkit-transform:translateX(0);
               transform:translateX(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-left.bp3-overlay-exit{
       -webkit-transform:translateX(0);
               transform:translateX(0); }
     .bp3-drawer.bp3-position-left.bp3-overlay-exit-active{
       -webkit-transform:translateX(-100%);
               transform:translateX(-100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-position-right{
-    top:0;
-    right:0;
     bottom:0;
+    right:0;
+    top:0;
     width:50%; }
     .bp3-drawer.bp3-position-right.bp3-overlay-enter, .bp3-drawer.bp3-position-right.bp3-overlay-appear{
       -webkit-transform:translateX(100%);
@@ -2482,37 +2757,37 @@ a.bp3-button{
     .bp3-drawer.bp3-position-right.bp3-overlay-enter-active, .bp3-drawer.bp3-position-right.bp3-overlay-appear-active{
       -webkit-transform:translateX(0);
               transform:translateX(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer.bp3-position-right.bp3-overlay-exit{
       -webkit-transform:translateX(0);
               transform:translateX(0); }
     .bp3-drawer.bp3-position-right.bp3-overlay-exit-active{
       -webkit-transform:translateX(100%);
               transform:translateX(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
   .bp3-position-right):not(.bp3-vertical){
-    top:0;
-    right:0;
     bottom:0;
+    right:0;
+    top:0;
     width:50%; }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
@@ -2524,16 +2799,16 @@ a.bp3-button{
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-appear-active{
       -webkit-transform:translateX(0);
               transform:translateX(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit{
       -webkit-transform:translateX(0);
@@ -2542,22 +2817,22 @@ a.bp3-button{
     .bp3-position-right):not(.bp3-vertical).bp3-overlay-exit-active{
       -webkit-transform:translateX(100%);
               transform:translateX(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
   .bp3-position-right).bp3-vertical{
-    right:0;
     bottom:0;
+    height:50%;
     left:0;
-    height:50%; }
+    right:0; }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right).bp3-vertical.bp3-overlay-enter, .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right).bp3-vertical.bp3-overlay-appear{
@@ -2568,16 +2843,16 @@ a.bp3-button{
     .bp3-position-right).bp3-vertical.bp3-overlay-appear-active{
       -webkit-transform:translateY(0);
               transform:translateY(0);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:200ms;
+              transition-duration:200ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:200ms;
-              transition-duration:200ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
     .bp3-drawer:not(.bp3-position-top):not(.bp3-position-bottom):not(.bp3-position-left):not(
     .bp3-position-right).bp3-vertical.bp3-overlay-exit{
       -webkit-transform:translateY(0);
@@ -2586,47 +2861,47 @@ a.bp3-button{
     .bp3-position-right).bp3-vertical.bp3-overlay-exit-active{
       -webkit-transform:translateY(100%);
               transform:translateY(100%);
+      -webkit-transition-delay:0;
+              transition-delay:0;
+      -webkit-transition-duration:100ms;
+              transition-duration:100ms;
       -webkit-transition-property:-webkit-transform;
       transition-property:-webkit-transform;
       transition-property:transform;
       transition-property:transform, -webkit-transform;
-      -webkit-transition-duration:100ms;
-              transition-duration:100ms;
       -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-      -webkit-transition-delay:0;
-              transition-delay:0; }
+              transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-drawer.bp3-dark,
   .bp3-dark .bp3-drawer{
+    background:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background:#30404d;
     color:#f5f8fa; }
 
 .bp3-drawer-header{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  border-radius:0;
+  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  position:relative;
-  border-radius:0;
-  -webkit-box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px 0 rgba(16, 22, 26, 0.15);
   min-height:40px;
   padding:5px;
-  padding-left:20px; }
+  padding-left:20px;
+  position:relative; }
   .bp3-drawer-header .bp3-icon-large,
   .bp3-drawer-header .bp3-icon{
+    color:#5c7080;
     -webkit-box-flex:0;
         -ms-flex:0 0 auto;
             flex:0 0 auto;
-    margin-right:10px;
-    color:#5c7080; }
+    margin-right:10px; }
   .bp3-drawer-header .bp3-heading{
     overflow:hidden;
     text-overflow:ellipsis;
@@ -2635,8 +2910,8 @@ a.bp3-button{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
             flex:1 1 auto;
-    margin:0;
-    line-height:inherit; }
+    line-height:inherit;
+    margin:0; }
     .bp3-drawer-header .bp3-heading:last-child{
       margin-right:20px; }
   .bp3-dark .bp3-drawer-header{
@@ -2650,33 +2925,33 @@ a.bp3-button{
   -webkit-box-flex:1;
       -ms-flex:1 1 auto;
           flex:1 1 auto;
-  overflow:auto;
-  line-height:18px; }
+  line-height:18px;
+  overflow:auto; }
 
 .bp3-drawer-footer{
+  -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
+          box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  position:relative;
-  -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-          box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-  padding:10px 20px; }
+  padding:10px 20px;
+  position:relative; }
   .bp3-dark .bp3-drawer-footer{
     -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.4); }
 .bp3-editable-text{
-  display:inline-block;
-  position:relative;
   cursor:text;
+  display:inline-block;
   max-width:100%;
+  position:relative;
   vertical-align:top;
   white-space:nowrap; }
   .bp3-editable-text::before{
-    position:absolute;
-    top:-3px;
-    right:-3px;
     bottom:-3px;
     left:-3px;
+    position:absolute;
+    right:-3px;
+    top:-3px;
     border-radius:3px;
     content:"";
     -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
@@ -2687,9 +2962,9 @@ a.bp3-button{
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
   .bp3-editable-text.bp3-editable-text-editing::before{
+    background-color:#ffffff;
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-    background-color:#ffffff; }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
   .bp3-editable-text.bp3-disabled::before{
     -webkit-box-shadow:none;
             box-shadow:none; }
@@ -2733,9 +3008,9 @@ a.bp3-button{
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(255, 255, 255, 0.15); }
   .bp3-dark .bp3-editable-text.bp3-editable-text-editing::before{
+    background-color:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background-color:rgba(16, 22, 26, 0.3); }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-editable-text.bp3-disabled::before{
     -webkit-box-shadow:none;
             box-shadow:none; }
@@ -2774,40 +3049,40 @@ a.bp3-button{
 
 .bp3-editable-text-input,
 .bp3-editable-text-content{
-  display:inherit;
-  position:relative;
-  min-width:inherit;
-  max-width:inherit;
-  vertical-align:top;
-  text-transform:inherit;
-  letter-spacing:inherit;
   color:inherit;
+  display:inherit;
   font:inherit;
-  resize:none; }
+  letter-spacing:inherit;
+  max-width:inherit;
+  min-width:inherit;
+  position:relative;
+  resize:none;
+  text-transform:inherit;
+  vertical-align:top; }
 
 .bp3-editable-text-input{
+  background:none;
   border:none;
   -webkit-box-shadow:none;
           box-shadow:none;
-  background:none;
-  width:100%;
   padding:0;
-  white-space:pre-wrap; }
+  white-space:pre-wrap;
+  width:100%; }
   .bp3-editable-text-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-editable-text-input:focus{
     outline:none; }
   .bp3-editable-text-input::-ms-clear{
@@ -2819,8 +3094,8 @@ a.bp3-button{
   text-overflow:ellipsis;
   white-space:pre; }
   .bp3-editable-text-editing > .bp3-editable-text-content{
-    position:absolute;
     left:0;
+    position:absolute;
     visibility:hidden; }
   .bp3-editable-text-placeholder > .bp3-editable-text-content{
     color:rgba(92, 112, 128, 0.6); }
@@ -2833,6 +3108,12 @@ a.bp3-button{
     overflow:auto;
     white-space:pre-wrap;
     word-wrap:break-word; }
+.bp3-divider{
+  border-bottom:1px solid rgba(16, 22, 26, 0.15);
+  border-right:1px solid rgba(16, 22, 26, 0.15);
+  margin:5px; }
+  .bp3-dark .bp3-divider{
+    border-color:rgba(16, 22, 26, 0.4); }
 .bp3-control-group{
   -webkit-transform:translateZ(0);
           transform:translateZ(0);
@@ -2864,11 +3145,11 @@ a.bp3-button{
   .bp3-control-group .bp3-select{
     position:relative; }
   .bp3-control-group .bp3-input{
-    z-index:2;
-    border-radius:inherit; }
+    border-radius:inherit;
+    z-index:2; }
     .bp3-control-group .bp3-input:focus{
-      z-index:14;
-      border-radius:3px; }
+      border-radius:3px;
+      z-index:14; }
     .bp3-control-group .bp3-input[class*="bp3-intent"]{
       z-index:13; }
       .bp3-control-group .bp3-input[class*="bp3-intent"]:focus{
@@ -2884,8 +3165,8 @@ a.bp3-button{
   .bp3-control-group .bp3-select select{
     -webkit-transform:translateZ(0);
             transform:translateZ(0);
-    z-index:4;
-    border-radius:inherit; }
+    border-radius:inherit;
+    z-index:4; }
     .bp3-control-group .bp3-button:focus,
     .bp3-control-group .bp3-html-select select:focus,
     .bp3-control-group .bp3-select select:focus{
@@ -2939,9 +3220,13 @@ a.bp3-button{
   .bp3-control-group .bp3-select > .bp3-icon,
   .bp3-control-group .bp3-html-select > .bp3-icon{
     z-index:17; }
-  .bp3-control-group:not(.bp3-vertical) > *{
+  .bp3-control-group .bp3-select:focus-within{
+    z-index:5; }
+  .bp3-control-group:not(.bp3-vertical) > *:not(.bp3-divider){
     margin-right:-1px; }
-  .bp3-dark .bp3-control-group:not(.bp3-vertical) > *{
+  .bp3-control-group:not(.bp3-vertical) > .bp3-divider:not(:first-child){
+    margin-left:6px; }
+  .bp3-dark .bp3-control-group:not(.bp3-vertical) > *:not(.bp3-divider){
     margin-right:0; }
   .bp3-dark .bp3-control-group:not(.bp3-vertical) > .bp3-button + .bp3-button{
     margin-left:1px; }
@@ -2951,13 +3236,18 @@ a.bp3-button{
   .bp3-control-group > :first-child{
     border-radius:3px 0 0 3px; }
   .bp3-control-group > :last-child{
-    margin-right:0;
-    border-radius:0 3px 3px 0; }
+    border-radius:0 3px 3px 0;
+    margin-right:0; }
   .bp3-control-group > :only-child{
-    margin-right:0;
-    border-radius:3px; }
+    border-radius:3px;
+    margin-right:0; }
   .bp3-control-group .bp3-input-group .bp3-button{
     border-radius:3px; }
+  .bp3-control-group .bp3-numeric-input:not(:first-child) .bp3-input-group{
+    border-bottom-left-radius:0;
+    border-top-left-radius:0; }
+  .bp3-control-group.bp3-fill{
+    width:100%; }
   .bp3-control-group > .bp3-fill{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
@@ -2974,50 +3264,50 @@ a.bp3-button{
     .bp3-control-group.bp3-vertical > *{
       margin-top:-1px; }
     .bp3-control-group.bp3-vertical > :first-child{
-      margin-top:0;
-      border-radius:3px 3px 0 0; }
+      border-radius:3px 3px 0 0;
+      margin-top:0; }
     .bp3-control-group.bp3-vertical > :last-child{
       border-radius:0 0 3px 3px; }
 .bp3-control{
-  display:block;
-  position:relative;
-  margin-bottom:10px;
   cursor:pointer;
+  display:block;
+  margin-bottom:10px;
+  position:relative;
   text-transform:none; }
   .bp3-control input:checked ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#137cbd;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-  .bp3-control:hover input:checked ~ .bp3-control-indicator{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#106ba3; }
+    color:#ffffff; }
+  .bp3-control:hover input:checked ~ .bp3-control-indicator{
+    background-color:#106ba3;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
   .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
+    background:#0e5a8a;
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#0e5a8a; }
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-control input:disabled:checked ~ .bp3-control-indicator{
+    background:rgba(19, 124, 189, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(19, 124, 189, 0.5); }
+            box-shadow:none; }
   .bp3-dark .bp3-control input:checked ~ .bp3-control-indicator{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control:hover input:checked ~ .bp3-control-indicator{
+    background-color:#106ba3;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#106ba3; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control input:not(:disabled):active:checked ~ .bp3-control-indicator{
+    background-color:#0e5a8a;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#0e5a8a; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-dark .bp3-control input:disabled:checked ~ .bp3-control-indicator{
+    background:rgba(14, 90, 138, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(14, 90, 138, 0.5); }
+            box-shadow:none; }
   .bp3-control:not(.bp3-align-right){
     padding-left:26px; }
     .bp3-control:not(.bp3-align-right) .bp3-control-indicator{
@@ -3027,53 +3317,53 @@ a.bp3-button{
     .bp3-control.bp3-align-right .bp3-control-indicator{
       margin-right:-26px; }
   .bp3-control.bp3-disabled{
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
   .bp3-control.bp3-inline{
     display:inline-block;
     margin-right:20px; }
   .bp3-control input{
-    position:absolute;
-    top:0;
     left:0;
     opacity:0;
+    position:absolute;
+    top:0;
     z-index:-1; }
   .bp3-control .bp3-control-indicator{
-    display:inline-block;
-    position:relative;
-    margin-top:-3px;
-    margin-right:10px;
-    border:none;
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
     background-color:#f5f8fa;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    border:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     cursor:pointer;
-    width:1em;
-    height:1em;
-    vertical-align:middle;
+    display:inline-block;
     font-size:16px;
+    height:1em;
+    margin-right:10px;
+    margin-top:-3px;
+    position:relative;
     -webkit-user-select:none;
        -moz-user-select:none;
         -ms-user-select:none;
-            user-select:none; }
+            user-select:none;
+    vertical-align:middle;
+    width:1em; }
     .bp3-control .bp3-control-indicator::before{
+      content:"";
       display:block;
-      width:1em;
       height:1em;
-      content:""; }
+      width:1em; }
   .bp3-control:hover .bp3-control-indicator{
     background-color:#ebf1f5; }
   .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
+    background:#d8e1e8;
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#d8e1e8; }
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-control input:disabled ~ .bp3-control-indicator{
+    background:rgba(206, 217, 224, 0.5);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
     cursor:not-allowed; }
   .bp3-control input:focus ~ .bp3-control-indicator{
     outline:rgba(19, 124, 189, 0.6) auto 2px;
@@ -3081,8 +3371,8 @@ a.bp3-button{
     -moz-outline-radius:6px; }
   .bp3-control.bp3-align-right .bp3-control-indicator{
     float:right;
-    margin-top:1px;
-    margin-left:10px; }
+    margin-left:10px;
+    margin-top:1px; }
   .bp3-control.bp3-large{
     font-size:16px; }
     .bp3-control.bp3-large:not(.bp3-align-right){
@@ -3098,43 +3388,43 @@ a.bp3-button{
     .bp3-control.bp3-large.bp3-align-right .bp3-control-indicator{
       margin-top:0; }
   .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
     background-color:#137cbd;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-    color:#ffffff; }
-  .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
-    background-color:#106ba3; }
+    color:#ffffff; }
+  .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
+    background-color:#106ba3;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.2); }
   .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
+    background:#0e5a8a;
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background:#0e5a8a; }
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
+    background:rgba(19, 124, 189, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(19, 124, 189, 0.5); }
+            box-shadow:none; }
   .bp3-dark .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-checkbox:hover input:indeterminate ~ .bp3-control-indicator{
+    background-color:#106ba3;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#106ba3; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-checkbox input:not(:disabled):active:indeterminate ~ .bp3-control-indicator{
+    background-color:#0e5a8a;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-    background-color:#0e5a8a; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
+    background:rgba(14, 90, 138, 0.5);
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:rgba(14, 90, 138, 0.5); }
+            box-shadow:none; }
   .bp3-control.bp3-checkbox .bp3-control-indicator{
     border-radius:3px; }
   .bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator::before{
-    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='white'/%3e%3c/svg%3e"); }
+    background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='white'/%3e%3c/svg%3e"); }
   .bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator::before{
     background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M11 7H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z' fill='white'/%3e%3c/svg%3e"); }
   .bp3-control.bp3-radio .bp3-control-indicator{
@@ -3178,22 +3468,22 @@ a.bp3-button{
     border-radius:1.75em;
     -webkit-box-shadow:none !important;
             box-shadow:none !important;
-    width:auto;
     min-width:1.75em;
     -webkit-transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+    transition:background-color 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    width:auto; }
     .bp3-control.bp3-switch .bp3-control-indicator::before{
-      position:absolute;
-      left:0;
-      margin:2px;
+      background:#ffffff;
       border-radius:50%;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
-      background:#ffffff;
-      width:calc(1em - 4px);
       height:calc(1em - 4px);
+      left:0;
+      margin:2px;
+      position:absolute;
       -webkit-transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-      transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+      transition:left 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
+      width:calc(1em - 4px); }
   .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
     left:calc(100% - 1em); }
   .bp3-control.bp3-switch.bp3-large:not(.bp3-align-right){
@@ -3225,96 +3515,96 @@ a.bp3-button{
     .bp3-dark .bp3-control.bp3-switch input:checked:disabled ~ .bp3-control-indicator::before{
       background:rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-switch .bp3-control-indicator::before{
+    background:#394b59;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background:#394b59; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator::before{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-control.bp3-switch .bp3-switch-inner-text{
-    text-align:center;
-    font-size:0.7em; }
+    font-size:0.7em;
+    text-align:center; }
   .bp3-control.bp3-switch .bp3-control-indicator-child:first-child{
-    visibility:hidden;
-    margin-right:1.2em;
+    line-height:0;
     margin-left:0.5em;
-    line-height:0; }
+    margin-right:1.2em;
+    visibility:hidden; }
   .bp3-control.bp3-switch .bp3-control-indicator-child:last-child{
-    visibility:visible;
-    margin-right:0.5em;
+    line-height:1em;
     margin-left:1.2em;
-    line-height:1em; }
+    margin-right:0.5em;
+    visibility:visible; }
   .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:first-child{
-    visibility:visible;
-    line-height:1em; }
+    line-height:1em;
+    visibility:visible; }
   .bp3-control.bp3-switch input:checked ~ .bp3-control-indicator .bp3-control-indicator-child:last-child{
-    visibility:hidden;
-    line-height:0; }
+    line-height:0;
+    visibility:hidden; }
   .bp3-dark .bp3-control{
     color:#f5f8fa; }
     .bp3-dark .bp3-control.bp3-disabled{
       color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-control .bp3-control-indicator{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
       background-color:#394b59;
       background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
-      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0)); }
+      background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-control:hover .bp3-control-indicator{
       background-color:#30404d; }
     .bp3-dark .bp3-control input:not(:disabled):active ~ .bp3-control-indicator{
+      background:#202b33;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-      background:#202b33; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-control input:disabled ~ .bp3-control-indicator{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       cursor:not-allowed; }
     .bp3-dark .bp3-control.bp3-checkbox input:disabled:checked ~ .bp3-control-indicator, .bp3-dark .bp3-control.bp3-checkbox input:disabled:indeterminate ~ .bp3-control-indicator{
       color:rgba(167, 182, 194, 0.6); }
 .bp3-file-input{
-  display:inline-block;
-  position:relative;
   cursor:pointer;
-  height:30px; }
+  display:inline-block;
+  height:30px;
+  position:relative; }
   .bp3-file-input input{
-    opacity:0;
     margin:0;
-    min-width:200px; }
+    min-width:200px;
+    opacity:0; }
     .bp3-file-input input:disabled + .bp3-file-upload-input,
     .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
+      background:rgba(206, 217, 224, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(206, 217, 224, 0.5);
-      cursor:not-allowed;
       color:rgba(92, 112, 128, 0.6);
+      cursor:not-allowed;
       resize:none; }
       .bp3-file-input input:disabled + .bp3-file-upload-input::after,
       .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
-        outline:none;
-        -webkit-box-shadow:none;
-                box-shadow:none;
         background-color:rgba(206, 217, 224, 0.5);
         background-image:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
+        color:rgba(92, 112, 128, 0.6);
         cursor:not-allowed;
-        color:rgba(92, 112, 128, 0.6); }
+        outline:none; }
         .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active:hover,
         .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active,
         .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active:hover{
           background:rgba(206, 217, 224, 0.7); }
       .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input, .bp3-dark
       .bp3-file-input input.bp3-disabled + .bp3-file-upload-input{
+        background:rgba(57, 75, 89, 0.5);
         -webkit-box-shadow:none;
                 box-shadow:none;
-        background:rgba(57, 75, 89, 0.5);
         color:rgba(167, 182, 194, 0.6); }
         .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after, .bp3-dark
         .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after{
-          -webkit-box-shadow:none;
-                  box-shadow:none;
           background-color:rgba(57, 75, 89, 0.5);
           background-image:none;
+          -webkit-box-shadow:none;
+                  box-shadow:none;
           color:rgba(167, 182, 194, 0.6); }
           .bp3-dark .bp3-file-input input:disabled + .bp3-file-upload-input::after.bp3-active, .bp3-dark
           .bp3-file-input input.bp3-disabled + .bp3-file-upload-input::after.bp3-active{
@@ -3332,55 +3622,55 @@ a.bp3-button{
     content:attr(bp3-button-text); }
 
 .bp3-file-upload-input{
-  outline:none;
+  -webkit-appearance:none;
+     -moz-appearance:none;
+          appearance:none;
+  background:#ffffff;
   border:none;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  height:30px;
-  padding:0 10px;
-  vertical-align:middle;
-  line-height:30px;
   color:#182026;
   font-size:14px;
   font-weight:400;
+  height:30px;
+  line-height:30px;
+  outline:none;
+  padding:0 10px;
   -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  -webkit-appearance:none;
-     -moz-appearance:none;
-          appearance:none;
+  vertical-align:middle;
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
   word-wrap:normal;
-  position:absolute;
-  top:0;
-  right:0;
+  color:rgba(92, 112, 128, 0.6);
   left:0;
   padding-right:80px;
-  color:rgba(92, 112, 128, 0.6);
+  position:absolute;
+  right:0;
+  top:0;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
           user-select:none; }
   .bp3-file-upload-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-file-upload-input:focus, .bp3-file-upload-input.bp3-active{
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
@@ -3393,81 +3683,81 @@ a.bp3-button{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
   .bp3-file-upload-input:disabled, .bp3-file-upload-input.bp3-disabled{
+    background:rgba(206, 217, 224, 0.5);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
-    cursor:not-allowed;
     color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed;
     resize:none; }
   .bp3-file-upload-input::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-color:#f5f8fa;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     color:#182026;
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     overflow:hidden;
     text-overflow:ellipsis;
     white-space:nowrap;
     word-wrap:normal;
-    position:absolute;
-    top:0;
-    right:0;
-    margin:3px;
     border-radius:3px;
-    width:70px;
-    text-align:center;
+    content:"Browse";
     line-height:24px;
-    content:"Browse"; }
+    margin:3px;
+    position:absolute;
+    right:0;
+    text-align:center;
+    top:0;
+    width:70px; }
     .bp3-file-upload-input::after:hover{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
       background-clip:padding-box;
-      background-color:#ebf1f5; }
+      background-color:#ebf1f5;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
     .bp3-file-upload-input::after:active, .bp3-file-upload-input::after.bp3-active{
-      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#d8e1e8;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-file-upload-input::after:disabled, .bp3-file-upload-input::after.bp3-disabled{
-      outline:none;
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(206, 217, 224, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
+      color:rgba(92, 112, 128, 0.6);
       cursor:not-allowed;
-      color:rgba(92, 112, 128, 0.6); }
+      outline:none; }
       .bp3-file-upload-input::after:disabled.bp3-active, .bp3-file-upload-input::after:disabled.bp3-active:hover, .bp3-file-upload-input::after.bp3-disabled.bp3-active, .bp3-file-upload-input::after.bp3-disabled.bp3-active:hover{
         background:rgba(206, 217, 224, 0.7); }
   .bp3-file-upload-input:hover::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
-    background-color:#ebf1f5; }
+    background-color:#ebf1f5;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
   .bp3-file-upload-input:active::after{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-large .bp3-file-upload-input{
+    font-size:16px;
     height:40px;
     line-height:40px;
-    font-size:16px;
     padding-right:95px; }
     .bp3-large .bp3-file-upload-input[type="search"], .bp3-large .bp3-file-upload-input.bp3-round{
       padding:0 15px; }
     .bp3-large .bp3-file-upload-input::after{
-      min-width:30px;
       min-height:30px;
+      min-width:30px;
+      line-height:30px;
       margin:5px;
-      width:85px;
-      line-height:30px; }
+      width:85px; }
   .bp3-dark .bp3-file-upload-input{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa;
     color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-file-upload-input::-webkit-input-placeholder{
@@ -3487,33 +3777,33 @@ a.bp3-button{
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
               box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-file-upload-input:disabled, .bp3-dark .bp3-file-upload-input.bp3-disabled{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-file-upload-input::after{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
       background-color:#394b59;
       background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
       background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
       color:#f5f8fa; }
       .bp3-dark .bp3-file-upload-input::after:hover, .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
         color:#f5f8fa; }
       .bp3-dark .bp3-file-upload-input::after:hover{
+        background-color:#30404d;
         -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-        background-color:#30404d; }
+                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
       .bp3-dark .bp3-file-upload-input::after:active, .bp3-dark .bp3-file-upload-input::after.bp3-active{
-        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
         background-color:#202b33;
-        background-image:none; }
+        background-image:none;
+        -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+                box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
       .bp3-dark .bp3-file-upload-input::after:disabled, .bp3-dark .bp3-file-upload-input::after.bp3-disabled{
-        -webkit-box-shadow:none;
-                box-shadow:none;
         background-color:rgba(57, 75, 89, 0.5);
         background-image:none;
+        -webkit-box-shadow:none;
+                box-shadow:none;
         color:rgba(167, 182, 194, 0.6); }
         .bp3-dark .bp3-file-upload-input::after:disabled.bp3-active, .bp3-dark .bp3-file-upload-input::after.bp3-disabled.bp3-active{
           background:rgba(57, 75, 89, 0.7); }
@@ -3521,15 +3811,14 @@ a.bp3-button{
         background:rgba(16, 22, 26, 0.5);
         stroke:#8a9ba8; }
     .bp3-dark .bp3-file-upload-input:hover::after{
+      background-color:#30404d;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-file-upload-input:active::after{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#202b33;
-      background-image:none; }
-
+      background-image:none;
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
 .bp3-file-upload-input::after{
   -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
           box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
@@ -3547,9 +3836,9 @@ a.bp3-button{
   .bp3-form-group .bp3-control{
     margin-top:7px; }
   .bp3-form-group .bp3-form-helper-text{
-    margin-top:5px;
     color:#5c7080;
-    font-size:12px; }
+    font-size:12px;
+    margin-top:5px; }
   .bp3-form-group.bp3-intent-primary .bp3-form-helper-text{
     color:#106ba3; }
   .bp3-form-group.bp3-intent-success .bp3-form-helper-text{
@@ -3559,19 +3848,19 @@ a.bp3-button{
   .bp3-form-group.bp3-intent-danger .bp3-form-helper-text{
     color:#c23030; }
   .bp3-form-group.bp3-inline{
+    -webkit-box-align:start;
+        -ms-flex-align:start;
+            align-items:flex-start;
     -webkit-box-orient:horizontal;
     -webkit-box-direction:normal;
         -ms-flex-direction:row;
-            flex-direction:row;
-    -webkit-box-align:start;
-        -ms-flex-align:start;
-            align-items:flex-start; }
+            flex-direction:row; }
     .bp3-form-group.bp3-inline.bp3-large label.bp3-label{
-      margin:0 10px 0 0;
-      line-height:40px; }
+      line-height:40px;
+      margin:0 10px 0 0; }
     .bp3-form-group.bp3-inline label.bp3-label{
-      margin:0 10px 0 0;
-      line-height:30px; }
+      line-height:30px;
+      margin:0 10px 0 0; }
   .bp3-form-group.bp3-disabled .bp3-label,
   .bp3-form-group.bp3-disabled .bp3-text-muted,
   .bp3-form-group.bp3-disabled .bp3-form-helper-text{
@@ -3601,36 +3890,44 @@ a.bp3-button{
     .bp3-input-group .bp3-input:not(:last-child){
       padding-right:30px; }
   .bp3-input-group .bp3-input-action,
+  .bp3-input-group > .bp3-input-left-container,
   .bp3-input-group > .bp3-button,
   .bp3-input-group > .bp3-icon{
     position:absolute;
     top:0; }
     .bp3-input-group .bp3-input-action:first-child,
+    .bp3-input-group > .bp3-input-left-container:first-child,
     .bp3-input-group > .bp3-button:first-child,
     .bp3-input-group > .bp3-icon:first-child{
       left:0; }
     .bp3-input-group .bp3-input-action:last-child,
+    .bp3-input-group > .bp3-input-left-container:last-child,
     .bp3-input-group > .bp3-button:last-child,
     .bp3-input-group > .bp3-icon:last-child{
       right:0; }
   .bp3-input-group .bp3-button{
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     margin:3px;
     padding:0 7px; }
     .bp3-input-group .bp3-button:empty{
       padding:0; }
+  .bp3-input-group > .bp3-input-left-container,
   .bp3-input-group > .bp3-icon{
-    z-index:1;
+    z-index:1; }
+  .bp3-input-group > .bp3-input-left-container > .bp3-icon,
+  .bp3-input-group > .bp3-icon{
     color:#5c7080; }
+    .bp3-input-group > .bp3-input-left-container > .bp3-icon:empty,
     .bp3-input-group > .bp3-icon:empty{
-      line-height:1;
       font-family:"Icons16", sans-serif;
       font-size:16px;
-      font-weight:400;
       font-style:normal;
+      font-weight:400;
+      line-height:1;
       -moz-osx-font-smoothing:grayscale;
       -webkit-font-smoothing:antialiased; }
+  .bp3-input-group > .bp3-input-left-container > .bp3-icon,
   .bp3-input-group > .bp3-icon,
   .bp3-input-group .bp3-input-action > .bp3-spinner{
     margin:7px; }
@@ -3660,16 +3957,17 @@ a.bp3-button{
     .bp3-input-group.bp3-disabled .bp3-icon{
       color:rgba(92, 112, 128, 0.6); }
   .bp3-input-group.bp3-large .bp3-button{
-    min-width:30px;
     min-height:30px;
+    min-width:30px;
     margin:5px; }
+  .bp3-input-group.bp3-large > .bp3-input-left-container > .bp3-icon,
   .bp3-input-group.bp3-large > .bp3-icon,
   .bp3-input-group.bp3-large .bp3-input-action > .bp3-spinner{
     margin:12px; }
   .bp3-input-group.bp3-large .bp3-input{
+    font-size:16px;
     height:40px;
-    line-height:40px;
-    font-size:16px; }
+    line-height:40px; }
     .bp3-input-group.bp3-large .bp3-input[type="search"], .bp3-input-group.bp3-large .bp3-input.bp3-round{
       padding:0 15px; }
     .bp3-input-group.bp3-large .bp3-input:not(:first-child){
@@ -3677,22 +3975,23 @@ a.bp3-button{
     .bp3-input-group.bp3-large .bp3-input:not(:last-child){
       padding-right:40px; }
   .bp3-input-group.bp3-small .bp3-button{
-    min-width:20px;
     min-height:20px;
+    min-width:20px;
     margin:2px; }
   .bp3-input-group.bp3-small .bp3-tag{
-    min-width:20px;
     min-height:20px;
+    min-width:20px;
     margin:2px; }
+  .bp3-input-group.bp3-small > .bp3-input-left-container > .bp3-icon,
   .bp3-input-group.bp3-small > .bp3-icon,
   .bp3-input-group.bp3-small .bp3-input-action > .bp3-spinner{
     margin:4px; }
   .bp3-input-group.bp3-small .bp3-input{
+    font-size:12px;
     height:24px;
-    padding-right:8px;
-    padding-left:8px;
     line-height:24px;
-    font-size:12px; }
+    padding-left:8px;
+    padding-right:8px; }
     .bp3-input-group.bp3-small .bp3-input[type="search"], .bp3-input-group.bp3-small .bp3-input.bp3-round{
       padding:0 12px; }
     .bp3-input-group.bp3-small .bp3-input:not(:first-child){
@@ -3777,41 +4076,41 @@ a.bp3-button{
     .bp3-dark .bp3-input-group.bp3-intent-danger > .bp3-icon{
       color:#ff7373; }
 .bp3-input{
-  outline:none;
+  -webkit-appearance:none;
+     -moz-appearance:none;
+          appearance:none;
+  background:#ffffff;
   border:none;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-  background:#ffffff;
-  height:30px;
-  padding:0 10px;
-  vertical-align:middle;
-  line-height:30px;
   color:#182026;
   font-size:14px;
   font-weight:400;
+  height:30px;
+  line-height:30px;
+  outline:none;
+  padding:0 10px;
   -webkit-transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9), -webkit-box-shadow 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
-  -webkit-appearance:none;
-     -moz-appearance:none;
-          appearance:none; }
+  vertical-align:middle; }
   .bp3-input::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input:focus, .bp3-input.bp3-active{
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
@@ -3824,24 +4123,24 @@ a.bp3-button{
     -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15);
             box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.15); }
   .bp3-input:disabled, .bp3-input.bp3-disabled{
+    background:rgba(206, 217, 224, 0.5);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(206, 217, 224, 0.5);
-    cursor:not-allowed;
     color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed;
     resize:none; }
   .bp3-input.bp3-large{
+    font-size:16px;
     height:40px;
-    line-height:40px;
-    font-size:16px; }
+    line-height:40px; }
     .bp3-input.bp3-large[type="search"], .bp3-input.bp3-large.bp3-round{
       padding:0 15px; }
   .bp3-input.bp3-small{
+    font-size:12px;
     height:24px;
-    padding-right:8px;
-    padding-left:8px;
     line-height:24px;
-    font-size:12px; }
+    padding-left:8px;
+    padding-right:8px; }
     .bp3-input.bp3-small[type="search"], .bp3-input.bp3-small.bp3-round{
       padding:0 12px; }
   .bp3-input.bp3-fill{
@@ -3850,9 +4149,9 @@ a.bp3-button{
             flex:1 1 auto;
     width:100%; }
   .bp3-dark .bp3-input{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa; }
     .bp3-dark .bp3-input::-webkit-input-placeholder{
       color:rgba(167, 182, 194, 0.6); }
@@ -3871,9 +4170,9 @@ a.bp3-button{
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
               box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-input:disabled, .bp3-dark .bp3-input.bp3-disabled{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       color:rgba(167, 182, 194, 0.6); }
   .bp3-input.bp3-intent-primary{
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px #137cbd, inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
@@ -3982,9 +4281,9 @@ textarea.bp3-input{
   textarea.bp3-input.bp3-small{
     padding:8px; }
   .bp3-dark textarea.bp3-input{
+    background:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background:rgba(16, 22, 26, 0.3);
     color:#f5f8fa; }
     .bp3-dark textarea.bp3-input::-webkit-input-placeholder{
       color:rgba(167, 182, 194, 0.6); }
@@ -4003,14 +4302,14 @@ textarea.bp3-input{
       -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4);
               box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark textarea.bp3-input:disabled, .bp3-dark textarea.bp3-input.bp3-disabled{
+      background:rgba(57, 75, 89, 0.5);
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:rgba(57, 75, 89, 0.5);
       color:rgba(167, 182, 194, 0.6); }
 label.bp3-label{
   display:block;
-  margin-top:0;
-  margin-bottom:15px; }
+  margin-bottom:15px;
+  margin-top:0; }
   label.bp3-label .bp3-html-select,
   label.bp3-label .bp3-input,
   label.bp3-label .bp3-select,
@@ -4023,9 +4322,9 @@ label.bp3-label{
     margin-top:5px; }
   label.bp3-label .bp3-select select,
   label.bp3-label .bp3-html-select select{
-    width:100%;
+    font-weight:400;
     vertical-align:top;
-    font-weight:400; }
+    width:100%; }
   label.bp3-label.bp3-disabled,
   label.bp3-label.bp3-disabled .bp3-text-muted{
     color:rgba(92, 112, 128, 0.6); }
@@ -4056,9 +4355,9 @@ label.bp3-label{
   -webkit-box-flex:1;
       -ms-flex:1 1 14px;
           flex:1 1 14px;
-  width:30px;
   min-height:0;
-  padding:0; }
+  padding:0;
+  width:30px; }
   .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:first-child{
     border-radius:0 3px 0 0; }
   .bp3-numeric-input .bp3-button-group.bp3-vertical > .bp3-button:last-child{
@@ -4087,28 +4386,28 @@ form{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  -webkit-box-pack:center;
-      -ms-flex-pack:center;
-          justify-content:center;
   border:none;
   border-radius:3px;
   cursor:pointer;
-  padding:5px 10px;
-  vertical-align:middle;
-  text-align:left;
   font-size:14px;
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+  -webkit-box-pack:center;
+      -ms-flex-pack:center;
+          justify-content:center;
+  padding:5px 10px;
+  text-align:left;
+  vertical-align:middle;
   background-color:#f5f8fa;
   background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
   background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
   color:#182026;
+  -moz-appearance:none;
+  -webkit-appearance:none;
   border-radius:3px;
-  width:100%;
   height:30px;
   padding:0 25px 0 10px;
-  -moz-appearance:none;
-  -webkit-appearance:none; }
+  width:100%; }
   .bp3-html-select select > *, .bp3-select select > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -4131,27 +4430,27 @@ form{
     margin-right:0; }
   .bp3-html-select select:hover,
   .bp3-select select:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
-    background-color:#ebf1f5; }
+    background-color:#ebf1f5;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
   .bp3-html-select select:active,
   .bp3-select select:active, .bp3-html-select select.bp3-active,
   .bp3-select select.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-html-select select:disabled,
   .bp3-select select:disabled, .bp3-html-select select.bp3-disabled,
   .bp3-select select.bp3-disabled{
-    outline:none;
-    -webkit-box-shadow:none;
-            box-shadow:none;
     background-color:rgba(206, 217, 224, 0.5);
     background-image:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    color:rgba(92, 112, 128, 0.6);
     cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    outline:none; }
     .bp3-html-select select:disabled.bp3-active,
     .bp3-select select:disabled.bp3-active, .bp3-html-select select:disabled.bp3-active:hover,
     .bp3-select select:disabled.bp3-active:hover, .bp3-html-select select.bp3-disabled.bp3-active,
@@ -4161,22 +4460,22 @@ form{
 
 .bp3-html-select.bp3-minimal select,
 .bp3-select.bp3-minimal select{
+  background:none;
   -webkit-box-shadow:none;
-          box-shadow:none;
-  background:none; }
+          box-shadow:none; }
   .bp3-html-select.bp3-minimal select:hover,
   .bp3-select.bp3-minimal select:hover{
+    background:rgba(167, 182, 194, 0.3);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(167, 182, 194, 0.3);
-    text-decoration:none;
-    color:#182026; }
+    color:#182026;
+    text-decoration:none; }
   .bp3-html-select.bp3-minimal select:active,
   .bp3-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal select.bp3-active,
   .bp3-select.bp3-minimal select.bp3-active{
+    background:rgba(115, 134, 148, 0.3);
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:rgba(115, 134, 148, 0.3);
     color:#182026; }
   .bp3-html-select.bp3-minimal select:disabled,
   .bp3-select.bp3-minimal select:disabled, .bp3-html-select.bp3-minimal select:disabled:hover,
@@ -4184,8 +4483,8 @@ form{
   .bp3-select.bp3-minimal select.bp3-disabled, .bp3-html-select.bp3-minimal select.bp3-disabled:hover,
   .bp3-select.bp3-minimal select.bp3-disabled:hover{
     background:none;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
     .bp3-html-select.bp3-minimal select:disabled.bp3-active,
     .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active,
     .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active,
@@ -4194,17 +4493,17 @@ form{
       background:rgba(115, 134, 148, 0.3); }
   .bp3-dark .bp3-html-select.bp3-minimal select, .bp3-html-select.bp3-minimal .bp3-dark select,
   .bp3-dark .bp3-select.bp3-minimal select, .bp3-select.bp3-minimal .bp3-dark select{
+    background:none;
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:none;
     color:inherit; }
     .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
     .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover, .bp3-dark .bp3-html-select.bp3-minimal select:active, .bp3-html-select.bp3-minimal .bp3-dark select:active,
     .bp3-dark .bp3-select.bp3-minimal select:active, .bp3-select.bp3-minimal .bp3-dark select:active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-active,
     .bp3-dark .bp3-select.bp3-minimal select.bp3-active, .bp3-select.bp3-minimal .bp3-dark select.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
-              box-shadow:none;
-      background:none; }
+              box-shadow:none; }
     .bp3-dark .bp3-html-select.bp3-minimal select:hover, .bp3-html-select.bp3-minimal .bp3-dark select:hover,
     .bp3-dark .bp3-select.bp3-minimal select:hover, .bp3-select.bp3-minimal .bp3-dark select:hover{
       background:rgba(138, 155, 168, 0.15); }
@@ -4219,8 +4518,8 @@ form{
     .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled:hover, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled:hover,
     .bp3-dark .bp3-select.bp3-minimal select.bp3-disabled:hover, .bp3-select.bp3-minimal .bp3-dark select.bp3-disabled:hover{
       background:none;
-      cursor:not-allowed;
-      color:rgba(167, 182, 194, 0.6); }
+      color:rgba(167, 182, 194, 0.6);
+      cursor:not-allowed; }
       .bp3-dark .bp3-html-select.bp3-minimal select:disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled.bp3-active,
       .bp3-dark .bp3-select.bp3-minimal select:disabled.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active,
       .bp3-dark .bp3-select.bp3-minimal select:disabled:hover.bp3-active, .bp3-select.bp3-minimal .bp3-dark select:disabled:hover.bp3-active, .bp3-dark .bp3-html-select.bp3-minimal select.bp3-disabled.bp3-active, .bp3-html-select.bp3-minimal .bp3-dark select.bp3-disabled.bp3-active,
@@ -4234,9 +4533,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-primary:hover, .bp3-html-select.bp3-minimal select.bp3-intent-primary:active,
     .bp3-select.bp3-minimal select.bp3-intent-primary:active, .bp3-html-select.bp3-minimal select.bp3-intent-primary.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-primary.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#106ba3; }
     .bp3-html-select.bp3-minimal select.bp3-intent-primary:hover,
     .bp3-select.bp3-minimal select.bp3-intent-primary:hover{
@@ -4286,9 +4585,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-success:hover, .bp3-html-select.bp3-minimal select.bp3-intent-success:active,
     .bp3-select.bp3-minimal select.bp3-intent-success:active, .bp3-html-select.bp3-minimal select.bp3-intent-success.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-success.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#0d8050; }
     .bp3-html-select.bp3-minimal select.bp3-intent-success:hover,
     .bp3-select.bp3-minimal select.bp3-intent-success:hover{
@@ -4338,9 +4637,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-warning:hover, .bp3-html-select.bp3-minimal select.bp3-intent-warning:active,
     .bp3-select.bp3-minimal select.bp3-intent-warning:active, .bp3-html-select.bp3-minimal select.bp3-intent-warning.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-warning.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#bf7326; }
     .bp3-html-select.bp3-minimal select.bp3-intent-warning:hover,
     .bp3-select.bp3-minimal select.bp3-intent-warning:hover{
@@ -4390,9 +4689,9 @@ form{
     .bp3-select.bp3-minimal select.bp3-intent-danger:hover, .bp3-html-select.bp3-minimal select.bp3-intent-danger:active,
     .bp3-select.bp3-minimal select.bp3-intent-danger:active, .bp3-html-select.bp3-minimal select.bp3-intent-danger.bp3-active,
     .bp3-select.bp3-minimal select.bp3-intent-danger.bp3-active{
+      background:none;
       -webkit-box-shadow:none;
               box-shadow:none;
-      background:none;
       color:#c23030; }
     .bp3-html-select.bp3-minimal select.bp3-intent-danger:hover,
     .bp3-select.bp3-minimal select.bp3-intent-danger:hover{
@@ -4438,33 +4737,33 @@ form{
 
 .bp3-html-select.bp3-large select,
 .bp3-select.bp3-large select{
+  font-size:16px;
   height:40px;
-  padding-right:35px;
-  font-size:16px; }
+  padding-right:35px; }
 
 .bp3-dark .bp3-html-select select, .bp3-dark .bp3-select select{
-  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
   background-color:#394b59;
   background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
   background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+          box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
   color:#f5f8fa; }
   .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover, .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
     color:#f5f8fa; }
   .bp3-dark .bp3-html-select select:hover, .bp3-dark .bp3-select select:hover{
+    background-color:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-    background-color:#30404d; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
   .bp3-dark .bp3-html-select select:active, .bp3-dark .bp3-select select:active, .bp3-dark .bp3-html-select select.bp3-active, .bp3-dark .bp3-select select.bp3-active{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#202b33;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-dark .bp3-html-select select:disabled, .bp3-dark .bp3-select select:disabled, .bp3-dark .bp3-html-select select.bp3-disabled, .bp3-dark .bp3-select select.bp3-disabled{
-    -webkit-box-shadow:none;
-            box-shadow:none;
     background-color:rgba(57, 75, 89, 0.5);
     background-image:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
     color:rgba(167, 182, 194, 0.6); }
     .bp3-dark .bp3-html-select select:disabled.bp3-active, .bp3-dark .bp3-select select:disabled.bp3-active, .bp3-dark .bp3-html-select select.bp3-disabled.bp3-active, .bp3-dark .bp3-select select.bp3-disabled.bp3-active{
       background:rgba(57, 75, 89, 0.7); }
@@ -4474,28 +4773,28 @@ form{
 
 .bp3-html-select select:disabled,
 .bp3-select select:disabled{
+  background-color:rgba(206, 217, 224, 0.5);
   -webkit-box-shadow:none;
           box-shadow:none;
-  background-color:rgba(206, 217, 224, 0.5);
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-html-select .bp3-icon,
 .bp3-select .bp3-icon, .bp3-select::after{
-  position:absolute;
-  top:7px;
-  right:7px;
   color:#5c7080;
-  pointer-events:none; }
+  pointer-events:none;
+  position:absolute;
+  right:7px;
+  top:7px; }
   .bp3-html-select .bp3-disabled.bp3-icon,
   .bp3-select .bp3-disabled.bp3-icon, .bp3-disabled.bp3-select::after{
     color:rgba(92, 112, 128, 0.6); }
 .bp3-html-select,
 .bp3-select{
   display:inline-block;
+  letter-spacing:normal;
   position:relative;
-  vertical-align:middle;
-  letter-spacing:normal; }
+  vertical-align:middle; }
   .bp3-html-select select::-ms-expand,
   .bp3-select select::-ms-expand{
     display:none; }
@@ -4515,8 +4814,8 @@ form{
   .bp3-html-select.bp3-large .bp3-icon,
   .bp3-select.bp3-large::after,
   .bp3-select.bp3-large .bp3-icon{
-    top:12px;
-    right:12px; }
+    right:12px;
+    top:12px; }
   .bp3-html-select.bp3-fill,
   .bp3-html-select.bp3-fill select,
   .bp3-select.bp3-fill,
@@ -4526,16 +4825,19 @@ form{
   .bp3-select option{
     background-color:#30404d;
     color:#f5f8fa; }
+  .bp3-dark .bp3-html-select option:disabled, .bp3-dark
+  .bp3-select option:disabled{
+    color:rgba(167, 182, 194, 0.6); }
   .bp3-dark .bp3-html-select::after, .bp3-dark
   .bp3-select::after{
     color:#a7b6c2; }
 
 .bp3-select::after{
-  line-height:1;
   font-family:"Icons16", sans-serif;
   font-size:16px;
-  font-weight:400;
   font-style:normal;
+  font-weight:400;
+  line-height:1;
   -moz-osx-font-smoothing:grayscale;
   -webkit-font-smoothing:antialiased;
   content:""; }
@@ -4546,8 +4848,8 @@ form{
   .bp3-running-text table td,
   table.bp3-html-table td{
     padding:11px;
-    vertical-align:top;
-    text-align:left; }
+    text-align:left;
+    vertical-align:top; }
   .bp3-running-text table th, table.bp3-html-table th{
     color:#182026;
     font-weight:600; }
@@ -4574,8 +4876,8 @@ form{
 table.bp3-html-table.bp3-html-table-condensed th,
 table.bp3-html-table.bp3-html-table-condensed td, table.bp3-html-table.bp3-small th,
 table.bp3-html-table.bp3-small td{
-  padding-top:6px;
-  padding-bottom:6px; }
+  padding-bottom:6px;
+  padding-top:6px; }
 
 table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
   background:rgba(191, 204, 214, 0.15); }
@@ -4605,33 +4907,29 @@ table.bp3-html-table.bp3-interactive tbody tr:hover td{
 table.bp3-html-table.bp3-interactive tbody tr:active td{
   background-color:rgba(191, 204, 214, 0.4); }
 
-.bp3-dark table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
-  background:rgba(92, 112, 128, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
-  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td{
-  -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
-  .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
-    -webkit-box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
-            box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15); }
-
-.bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
-  -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
-          box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
-  .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:first-child{
-    -webkit-box-shadow:none;
-            box-shadow:none; }
-
-.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:hover td{
-  background-color:rgba(92, 112, 128, 0.3);
-  cursor:pointer; }
-
-.bp3-dark table.bp3-html-table.bp3-interactive tbody tr:active td{
-  background-color:rgba(92, 112, 128, 0.4); }
+.bp3-dark table.bp3-html-table{ }
+  .bp3-dark table.bp3-html-table.bp3-html-table-striped tbody tr:nth-child(odd) td{
+    background:rgba(92, 112, 128, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered th:not(:first-child){
+    -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td{
+    -webkit-box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 0 1px 0 0 rgba(255, 255, 255, 0.15); }
+    .bp3-dark table.bp3-html-table.bp3-html-table-bordered tbody tr td:not(:first-child){
+      -webkit-box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15);
+              box-shadow:inset 1px 1px 0 0 rgba(255, 255, 255, 0.15); }
+  .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td{
+    -webkit-box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15);
+            box-shadow:inset 1px 0 0 0 rgba(255, 255, 255, 0.15); }
+    .bp3-dark table.bp3-html-table.bp3-html-table-bordered.bp3-html-table-striped tbody tr:not(:first-child) td:first-child{
+      -webkit-box-shadow:none;
+              box-shadow:none; }
+  .bp3-dark table.bp3-html-table.bp3-interactive tbody tr:hover td{
+    background-color:rgba(92, 112, 128, 0.3);
+    cursor:pointer; }
+  .bp3-dark table.bp3-html-table.bp3-interactive tbody tr:active td{
+    background-color:rgba(92, 112, 128, 0.4); }
 
 .bp3-key-combo{
   display:-webkit-box;
@@ -4664,8 +4962,8 @@ table.bp3-html-table.bp3-interactive tbody tr:active td{
     margin-right:0; }
 
 .bp3-hotkey-dialog{
-  top:40px;
-  padding-bottom:0; }
+  padding-bottom:0;
+  top:40px; }
   .bp3-hotkey-dialog .bp3-dialog-body{
     margin:0;
     padding:0; }
@@ -4685,17 +4983,17 @@ table.bp3-html-table.bp3-interactive tbody tr:active td{
       margin-top:40px; }
 
 .bp3-hotkey{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   -webkit-box-pack:justify;
       -ms-flex-pack:justify;
           justify-content:space-between;
-  margin-right:0;
-  margin-left:0; }
+  margin-left:0;
+  margin-right:0; }
   .bp3-hotkey:not(:last-child){
     margin-bottom:10px; }
 .bp3-icon{
@@ -4733,31 +5031,31 @@ table.bp3-html-table.bp3-interactive tbody tr:active td{
     color:#ff7373; }
 
 span.bp3-icon-standard{
-  line-height:1;
   font-family:"Icons16", sans-serif;
   font-size:16px;
-  font-weight:400;
   font-style:normal;
+  font-weight:400;
+  line-height:1;
   -moz-osx-font-smoothing:grayscale;
   -webkit-font-smoothing:antialiased;
   display:inline-block; }
 
 span.bp3-icon-large{
-  line-height:1;
   font-family:"Icons20", sans-serif;
   font-size:20px;
-  font-weight:400;
   font-style:normal;
+  font-weight:400;
+  line-height:1;
   -moz-osx-font-smoothing:grayscale;
   -webkit-font-smoothing:antialiased;
   display:inline-block; }
 
 span.bp3-icon:empty{
-  line-height:1;
   font-family:"Icons20";
   font-size:inherit;
+  font-style:normal;
   font-weight:400;
-  font-style:normal; }
+  line-height:1; }
   span.bp3-icon:empty::before{
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased; }
@@ -5070,6 +5368,9 @@ span.bp3-icon:empty{
 
 .bp3-icon-desktop::before{
   content:""; }
+
+.bp3-icon-diagnosis::before{
+  content:""; }
 
 .bp3-icon-diagram-tree::before{
   content:""; }
@@ -5505,6 +5806,9 @@ span.bp3-icon:empty{
 
 .bp3-icon-known-vehicle::before{
   content:""; }
+
+.bp3-icon-lab-test::before{
+  content:""; }
 
 .bp3-icon-label::before{
   content:""; }
@@ -6218,6 +6522,7 @@ span.bp3-icon:empty{
 
 .bp3-submenu .bp3-popover-target{
   display:block; }
+  .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{ }
 
 .bp3-submenu.bp3-popover{
   -webkit-box-shadow:none;
@@ -6233,19 +6538,19 @@ span.bp3-icon:empty{
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
 .bp3-menu{
-  margin:0;
-  border-radius:3px;
   background:#ffffff;
+  border-radius:3px;
+  color:#182026;
+  list-style:none;
+  margin:0;
   min-width:180px;
   padding:5px;
-  list-style:none;
-  text-align:left;
-  color:#182026; }
+  text-align:left; }
 
 .bp3-menu-divider{
+  border-top:1px solid rgba(16, 22, 26, 0.15);
   display:block;
-  margin:5px;
-  border-top:1px solid rgba(16, 22, 26, 0.15); }
+  margin:5px; }
   .bp3-dark .bp3-menu-divider{
     border-top-color:rgba(255, 255, 255, 0.15); }
 
@@ -6261,10 +6566,10 @@ span.bp3-icon:empty{
       -ms-flex-align:start;
           align-items:flex-start;
   border-radius:2px;
+  color:inherit;
+  line-height:20px;
   padding:5px 7px;
   text-decoration:none;
-  line-height:20px;
-  color:inherit;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
@@ -6295,8 +6600,8 @@ span.bp3-icon:empty{
     text-decoration:none; }
   .bp3-menu-item.bp3-disabled{
     background-color:inherit;
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
   .bp3-dark .bp3-menu-item{
     color:inherit; }
     .bp3-dark .bp3-menu-item:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
@@ -6374,18 +6679,18 @@ span.bp3-icon:empty{
     .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
       color:#ffffff; }
   .bp3-menu-item::before{
-    line-height:1;
     font-family:"Icons16", sans-serif;
     font-size:16px;
-    font-weight:400;
     font-style:normal;
+    font-weight:400;
+    line-height:1;
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased;
     margin-right:7px; }
   .bp3-menu-item::before,
   .bp3-menu-item > .bp3-icon{
-    margin-top:2px;
-    color:#5c7080; }
+    color:#5c7080;
+    margin-top:2px; }
   .bp3-menu-item .bp3-menu-item-label{
     color:#5c7080; }
   .bp3-menu-item:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item{
@@ -6393,40 +6698,40 @@ span.bp3-icon:empty{
   .bp3-menu-item.bp3-active, .bp3-menu-item:active{
     background-color:rgba(115, 134, 148, 0.3); }
   .bp3-menu-item.bp3-disabled{
-    outline:none !important;
     background-color:inherit !important;
+    color:rgba(92, 112, 128, 0.6) !important;
     cursor:not-allowed !important;
-    color:rgba(92, 112, 128, 0.6) !important; }
+    outline:none !important; }
     .bp3-menu-item.bp3-disabled::before,
     .bp3-menu-item.bp3-disabled > .bp3-icon,
     .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
       color:rgba(92, 112, 128, 0.6) !important; }
   .bp3-large .bp3-menu-item{
-    padding:9px 7px;
+    font-size:16px;
     line-height:22px;
-    font-size:16px; }
+    padding:9px 7px; }
     .bp3-large .bp3-menu-item .bp3-icon{
       margin-top:3px; }
     .bp3-large .bp3-menu-item::before{
-      line-height:1;
       font-family:"Icons20", sans-serif;
       font-size:20px;
-      font-weight:400;
       font-style:normal;
+      font-weight:400;
+      line-height:1;
       -moz-osx-font-smoothing:grayscale;
       -webkit-font-smoothing:antialiased;
-      margin-top:1px;
-      margin-right:10px; }
+      margin-right:10px;
+      margin-top:1px; }
 
 button.bp3-menu-item{
-  border:none;
   background:none;
-  width:100%;
-  text-align:left; }
+  border:none;
+  text-align:left;
+  width:100%; }
 .bp3-menu-header{
+  border-top:1px solid rgba(16, 22, 26, 0.15);
   display:block;
   margin:5px;
-  border-top:1px solid rgba(16, 22, 26, 0.15);
   cursor:default;
   padding-left:2px; }
   .bp3-dark .bp3-menu-header{
@@ -6440,17 +6745,17 @@ button.bp3-menu-item{
     text-overflow:ellipsis;
     white-space:nowrap;
     word-wrap:normal;
+    line-height:17px;
     margin:0;
-    padding:10px 7px 0 1px;
-    line-height:17px; }
+    padding:10px 7px 0 1px; }
     .bp3-dark .bp3-menu-header > h6{
       color:#f5f8fa; }
   .bp3-menu-header:first-of-type > h6{
     padding-top:0; }
   .bp3-large .bp3-menu-header > h6{
-    padding-top:15px;
+    font-size:18px;
     padding-bottom:5px;
-    font-size:18px; }
+    padding-top:15px; }
   .bp3-large .bp3-menu-header:first-of-type > h6{
     padding-top:0; }
 
@@ -6458,98 +6763,92 @@ button.bp3-menu-item{
   background:#30404d;
   color:#f5f8fa; }
 
-.bp3-dark .bp3-menu-item.bp3-intent-primary{
-  color:#48aff0; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary::before, .bp3-dark .bp3-menu-item.bp3-intent-primary::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
+.bp3-dark .bp3-menu-item{ }
+  .bp3-dark .bp3-menu-item.bp3-intent-primary{
     color:#48aff0; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active{
-    background-color:#137cbd; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:active{
-    background-color:#106ba3; }
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary:active, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-success{
-  color:#3dcc91; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success::before, .bp3-dark .bp3-menu-item.bp3-intent-success::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary::before, .bp3-dark .bp3-menu-item.bp3-intent-primary::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary .bp3-menu-item-label{
+      color:#48aff0; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active{
+      background-color:#137cbd; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:active{
+      background-color:#106ba3; }
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-primary.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary:active, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-primary.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item.bp3-intent-success{
     color:#3dcc91; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active{
-    background-color:#0f9960; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:active{
-    background-color:#0d8050; }
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success:active, .bp3-dark .bp3-menu-item.bp3-intent-success:active::before, .bp3-dark .bp3-menu-item.bp3-intent-success:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-warning{
-  color:#ffb366; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning::before, .bp3-dark .bp3-menu-item.bp3-intent-warning::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success::before, .bp3-dark .bp3-menu-item.bp3-intent-success::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success .bp3-menu-item-label{
+      color:#3dcc91; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active{
+      background-color:#0f9960; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success:active{
+      background-color:#0d8050; }
+    .bp3-dark .bp3-menu-item.bp3-intent-success:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-success:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-success.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success:active, .bp3-dark .bp3-menu-item.bp3-intent-success:active::before, .bp3-dark .bp3-menu-item.bp3-intent-success:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-success.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item.bp3-intent-warning{
     color:#ffb366; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active{
-    background-color:#d9822b; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:active{
-    background-color:#bf7326; }
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning:active, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item.bp3-intent-danger{
-  color:#ff7373; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-icon{
-    color:inherit; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger::before, .bp3-dark .bp3-menu-item.bp3-intent-danger::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning::before, .bp3-dark .bp3-menu-item.bp3-intent-warning::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning .bp3-menu-item-label{
+      color:#ffb366; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active{
+      background-color:#d9822b; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:active{
+      background-color:#bf7326; }
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-warning.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning:active, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-warning.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item.bp3-intent-danger{
     color:#ff7373; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active{
-    background-color:#db3737; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:active{
-    background-color:#c23030; }
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
-  .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label,
-  .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger:active, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::after,
-  .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
-    color:#ffffff; }
-
-.bp3-dark .bp3-menu-item::before,
-.bp3-dark .bp3-menu-item > .bp3-icon{
-  color:#a7b6c2; }
-
-.bp3-dark .bp3-menu-item .bp3-menu-item-label{
-  color:#a7b6c2; }
-
-.bp3-dark .bp3-menu-item.bp3-active, .bp3-dark .bp3-menu-item:active{
-  background-color:rgba(138, 155, 168, 0.3); }
-
-.bp3-dark .bp3-menu-item.bp3-disabled{
-  color:rgba(167, 182, 194, 0.6) !important; }
-  .bp3-dark .bp3-menu-item.bp3-disabled::before,
-  .bp3-dark .bp3-menu-item.bp3-disabled > .bp3-icon,
-  .bp3-dark .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
+    .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-icon{
+      color:inherit; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger::before, .bp3-dark .bp3-menu-item.bp3-intent-danger::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger .bp3-menu-item-label{
+      color:#ff7373; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active{
+      background-color:#db3737; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:active{
+      background-color:#c23030; }
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:hover, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::before, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:hover::after, .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after, .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:hover .bp3-menu-item-label,
+    .bp3-dark .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label,
+    .bp3-submenu .bp3-dark .bp3-popover-target.bp3-popover-open > .bp3-intent-danger.bp3-menu-item .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger:active, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger:active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger:active .bp3-menu-item-label, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::before, .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active::after,
+    .bp3-dark .bp3-menu-item.bp3-intent-danger.bp3-active .bp3-menu-item-label{
+      color:#ffffff; }
+  .bp3-dark .bp3-menu-item::before,
+  .bp3-dark .bp3-menu-item > .bp3-icon{
+    color:#a7b6c2; }
+  .bp3-dark .bp3-menu-item .bp3-menu-item-label{
+    color:#a7b6c2; }
+  .bp3-dark .bp3-menu-item.bp3-active, .bp3-dark .bp3-menu-item:active{
+    background-color:rgba(138, 155, 168, 0.3); }
+  .bp3-dark .bp3-menu-item.bp3-disabled{
     color:rgba(167, 182, 194, 0.6) !important; }
+    .bp3-dark .bp3-menu-item.bp3-disabled::before,
+    .bp3-dark .bp3-menu-item.bp3-disabled > .bp3-icon,
+    .bp3-dark .bp3-menu-item.bp3-disabled .bp3-menu-item-label{
+      color:rgba(167, 182, 194, 0.6) !important; }
 
 .bp3-dark .bp3-menu-divider,
 .bp3-dark .bp3-menu-header{
@@ -6561,14 +6860,14 @@ button.bp3-menu-item{
 .bp3-label .bp3-menu{
   margin-top:5px; }
 .bp3-navbar{
-  position:relative;
-  z-index:10;
+  background-color:#ffffff;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  width:100%;
   height:50px;
-  padding:0 15px; }
+  padding:0 15px;
+  position:relative;
+  width:100%;
+  z-index:10; }
   .bp3-navbar.bp3-dark,
   .bp3-dark .bp3-navbar{
     background-color:#394b59; }
@@ -6579,22 +6878,22 @@ button.bp3-menu-item{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4); }
   .bp3-navbar.bp3-fixed-top{
+    left:0;
     position:fixed;
-    top:0;
     right:0;
-    left:0; }
+    top:0; }
 
 .bp3-navbar-heading{
-  margin-right:15px;
-  font-size:16px; }
+  font-size:16px;
+  margin-right:15px; }
 
 .bp3-navbar-group{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   height:50px; }
   .bp3-navbar-group.bp3-align-left{
     float:left; }
@@ -6602,9 +6901,9 @@ button.bp3-menu-item{
     float:right; }
 
 .bp3-navbar-divider{
-  margin:0 10px;
   border-left:1px solid rgba(16, 22, 26, 0.15);
-  height:20px; }
+  height:20px;
+  margin:0 10px; }
   .bp3-dark .bp3-navbar-divider{
     border-left-color:rgba(255, 255, 255, 0.15); }
 .bp3-non-ideal-state{
@@ -6618,12 +6917,12 @@ button.bp3-menu-item{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  height:100%;
   -webkit-box-pack:center;
       -ms-flex-pack:center;
           justify-content:center;
-  width:100%;
-  height:100%;
-  text-align:center; }
+  text-align:center;
+  width:100%; }
   .bp3-non-ideal-state > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -6668,22 +6967,22 @@ body.bp3-overlay-open{
   overflow:hidden; }
 
 .bp3-overlay{
-  position:static;
-  top:0;
-  right:0;
   bottom:0;
   left:0;
+  position:static;
+  right:0;
+  top:0;
   z-index:20; }
   .bp3-overlay:not(.bp3-overlay-open){
     pointer-events:none; }
   .bp3-overlay.bp3-overlay-container{
-    position:fixed;
-    overflow:hidden; }
+    overflow:hidden;
+    position:fixed; }
     .bp3-overlay.bp3-overlay-container.bp3-overlay-inline{
       position:absolute; }
   .bp3-overlay.bp3-overlay-scroll-container{
-    position:fixed;
-    overflow:auto; }
+    overflow:auto;
+    position:fixed; }
     .bp3-overlay.bp3-overlay-scroll-container.bp3-overlay-inline{
       position:absolute; }
   .bp3-overlay.bp3-overlay-inline{
@@ -6698,77 +6997,77 @@ body.bp3-overlay-open{
     position:absolute; }
 
 .bp3-overlay-backdrop{
-  position:fixed;
-  top:0;
-  right:0;
   bottom:0;
   left:0;
+  position:fixed;
+  right:0;
+  top:0;
   opacity:1;
-  z-index:20;
   background-color:rgba(16, 22, 26, 0.7);
   overflow:auto;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
-          user-select:none; }
+          user-select:none;
+  z-index:20; }
   .bp3-overlay-backdrop.bp3-overlay-enter, .bp3-overlay-backdrop.bp3-overlay-appear{
     opacity:0; }
   .bp3-overlay-backdrop.bp3-overlay-enter-active, .bp3-overlay-backdrop.bp3-overlay-appear-active{
     opacity:1;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:200ms;
             transition-duration:200ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-overlay-backdrop.bp3-overlay-exit{
     opacity:1; }
   .bp3-overlay-backdrop.bp3-overlay-exit-active{
     opacity:0;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:200ms;
             transition-duration:200ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-overlay-backdrop:focus{
     outline:none; }
   .bp3-overlay-inline .bp3-overlay-backdrop{
     position:absolute; }
 .bp3-panel-stack{
-  position:relative;
-  overflow:hidden; }
+  overflow:hidden;
+  position:relative; }
 
 .bp3-panel-stack-header{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
+  -webkit-box-shadow:0 1px rgba(16, 22, 26, 0.15);
+          box-shadow:0 1px rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -ms-flex-negative:0;
       flex-shrink:0;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  z-index:1;
-  -webkit-box-shadow:0 1px rgba(16, 22, 26, 0.15);
-          box-shadow:0 1px rgba(16, 22, 26, 0.15);
-  height:30px; }
+  height:30px;
+  z-index:1; }
   .bp3-dark .bp3-panel-stack-header{
     -webkit-box-shadow:0 1px rgba(255, 255, 255, 0.15);
             box-shadow:0 1px rgba(255, 255, 255, 0.15); }
   .bp3-panel-stack-header > span{
+    -webkit-box-align:stretch;
+        -ms-flex-align:stretch;
+            align-items:stretch;
     display:-webkit-box;
     display:-ms-flexbox;
     display:flex;
     -webkit-box-flex:1;
         -ms-flex:1;
-            flex:1;
-    -webkit-box-align:stretch;
-        -ms-flex-align:stretch;
-            align-items:stretch; }
+            flex:1; }
   .bp3-panel-stack-header .bp3-heading{
     margin:0 5px; }
 
@@ -6780,11 +7079,13 @@ body.bp3-overlay-open{
     margin:0 2px; }
 
 .bp3-panel-stack-view{
-  position:absolute;
-  top:0;
-  right:0;
   bottom:0;
   left:0;
+  position:absolute;
+  right:0;
+  top:0;
+  background-color:#ffffff;
+  border-right:1px solid rgba(16, 22, 26, 0.15);
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
@@ -6793,11 +7094,12 @@ body.bp3-overlay-open{
       -ms-flex-direction:column;
           flex-direction:column;
   margin-right:-1px;
-  border-right:1px solid rgba(16, 22, 26, 0.15);
-  background-color:#ffffff;
-  overflow-y:auto; }
+  overflow-y:auto;
+  z-index:1; }
   .bp3-dark .bp3-panel-stack-view{
     background-color:#30404d; }
+  .bp3-panel-stack-view:nth-last-child(n + 4){
+    display:none; }
 
 .bp3-panel-stack-push .bp3-panel-stack-enter, .bp3-panel-stack-push .bp3-panel-stack-appear{
   -webkit-transform:translateX(100%);
@@ -6808,16 +7110,16 @@ body.bp3-overlay-open{
   -webkit-transform:translate(0%);
           transform:translate(0%);
   opacity:1;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 
 .bp3-panel-stack-push .bp3-panel-stack-exit{
   -webkit-transform:translate(0%);
@@ -6828,16 +7130,16 @@ body.bp3-overlay-open{
   -webkit-transform:translateX(-50%);
           transform:translateX(-50%);
   opacity:0;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 
 .bp3-panel-stack-pop .bp3-panel-stack-enter, .bp3-panel-stack-pop .bp3-panel-stack-appear{
   -webkit-transform:translateX(-50%);
@@ -6848,16 +7150,16 @@ body.bp3-overlay-open{
   -webkit-transform:translate(0%);
           transform:translate(0%);
   opacity:1;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 
 .bp3-panel-stack-pop .bp3-panel-stack-exit{
   -webkit-transform:translate(0%);
@@ -6868,35 +7170,35 @@ body.bp3-overlay-open{
   -webkit-transform:translateX(100%);
           transform:translateX(100%);
   opacity:0;
+  -webkit-transition-delay:0;
+          transition-delay:0;
+  -webkit-transition-duration:400ms;
+          transition-duration:400ms;
   -webkit-transition-property:opacity, -webkit-transform;
   transition-property:opacity, -webkit-transform;
   transition-property:transform, opacity;
   transition-property:transform, opacity, -webkit-transform;
-  -webkit-transition-duration:400ms;
-          transition-duration:400ms;
   -webkit-transition-timing-function:ease;
-          transition-timing-function:ease;
-  -webkit-transition-delay:0;
-          transition-delay:0; }
+          transition-timing-function:ease; }
 .bp3-popover{
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
   -webkit-transform:scale(1);
           transform:scale(1);
+  border-radius:3px;
   display:inline-block;
-  z-index:20;
-  border-radius:3px; }
+  z-index:20; }
   .bp3-popover .bp3-popover-arrow{
+    height:30px;
     position:absolute;
-    width:30px;
-    height:30px; }
+    width:30px; }
     .bp3-popover .bp3-popover-arrow::before{
+      height:20px;
       margin:5px;
-      width:20px;
-      height:20px; }
+      width:20px; }
   .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover{
-    margin-top:-17px;
-    margin-bottom:17px; }
+    margin-bottom:17px;
+    margin-top:-17px; }
     .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow{
       bottom:-11px; }
       .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-popover > .bp3-popover-arrow svg{
@@ -6917,8 +7219,8 @@ body.bp3-overlay-open{
         -webkit-transform:rotate(90deg);
                 transform:rotate(90deg); }
   .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover{
-    margin-right:17px;
-    margin-left:-17px; }
+    margin-left:-17px;
+    margin-right:17px; }
     .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow{
       right:-11px; }
       .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-popover > .bp3-popover-arrow svg{
@@ -6984,35 +7286,35 @@ body.bp3-overlay-open{
   .bp3-popover-enter-active > .bp3-popover, .bp3-popover-appear-active > .bp3-popover{
     -webkit-transform:scale(1);
             transform:scale(1);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-popover-exit > .bp3-popover{
     -webkit-transform:scale(1);
             transform:scale(1); }
   .bp3-popover-exit-active > .bp3-popover{
     -webkit-transform:scale(0.3);
             transform:scale(0.3);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-popover .bp3-popover-content{
-    position:relative;
-    border-radius:3px; }
+    border-radius:3px;
+    position:relative; }
   .bp3-popover.bp3-popover-content-sizing .bp3-popover-content{
     max-width:350px;
     padding:20px; }
@@ -7031,32 +7333,32 @@ body.bp3-overlay-open{
       .bp3-popover-enter-active > .bp3-popover.bp3-minimal.bp3-popover, .bp3-popover-appear-active > .bp3-popover.bp3-minimal.bp3-popover{
         -webkit-transform:scale(1);
                 transform:scale(1);
+        -webkit-transition-delay:0;
+                transition-delay:0;
+        -webkit-transition-duration:100ms;
+                transition-duration:100ms;
         -webkit-transition-property:-webkit-transform;
         transition-property:-webkit-transform;
         transition-property:transform;
         transition-property:transform, -webkit-transform;
-        -webkit-transition-duration:100ms;
-                transition-duration:100ms;
         -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-        -webkit-transition-delay:0;
-                transition-delay:0; }
+                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
       .bp3-popover-exit > .bp3-popover.bp3-minimal.bp3-popover{
         -webkit-transform:scale(1);
                 transform:scale(1); }
       .bp3-popover-exit-active > .bp3-popover.bp3-minimal.bp3-popover{
         -webkit-transform:scale(1);
                 transform:scale(1);
+        -webkit-transition-delay:0;
+                transition-delay:0;
+        -webkit-transition-duration:100ms;
+                transition-duration:100ms;
         -webkit-transition-property:-webkit-transform;
         transition-property:-webkit-transform;
         transition-property:transform;
         transition-property:transform, -webkit-transform;
-        -webkit-transition-duration:100ms;
-                transition-duration:100ms;
         -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-        -webkit-transition-delay:0;
-                transition-delay:0; }
+                transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-popover.bp3-dark,
   .bp3-dark .bp3-popover{
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
@@ -7078,12 +7380,12 @@ body.bp3-overlay-open{
       fill:#30404d; }
 
 .bp3-popover-arrow::before{
+  border-radius:2px;
+  content:"";
   display:block;
   position:absolute;
   -webkit-transform:rotate(45deg);
-          transform:rotate(45deg);
-  border-radius:2px;
-  content:""; }
+          transform:rotate(45deg); }
 
 .bp3-tether-pinned .bp3-popover-arrow{
   display:none; }
@@ -7101,26 +7403,26 @@ body.bp3-overlay-open{
     opacity:0; }
   .bp3-transition-container.bp3-popover-enter-active, .bp3-transition-container.bp3-popover-appear-active{
     opacity:1;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:100ms;
             transition-duration:100ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-transition-container.bp3-popover-exit{
     opacity:1; }
   .bp3-transition-container.bp3-popover-exit-active{
     opacity:0;
-    -webkit-transition-property:opacity;
-    transition-property:opacity;
+    -webkit-transition-delay:0;
+            transition-delay:0;
     -webkit-transition-duration:100ms;
             transition-duration:100ms;
+    -webkit-transition-property:opacity;
+    transition-property:opacity;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-transition-container:focus{
     outline:none; }
   .bp3-transition-container.bp3-popover-leave .bp3-popover-content{
@@ -7135,10 +7437,10 @@ span.bp3-popover-target{
   width:100%; }
 
 .bp3-portal{
+  left:0;
   position:absolute;
-  top:0;
   right:0;
-  left:0; }
+  top:0; }
 @-webkit-keyframes linear-progress-bar-stripes{
   from{
     background-position:0 0; }
@@ -7151,23 +7453,23 @@ span.bp3-popover-target{
     background-position:30px 0; } }
 
 .bp3-progress-bar{
-  display:block;
-  position:relative;
-  border-radius:40px;
   background:rgba(92, 112, 128, 0.2);
-  width:100%;
+  border-radius:40px;
+  display:block;
   height:8px;
-  overflow:hidden; }
+  overflow:hidden;
+  position:relative;
+  width:100%; }
   .bp3-progress-bar .bp3-progress-meter{
-    position:absolute;
-    border-radius:40px;
     background:linear-gradient(-45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%);
     background-color:rgba(92, 112, 128, 0.8);
     background-size:30px 30px;
-    width:100%;
+    border-radius:40px;
     height:100%;
+    position:absolute;
     -webkit-transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
+    transition:width 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
+    width:100%; }
   .bp3-progress-bar:not(.bp3-no-animation):not(.bp3-no-stripes) .bp3-progress-meter{
     animation:linear-progress-bar-stripes 300ms linear infinite reverse; }
   .bp3-progress-bar.bp3-no-stripes .bp3-progress-meter{
@@ -7191,29 +7493,29 @@ span.bp3-popover-target{
   background-color:#db3737; }
 @-webkit-keyframes skeleton-glow{
   from{
-    border-color:rgba(206, 217, 224, 0.2);
-    background:rgba(206, 217, 224, 0.2); }
+    background:rgba(206, 217, 224, 0.2);
+    border-color:rgba(206, 217, 224, 0.2); }
   to{
-    border-color:rgba(92, 112, 128, 0.2);
-    background:rgba(92, 112, 128, 0.2); } }
+    background:rgba(92, 112, 128, 0.2);
+    border-color:rgba(92, 112, 128, 0.2); } }
 @keyframes skeleton-glow{
   from{
-    border-color:rgba(206, 217, 224, 0.2);
-    background:rgba(206, 217, 224, 0.2); }
+    background:rgba(206, 217, 224, 0.2);
+    border-color:rgba(206, 217, 224, 0.2); }
   to{
-    border-color:rgba(92, 112, 128, 0.2);
-    background:rgba(92, 112, 128, 0.2); } }
+    background:rgba(92, 112, 128, 0.2);
+    border-color:rgba(92, 112, 128, 0.2); } }
 .bp3-skeleton{
+  -webkit-animation:1000ms linear infinite alternate skeleton-glow;
+          animation:1000ms linear infinite alternate skeleton-glow;
+  background:rgba(206, 217, 224, 0.2);
+  background-clip:padding-box !important;
   border-color:rgba(206, 217, 224, 0.2) !important;
   border-radius:2px;
   -webkit-box-shadow:none !important;
           box-shadow:none !important;
-  background:rgba(206, 217, 224, 0.2);
-  background-clip:padding-box !important;
-  cursor:default;
   color:transparent !important;
-  -webkit-animation:1000ms linear infinite alternate skeleton-glow;
-          animation:1000ms linear infinite alternate skeleton-glow;
+  cursor:default;
   pointer-events:none;
   -webkit-user-select:none;
      -moz-user-select:none;
@@ -7223,12 +7525,12 @@ span.bp3-popover-target{
   .bp3-skeleton *{
     visibility:hidden !important; }
 .bp3-slider{
-  width:100%;
-  min-width:150px;
   height:40px;
-  position:relative;
-  outline:none;
+  min-width:150px;
+  width:100%;
   cursor:default;
+  outline:none;
+  position:relative;
   -webkit-user-select:none;
      -moz-user-select:none;
       -ms-user-select:none;
@@ -7239,17 +7541,17 @@ span.bp3-popover-target{
     cursor:-webkit-grabbing;
     cursor:grabbing; }
   .bp3-slider.bp3-disabled{
-    opacity:0.5;
-    cursor:not-allowed; }
+    cursor:not-allowed;
+    opacity:0.5; }
   .bp3-slider.bp3-slider-unlabeled{
     height:16px; }
 
 .bp3-slider-track,
 .bp3-slider-progress{
-  top:5px;
-  right:0;
-  left:0;
   height:6px;
+  left:0;
+  right:0;
+  top:5px;
   position:absolute; }
 
 .bp3-slider-track{
@@ -7270,90 +7572,90 @@ span.bp3-popover-target{
     background-color:#db3737; }
 
 .bp3-slider-handle{
-  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
   background-color:#f5f8fa;
   background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.8)), to(rgba(255, 255, 255, 0)));
   background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+  -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+          box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
   color:#182026;
-  position:absolute;
-  top:0;
-  left:0;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
   cursor:pointer;
-  width:16px;
-  height:16px; }
+  height:16px;
+  left:0;
+  position:absolute;
+  top:0;
+  width:16px; }
   .bp3-slider-handle:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
-    background-color:#ebf1f5; }
+    background-color:#ebf1f5;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1); }
   .bp3-slider-handle:active, .bp3-slider-handle.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
-    background-image:none; }
+    background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
   .bp3-slider-handle:disabled, .bp3-slider-handle.bp3-disabled{
-    outline:none;
-    -webkit-box-shadow:none;
-            box-shadow:none;
     background-color:rgba(206, 217, 224, 0.5);
     background-image:none;
+    -webkit-box-shadow:none;
+            box-shadow:none;
+    color:rgba(92, 112, 128, 0.6);
     cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    outline:none; }
     .bp3-slider-handle:disabled.bp3-active, .bp3-slider-handle:disabled.bp3-active:hover, .bp3-slider-handle.bp3-disabled.bp3-active, .bp3-slider-handle.bp3-disabled.bp3-active:hover{
       background:rgba(206, 217, 224, 0.7); }
   .bp3-slider-handle:focus{
     z-index:1; }
   .bp3-slider-handle:hover{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background-clip:padding-box;
     background-color:#ebf1f5;
-    z-index:2;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
     cursor:-webkit-grab;
-    cursor:grab; }
+    cursor:grab;
+    z-index:2; }
   .bp3-slider-handle.bp3-active{
-    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     background-color:#d8e1e8;
     background-image:none;
+    -webkit-box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+            box-shadow:inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2);
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 1px rgba(16, 22, 26, 0.1);
     cursor:-webkit-grabbing;
     cursor:grabbing; }
   .bp3-disabled .bp3-slider-handle{
+    background:#bfccd6;
     -webkit-box-shadow:none;
             box-shadow:none;
-    background:#bfccd6;
     pointer-events:none; }
   .bp3-dark .bp3-slider-handle{
-    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     background-color:#394b59;
     background-image:-webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.05)), to(rgba(255, 255, 255, 0)));
     background-image:linear-gradient(to bottom, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+    -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
     color:#f5f8fa; }
     .bp3-dark .bp3-slider-handle:hover, .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
       color:#f5f8fa; }
     .bp3-dark .bp3-slider-handle:hover{
+      background-color:#30404d;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4);
-      background-color:#30404d; }
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-slider-handle:active, .bp3-dark .bp3-slider-handle.bp3-active{
-      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
-              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
       background-color:#202b33;
-      background-image:none; }
+      background-image:none;
+      -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
+              box-shadow:0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2); }
     .bp3-dark .bp3-slider-handle:disabled, .bp3-dark .bp3-slider-handle.bp3-disabled{
-      -webkit-box-shadow:none;
-              box-shadow:none;
       background-color:rgba(57, 75, 89, 0.5);
       background-image:none;
+      -webkit-box-shadow:none;
+              box-shadow:none;
       color:rgba(167, 182, 194, 0.6); }
       .bp3-dark .bp3-slider-handle:disabled.bp3-active, .bp3-dark .bp3-slider-handle.bp3-disabled.bp3-active{
         background:rgba(57, 75, 89, 0.7); }
@@ -7365,21 +7667,21 @@ span.bp3-popover-target{
     .bp3-dark .bp3-slider-handle.bp3-active{
       background-color:#293742; }
   .bp3-dark .bp3-disabled .bp3-slider-handle{
+    background:#5c7080;
     border-color:#5c7080;
     -webkit-box-shadow:none;
-            box-shadow:none;
-    background:#5c7080; }
+            box-shadow:none; }
   .bp3-slider-handle .bp3-slider-label{
-    margin-left:8px;
+    background:#394b59;
     border-radius:3px;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
             box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-    background:#394b59;
-    color:#f5f8fa; }
+    color:#f5f8fa;
+    margin-left:8px; }
     .bp3-dark .bp3-slider-handle .bp3-slider-label{
+      background:#e1e8ed;
       -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
               box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-      background:#e1e8ed;
       color:#394b59; }
     .bp3-disabled .bp3-slider-handle .bp3-slider-label{
       -webkit-box-shadow:none;
@@ -7387,12 +7689,12 @@ span.bp3-popover-target{
   .bp3-slider-handle.bp3-start, .bp3-slider-handle.bp3-end{
     width:8px; }
   .bp3-slider-handle.bp3-start{
-    border-top-right-radius:0;
-    border-bottom-right-radius:0; }
+    border-bottom-right-radius:0;
+    border-top-right-radius:0; }
   .bp3-slider-handle.bp3-end{
-    margin-left:8px;
+    border-bottom-left-radius:0;
     border-top-left-radius:0;
-    border-bottom-left-radius:0; }
+    margin-left:8px; }
     .bp3-slider-handle.bp3-end .bp3-slider-label{
       margin-left:0; }
 
@@ -7400,23 +7702,23 @@ span.bp3-popover-target{
   -webkit-transform:translate(-50%, 20px);
           transform:translate(-50%, 20px);
   display:inline-block;
-  position:absolute;
-  padding:2px 5px;
-  vertical-align:top;
+  font-size:12px;
   line-height:1;
-  font-size:12px; }
+  padding:2px 5px;
+  position:absolute;
+  vertical-align:top; }
 
 .bp3-slider.bp3-vertical{
-  width:40px;
+  height:150px;
   min-width:40px;
-  height:150px; }
+  width:40px; }
   .bp3-slider.bp3-vertical .bp3-slider-track,
   .bp3-slider.bp3-vertical .bp3-slider-progress{
-    top:0;
     bottom:0;
+    height:auto;
     left:5px;
-    width:6px;
-    height:auto; }
+    top:0;
+    width:6px; }
   .bp3-slider.bp3-vertical .bp3-slider-progress{
     top:auto; }
   .bp3-slider.bp3-vertical .bp3-slider-label{
@@ -7425,23 +7727,23 @@ span.bp3-popover-target{
   .bp3-slider.bp3-vertical .bp3-slider-handle{
     top:auto; }
     .bp3-slider.bp3-vertical .bp3-slider-handle .bp3-slider-label{
-      margin-top:-8px;
-      margin-left:0; }
-    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end, .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
       margin-left:0;
-      width:16px;
-      height:8px; }
+      margin-top:-8px; }
+    .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end, .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
+      height:8px;
+      margin-left:0;
+      width:16px; }
     .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start{
-      border-top-left-radius:0;
-      border-bottom-right-radius:3px; }
+      border-bottom-right-radius:3px;
+      border-top-left-radius:0; }
       .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-start .bp3-slider-label{
         -webkit-transform:translate(20px);
                 transform:translate(20px); }
     .bp3-slider.bp3-vertical .bp3-slider-handle.bp3-end{
-      margin-bottom:8px;
-      border-top-left-radius:3px;
       border-bottom-left-radius:0;
-      border-bottom-right-radius:0; }
+      border-bottom-right-radius:0;
+      border-top-left-radius:3px;
+      margin-bottom:8px; }
 
 @-webkit-keyframes pt-spinner-animation{
   from{
@@ -7460,12 +7762,12 @@ span.bp3-popover-target{
             transform:rotate(360deg); } }
 
 .bp3-spinner{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   -webkit-box-pack:center;
       -ms-flex-pack:center;
           justify-content:center;
@@ -7476,12 +7778,12 @@ span.bp3-popover-target{
   .bp3-spinner path{
     fill-opacity:0; }
   .bp3-spinner .bp3-spinner-head{
+    stroke:rgba(92, 112, 128, 0.8);
+    stroke-linecap:round;
     -webkit-transform-origin:center;
             transform-origin:center;
     -webkit-transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
-    stroke:rgba(92, 112, 128, 0.8);
-    stroke-linecap:round; }
+    transition:stroke-dashoffset 200ms cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-spinner .bp3-spinner-track{
     stroke:rgba(92, 112, 128, 0.2); }
 
@@ -7514,48 +7816,48 @@ span.bp3-popover-target{
   display:-ms-flexbox;
   display:flex; }
   .bp3-tabs.bp3-vertical > .bp3-tab-list{
+    -webkit-box-align:start;
+        -ms-flex-align:start;
+            align-items:flex-start;
     -webkit-box-orient:vertical;
     -webkit-box-direction:normal;
         -ms-flex-direction:column;
-            flex-direction:column;
-    -webkit-box-align:start;
-        -ms-flex-align:start;
-            align-items:flex-start; }
+            flex-direction:column; }
     .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab{
       border-radius:3px;
-      width:100%;
-      padding:0 10px; }
+      padding:0 10px;
+      width:100%; }
       .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab[aria-selected="true"]{
+        background-color:rgba(19, 124, 189, 0.2);
         -webkit-box-shadow:none;
-                box-shadow:none;
-        background-color:rgba(19, 124, 189, 0.2); }
+                box-shadow:none; }
     .bp3-tabs.bp3-vertical > .bp3-tab-list .bp3-tab-indicator-wrapper .bp3-tab-indicator{
-      top:0;
-      right:0;
-      bottom:0;
-      left:0;
-      border-radius:3px;
       background-color:rgba(19, 124, 189, 0.2);
-      height:auto; }
+      border-radius:3px;
+      bottom:0;
+      height:auto;
+      left:0;
+      right:0;
+      top:0; }
   .bp3-tabs.bp3-vertical > .bp3-tab-panel{
     margin-top:0;
     padding-left:20px; }
 
 .bp3-tab-list{
+  -webkit-box-align:end;
+      -ms-flex-align:end;
+          align-items:flex-end;
+  border:none;
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  -webkit-box-align:end;
-      -ms-flex-align:end;
-          align-items:flex-end;
-  position:relative;
+  list-style:none;
   margin:0;
-  border:none;
   padding:0;
-  list-style:none; }
+  position:relative; }
   .bp3-tab-list > *:not(:last-child){
     margin-right:20px; }
 
@@ -7564,27 +7866,27 @@ span.bp3-popover-target{
   text-overflow:ellipsis;
   white-space:nowrap;
   word-wrap:normal;
+  color:#182026;
+  cursor:pointer;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
           flex:0 0 auto;
-  position:relative;
-  cursor:pointer;
-  max-width:100%;
-  vertical-align:top;
+  font-size:14px;
   line-height:30px;
-  color:#182026;
-  font-size:14px; }
+  max-width:100%;
+  position:relative;
+  vertical-align:top; }
   .bp3-tab a{
+    color:inherit;
     display:block;
-    text-decoration:none;
-    color:inherit; }
+    text-decoration:none; }
   .bp3-tab-indicator-wrapper ~ .bp3-tab{
+    background-color:transparent !important;
     -webkit-box-shadow:none !important;
-            box-shadow:none !important;
-    background-color:transparent !important; }
+            box-shadow:none !important; }
   .bp3-tab[aria-disabled="true"]{
-    cursor:not-allowed;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    cursor:not-allowed; }
   .bp3-tab[aria-selected="true"]{
     border-radius:0;
     -webkit-box-shadow:inset 0 -3px 0 #106ba3;
@@ -7594,8 +7896,8 @@ span.bp3-popover-target{
   .bp3-tab:focus{
     -moz-outline-radius:0; }
   .bp3-large > .bp3-tab{
-    line-height:40px;
-    font-size:16px; }
+    font-size:16px;
+    line-height:40px; }
 
 .bp3-tab-panel{
   margin-top:20px; }
@@ -7603,9 +7905,10 @@ span.bp3-popover-target{
     display:none; }
 
 .bp3-tab-indicator-wrapper{
+  left:0;
+  pointer-events:none;
   position:absolute;
   top:0;
-  left:0;
   -webkit-transform:translateX(0), translateY(0);
           transform:translateX(0), translateY(0);
   -webkit-transition:height, width, -webkit-transform;
@@ -7615,15 +7918,14 @@ span.bp3-popover-target{
   -webkit-transition-duration:200ms;
           transition-duration:200ms;
   -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-          transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-  pointer-events:none; }
+          transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-tab-indicator-wrapper .bp3-tab-indicator{
-    position:absolute;
-    right:0;
-    bottom:0;
-    left:0;
     background-color:#106ba3;
-    height:3px; }
+    bottom:0;
+    height:3px;
+    left:0;
+    position:absolute;
+    right:0; }
   .bp3-tab-indicator-wrapper.bp3-no-animation{
     -webkit-transition:none;
     transition:none; }
@@ -7656,19 +7958,19 @@ span.bp3-popover-target{
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  position:relative;
+  background-color:#5c7080;
   border:none;
   border-radius:3px;
   -webkit-box-shadow:none;
           box-shadow:none;
-  background-color:#5c7080;
-  min-width:20px;
+  color:#f5f8fa;
+  font-size:12px;
+  line-height:16px;
   max-width:100%;
   min-height:20px;
+  min-width:20px;
   padding:2px 6px;
-  line-height:16px;
-  color:#f5f8fa;
-  font-size:12px; }
+  position:relative; }
   .bp3-tag.bp3-interactive{
     cursor:pointer; }
     .bp3-tag.bp3-interactive:hover{
@@ -7699,8 +8001,8 @@ span.bp3-popover-target{
     -moz-outline-radius:6px; }
   .bp3-tag.bp3-round{
     border-radius:30px;
-    padding-right:8px;
-    padding-left:8px; }
+    padding-left:8px;
+    padding-right:8px; }
   .bp3-dark .bp3-tag{
     background-color:#bfccd6;
     color:#182026; }
@@ -7716,11 +8018,11 @@ span.bp3-popover-target{
     fill:#ffffff; }
   .bp3-tag.bp3-large,
   .bp3-large .bp3-tag{
-    min-width:30px;
-    min-height:30px;
-    padding:0 10px;
+    font-size:14px;
     line-height:20px;
-    font-size:14px; }
+    min-height:30px;
+    min-width:30px;
+    padding:5px 10px; }
     .bp3-tag.bp3-large::before,
     .bp3-tag.bp3-large > *,
     .bp3-large .bp3-tag::before,
@@ -7733,8 +8035,8 @@ span.bp3-popover-target{
       margin-right:0; }
     .bp3-tag.bp3-large.bp3-round,
     .bp3-large .bp3-tag.bp3-round{
-      padding-right:12px;
-      padding-left:12px; }
+      padding-left:12px;
+      padding-right:12px; }
   .bp3-tag.bp3-intent-primary{
     background:#137cbd;
     color:#ffffff; }
@@ -7879,44 +8181,43 @@ span.bp3-popover-target{
           background-color:rgba(219, 55, 55, 0.45); }
 
 .bp3-tag-remove{
+  background:none;
+  border:none;
+  color:inherit;
+  cursor:pointer;
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
-  opacity:0.5;
-  margin-top:-2px;
-  margin-right:-6px !important;
   margin-bottom:-2px;
-  border:none;
-  background:none;
-  cursor:pointer;
+  margin-right:-6px !important;
+  margin-top:-2px;
+  opacity:0.5;
   padding:2px;
-  padding-left:0;
-  color:inherit; }
+  padding-left:0; }
   .bp3-tag-remove:hover{
-    opacity:0.8;
     background:none;
+    opacity:0.8;
     text-decoration:none; }
   .bp3-tag-remove:active{
     opacity:1; }
   .bp3-tag-remove:empty::before{
-    line-height:1;
     font-family:"Icons16", sans-serif;
     font-size:16px;
-    font-weight:400;
     font-style:normal;
+    font-weight:400;
+    line-height:1;
     -moz-osx-font-smoothing:grayscale;
     -webkit-font-smoothing:antialiased;
     content:""; }
   .bp3-large .bp3-tag-remove{
     margin-right:-10px !important;
-    padding:5px;
-    padding-left:0; }
+    padding:0 5px 0 0; }
     .bp3-large .bp3-tag-remove:empty::before{
-      line-height:1;
       font-family:"Icons20", sans-serif;
       font-size:20px;
+      font-style:normal;
       font-weight:400;
-      font-style:normal; }
+      line-height:1; }
 .bp3-tag-input{
   display:-webkit-box;
   display:-ms-flexbox;
@@ -7930,10 +8231,10 @@ span.bp3-popover-target{
           align-items:flex-start;
   cursor:text;
   height:auto;
+  line-height:inherit;
   min-height:30px;
-  padding-right:0;
   padding-left:5px;
-  line-height:inherit; }
+  padding-right:0; }
   .bp3-tag-input > *{
     -webkit-box-flex:0;
         -ms-flex-positive:0;
@@ -7947,10 +8248,10 @@ span.bp3-popover-target{
     -ms-flex-negative:1;
         flex-shrink:1; }
   .bp3-tag-input .bp3-tag-input-icon{
-    margin-top:7px;
-    margin-right:7px;
+    color:#5c7080;
     margin-left:2px;
-    color:#5c7080; }
+    margin-right:7px;
+    margin-top:7px; }
   .bp3-tag-input .bp3-tag-input-values{
     display:-webkit-box;
     display:-ms-flexbox;
@@ -7959,15 +8260,15 @@ span.bp3-popover-target{
     -webkit-box-direction:normal;
         -ms-flex-direction:row;
             flex-direction:row;
-    -ms-flex-wrap:wrap;
-        flex-wrap:wrap;
     -webkit-box-align:center;
         -ms-flex-align:center;
             align-items:center;
     -ms-flex-item-align:stretch;
         align-self:stretch;
-    margin-top:5px;
+    -ms-flex-wrap:wrap;
+        flex-wrap:wrap;
     margin-right:7px;
+    margin-top:5px;
     min-width:0; }
     .bp3-tag-input .bp3-tag-input-values > *{
       -webkit-box-flex:0;
@@ -8001,8 +8302,8 @@ span.bp3-popover-target{
     -webkit-box-flex:1;
         -ms-flex:1 1 auto;
             flex:1 1 auto;
-    width:80px;
-    line-height:20px; }
+    line-height:20px;
+    width:80px; }
     .bp3-tag-input .bp3-input-ghost:disabled, .bp3-tag-input .bp3-input-ghost.bp3-disabled{
       cursor:not-allowed; }
   .bp3-tag-input .bp3-button,
@@ -8010,8 +8311,8 @@ span.bp3-popover-target{
     margin:3px;
     margin-left:0; }
   .bp3-tag-input .bp3-button{
-    min-width:24px;
     min-height:24px;
+    min-width:24px;
     padding:0 7px; }
   .bp3-tag-input.bp3-large{
     height:auto;
@@ -8023,13 +8324,13 @@ span.bp3-popover-target{
     .bp3-tag-input.bp3-large > :last-child{
       margin-right:0; }
     .bp3-tag-input.bp3-large .bp3-tag-input-icon{
-      margin-top:10px;
-      margin-left:5px; }
+      margin-left:5px;
+      margin-top:10px; }
     .bp3-tag-input.bp3-large .bp3-input-ghost{
       line-height:30px; }
     .bp3-tag-input.bp3-large .bp3-button{
-      min-width:30px;
       min-height:30px;
+      min-width:30px;
       padding:5px 10px;
       margin:5px;
       margin-left:0; }
@@ -8037,9 +8338,9 @@ span.bp3-popover-target{
       margin:8px;
       margin-left:0; }
   .bp3-tag-input.bp3-active{
+    background-color:#ffffff;
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
-    background-color:#ffffff; }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
     .bp3-tag-input.bp3-active.bp3-intent-primary{
       -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
               box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2); }
@@ -8067,9 +8368,9 @@ span.bp3-popover-target{
     .bp3-dark .bp3-tag-input .bp3-input-ghost::placeholder, .bp3-tag-input.bp3-dark .bp3-input-ghost::placeholder{
       color:rgba(167, 182, 194, 0.6); }
   .bp3-dark .bp3-tag-input.bp3-active, .bp3-tag-input.bp3-dark.bp3-active{
+    background-color:rgba(16, 22, 26, 0.3);
     -webkit-box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
-    background-color:rgba(16, 22, 26, 0.3); }
+            box-shadow:0 0 0 1px #137cbd, 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
     .bp3-dark .bp3-tag-input.bp3-active.bp3-intent-primary, .bp3-tag-input.bp3-dark.bp3-active.bp3-intent-primary{
       -webkit-box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4);
               box-shadow:0 0 0 1px #106ba3, 0 0 0 3px rgba(16, 107, 163, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
@@ -8084,76 +8385,76 @@ span.bp3-popover-target{
               box-shadow:0 0 0 1px #c23030, 0 0 0 3px rgba(194, 48, 48, 0.3), inset 0 0 0 1px rgba(16, 22, 26, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.4); }
 
 .bp3-input-ghost{
+  background:none;
   border:none;
   -webkit-box-shadow:none;
           box-shadow:none;
-  background:none;
   padding:0; }
   .bp3-input-ghost::-webkit-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost::-moz-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost:-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost::-ms-input-placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost::placeholder{
-    opacity:1;
-    color:rgba(92, 112, 128, 0.6); }
+    color:rgba(92, 112, 128, 0.6);
+    opacity:1; }
   .bp3-input-ghost:focus{
     outline:none !important; }
 .bp3-toast{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:start;
       -ms-flex-align:start;
           align-items:flex-start;
-  position:relative !important;
-  margin:20px 0 0;
+  background-color:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2), 0 8px 24px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  min-width:300px;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  margin:20px 0 0;
   max-width:500px;
-  pointer-events:all; }
+  min-width:300px;
+  pointer-events:all;
+  position:relative !important; }
   .bp3-toast.bp3-toast-enter, .bp3-toast.bp3-toast-appear{
     -webkit-transform:translateY(-40px);
             transform:translateY(-40px); }
   .bp3-toast.bp3-toast-enter-active, .bp3-toast.bp3-toast-appear-active{
     -webkit-transform:translateY(0);
             transform:translateY(0);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-toast.bp3-toast-enter ~ .bp3-toast, .bp3-toast.bp3-toast-appear ~ .bp3-toast{
     -webkit-transform:translateY(-40px);
             transform:translateY(-40px); }
   .bp3-toast.bp3-toast-enter-active ~ .bp3-toast, .bp3-toast.bp3-toast-appear-active ~ .bp3-toast{
     -webkit-transform:translateY(0);
             transform:translateY(0);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.54, 1.12, 0.38, 1.11); }
   .bp3-toast.bp3-toast-exit{
     opacity:1;
     -webkit-filter:blur(0);
@@ -8162,32 +8463,32 @@ span.bp3-popover-target{
     opacity:0;
     -webkit-filter:blur(10px);
             filter:blur(10px);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:300ms;
+            transition-duration:300ms;
     -webkit-transition-property:opacity, -webkit-filter;
     transition-property:opacity, -webkit-filter;
     transition-property:opacity, filter;
     transition-property:opacity, filter, -webkit-filter;
-    -webkit-transition-duration:300ms;
-            transition-duration:300ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-toast.bp3-toast-exit ~ .bp3-toast{
     -webkit-transform:translateY(0);
             transform:translateY(0); }
   .bp3-toast.bp3-toast-exit-active ~ .bp3-toast{
     -webkit-transform:translateY(-40px);
             transform:translateY(-40px);
+    -webkit-transition-delay:50ms;
+            transition-delay:50ms;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:50ms;
-            transition-delay:50ms; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-toast .bp3-button-group{
     -webkit-box-flex:0;
         -ms-flex:0 0 auto;
@@ -8195,14 +8496,14 @@ span.bp3-popover-target{
     padding:5px;
     padding-left:0; }
   .bp3-toast > .bp3-icon{
+    color:#5c7080;
     margin:12px;
-    margin-right:0;
-    color:#5c7080; }
+    margin-right:0; }
   .bp3-toast.bp3-dark,
   .bp3-dark .bp3-toast{
+    background-color:#394b59;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-    background-color:#394b59; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4); }
     .bp3-toast.bp3-dark > .bp3-icon,
     .bp3-dark .bp3-toast > .bp3-icon{
       color:#a7b6c2; }
@@ -8246,6 +8547,9 @@ span.bp3-popover-target{
   word-break:break-word; }
 
 .bp3-toast-container{
+  -webkit-box-align:center;
+      -ms-flex-align:center;
+          align-items:center;
   display:-webkit-box !important;
   display:-ms-flexbox !important;
   display:flex !important;
@@ -8253,26 +8557,22 @@ span.bp3-popover-target{
   -webkit-box-direction:normal;
       -ms-flex-direction:column;
           flex-direction:column;
-  -webkit-box-align:center;
-      -ms-flex-align:center;
-          align-items:center;
-  position:fixed;
-  right:0;
   left:0;
-  z-index:40;
   overflow:hidden;
   padding:0 20px 20px;
-  pointer-events:none; }
+  pointer-events:none;
+  position:fixed;
+  right:0;
+  z-index:40; }
   .bp3-toast-container.bp3-toast-container-top{
-    top:0;
-    bottom:auto; }
+    top:0; }
   .bp3-toast-container.bp3-toast-container-bottom{
+    bottom:0;
     -webkit-box-orient:vertical;
     -webkit-box-direction:reverse;
         -ms-flex-direction:column-reverse;
             flex-direction:column-reverse;
-    top:auto;
-    bottom:0; }
+    top:auto; }
   .bp3-toast-container.bp3-toast-container-left{
     -webkit-box-align:start;
         -ms-flex-align:start;
@@ -8285,6 +8585,7 @@ span.bp3-popover-target{
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active),
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-enter:not(.bp3-toast-enter-active) ~ .bp3-toast, .bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active),
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-appear:not(.bp3-toast-appear-active) ~ .bp3-toast,
+.bp3-toast-container-bottom .bp3-toast.bp3-toast-exit-active ~ .bp3-toast,
 .bp3-toast-container-bottom .bp3-toast.bp3-toast-leave-active ~ .bp3-toast{
   -webkit-transform:translateY(60px);
           transform:translateY(60px); }
@@ -8294,16 +8595,16 @@ span.bp3-popover-target{
   -webkit-transform:scale(1);
           transform:scale(1); }
   .bp3-tooltip .bp3-popover-arrow{
+    height:22px;
     position:absolute;
-    width:22px;
-    height:22px; }
+    width:22px; }
     .bp3-tooltip .bp3-popover-arrow::before{
+      height:14px;
       margin:4px;
-      width:14px;
-      height:14px; }
+      width:14px; }
   .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip{
-    margin-top:-11px;
-    margin-bottom:11px; }
+    margin-bottom:11px;
+    margin-top:-11px; }
     .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow{
       bottom:-8px; }
       .bp3-tether-element-attached-bottom.bp3-tether-target-attached-top > .bp3-tooltip > .bp3-popover-arrow svg{
@@ -8324,8 +8625,8 @@ span.bp3-popover-target{
         -webkit-transform:rotate(90deg);
                 transform:rotate(90deg); }
   .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip{
-    margin-right:11px;
-    margin-left:-11px; }
+    margin-left:-11px;
+    margin-right:11px; }
     .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow{
       right:-8px; }
       .bp3-tether-element-attached-right.bp3-tether-target-attached-left > .bp3-tooltip > .bp3-popover-arrow svg{
@@ -8391,32 +8692,32 @@ span.bp3-popover-target{
   .bp3-popover-enter-active > .bp3-tooltip, .bp3-popover-appear-active > .bp3-tooltip{
     -webkit-transform:scale(1);
             transform:scale(1);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-popover-exit > .bp3-tooltip{
     -webkit-transform:scale(1);
             transform:scale(1); }
   .bp3-popover-exit-active > .bp3-tooltip{
     -webkit-transform:scale(0.8);
             transform:scale(0.8);
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:100ms;
+            transition-duration:100ms;
     -webkit-transition-property:-webkit-transform;
     transition-property:-webkit-transform;
     transition-property:transform;
     transition-property:transform, -webkit-transform;
-    -webkit-transition-duration:100ms;
-            transition-duration:100ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-tooltip .bp3-popover-content{
     padding:10px 12px; }
   .bp3-tooltip.bp3-dark,
@@ -8474,15 +8775,15 @@ span.bp3-popover-target{
     color:#db3737; }
 
 .bp3-tree-node-list{
+  list-style:none;
   margin:0;
-  padding-left:0;
-  list-style:none; }
+  padding-left:0; }
 
 .bp3-tree-root{
-  position:relative;
   background-color:transparent;
   cursor:default;
-  padding-left:0; }
+  padding-left:0;
+  position:relative; }
 
 .bp3-tree-node-content-0{
   padding-left:0px; }
@@ -8548,15 +8849,15 @@ span.bp3-popover-target{
   padding-left:460px; }
 
 .bp3-tree-node-content{
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  width:100%;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
   height:30px;
-  padding-right:5px; }
+  padding-right:5px;
+  width:100%; }
   .bp3-tree-node-content:hover{
     background-color:rgba(191, 204, 214, 0.4); }
 
@@ -8566,10 +8867,10 @@ span.bp3-popover-target{
 
 .bp3-tree-node-caret{
   color:#5c7080;
-  -webkit-transform:rotate(0deg);
-          transform:rotate(0deg);
   cursor:pointer;
   padding:7px;
+  -webkit-transform:rotate(0deg);
+          transform:rotate(0deg);
   -webkit-transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:-webkit-transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
   transition:transform 200ms cubic-bezier(0.4, 1, 0.75, 0.9);
@@ -8587,8 +8888,8 @@ span.bp3-popover-target{
     content:""; }
 
 .bp3-tree-node-icon{
-  position:relative;
-  margin-right:7px; }
+  margin-right:7px;
+  position:relative; }
 
 .bp3-tree-node-label{
   overflow:hidden;
@@ -8614,22 +8915,22 @@ span.bp3-popover-target{
           user-select:none; }
   .bp3-tree-node-secondary-label .bp3-popover-wrapper,
   .bp3-tree-node-secondary-label .bp3-popover-target{
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
     -webkit-box-align:center;
         -ms-flex-align:center;
-            align-items:center; }
+            align-items:center;
+    display:-webkit-box;
+    display:-ms-flexbox;
+    display:flex; }
 
 .bp3-tree-node.bp3-disabled .bp3-tree-node-content{
   background-color:inherit;
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-tree-node.bp3-disabled .bp3-tree-node-caret,
 .bp3-tree-node.bp3-disabled .bp3-tree-node-icon{
-  cursor:not-allowed;
-  color:rgba(92, 112, 128, 0.6); }
+  color:rgba(92, 112, 128, 0.6);
+  cursor:not-allowed; }
 
 .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
   background-color:#137cbd; }
@@ -8657,24 +8958,18 @@ span.bp3-popover-target{
 
 .bp3-dark .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
   background-color:#137cbd; }
-/*!
-
-Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
-Licensed under the Apache License, Version 2.0.
-
-*/
 .bp3-omnibar{
   -webkit-filter:blur(0);
           filter:blur(0);
   opacity:1;
-  top:20vh;
-  left:calc(50% - 250px);
-  z-index:21;
+  background-color:#ffffff;
   border-radius:3px;
   -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
           box-shadow:0 0 0 1px rgba(16, 22, 26, 0.1), 0 4px 8px rgba(16, 22, 26, 0.2), 0 18px 46px 6px rgba(16, 22, 26, 0.2);
-  background-color:#ffffff;
-  width:500px; }
+  left:calc(50% - 250px);
+  top:20vh;
+  width:500px;
+  z-index:21; }
   .bp3-omnibar.bp3-overlay-enter, .bp3-omnibar.bp3-overlay-appear{
     -webkit-filter:blur(20px);
             filter:blur(20px);
@@ -8683,16 +8978,16 @@ Licensed under the Apache License, Version 2.0.
     -webkit-filter:blur(0);
             filter:blur(0);
     opacity:1;
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
     -webkit-transition-property:opacity, -webkit-filter;
     transition-property:opacity, -webkit-filter;
     transition-property:filter, opacity;
     transition-property:filter, opacity, -webkit-filter;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-omnibar.bp3-overlay-exit{
     -webkit-filter:blur(0);
             filter:blur(0);
@@ -8701,35 +8996,35 @@ Licensed under the Apache License, Version 2.0.
     -webkit-filter:blur(20px);
             filter:blur(20px);
     opacity:0.2;
+    -webkit-transition-delay:0;
+            transition-delay:0;
+    -webkit-transition-duration:200ms;
+            transition-duration:200ms;
     -webkit-transition-property:opacity, -webkit-filter;
     transition-property:opacity, -webkit-filter;
     transition-property:filter, opacity;
     transition-property:filter, opacity, -webkit-filter;
-    -webkit-transition-duration:200ms;
-            transition-duration:200ms;
     -webkit-transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9);
-    -webkit-transition-delay:0;
-            transition-delay:0; }
+            transition-timing-function:cubic-bezier(0.4, 1, 0.75, 0.9); }
   .bp3-omnibar .bp3-input{
-    border-radius:0;
-    background-color:transparent; }
+    background-color:transparent;
+    border-radius:0; }
     .bp3-omnibar .bp3-input, .bp3-omnibar .bp3-input:focus{
       -webkit-box-shadow:none;
               box-shadow:none; }
   .bp3-omnibar .bp3-menu{
+    background-color:transparent;
     border-radius:0;
     -webkit-box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
             box-shadow:inset 0 1px 0 rgba(16, 22, 26, 0.15);
-    background-color:transparent;
     max-height:calc(60vh - 40px);
     overflow:auto; }
     .bp3-omnibar .bp3-menu:empty{
       display:none; }
   .bp3-dark .bp3-omnibar, .bp3-omnibar.bp3-dark{
+    background-color:#30404d;
     -webkit-box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4);
-    background-color:#30404d; }
+            box-shadow:0 0 0 1px rgba(16, 22, 26, 0.2), 0 4px 8px rgba(16, 22, 26, 0.4), 0 18px 46px 6px rgba(16, 22, 26, 0.4); }
 
 .bp3-omnibar-overlay .bp3-overlay-backdrop{
   background-color:rgba(16, 22, 26, 0.2); }
@@ -8741,8 +9036,8 @@ Licensed under the Apache License, Version 2.0.
   margin-bottom:0; }
 
 .bp3-select-popover .bp3-menu{
-  max-width:400px;
   max-height:300px;
+  max-width:400px;
   overflow:auto;
   padding:0; }
   .bp3-select-popover .bp3-menu:not(:first-child){
@@ -8752,8 +9047,8 @@ Licensed under the Apache License, Version 2.0.
   min-width:150px; }
 
 .bp3-multi-select-popover .bp3-menu{
-  max-width:400px;
   max-height:300px;
+  max-width:400px;
   overflow:auto; }
 
 .bp3-select-popover .bp3-popover-content{
@@ -8763,8 +9058,8 @@ Licensed under the Apache License, Version 2.0.
   margin-bottom:0; }
 
 .bp3-select-popover .bp3-menu{
-  max-width:400px;
   max-height:300px;
+  max-width:400px;
   overflow:auto;
   padding:0; }
   .bp3-select-popover .bp3-menu:not(:first-child){
@@ -8799,6 +9094,7 @@ Licensed under the Apache License, Version 2.0.
   --jp-icon-circle: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPGNpcmNsZSBjeD0iOSIgY3k9IjkiIHI9IjgiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-clear: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8bWFzayBpZD0iZG9udXRIb2xlIj4KICAgIDxyZWN0IHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0id2hpdGUiIC8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI4IiBmaWxsPSJibGFjayIvPgogIDwvbWFzaz4KCiAgPGcgY2xhc3M9ImpwLWljb24zIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxyZWN0IGhlaWdodD0iMTgiIHdpZHRoPSIyIiB4PSIxMSIgeT0iMyIgdHJhbnNmb3JtPSJyb3RhdGUoMzE1LCAxMiwgMTIpIi8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgbWFzaz0idXJsKCNkb251dEhvbGUpIi8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-close: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1ub25lIGpwLWljb24tc2VsZWN0YWJsZS1pbnZlcnNlIGpwLWljb24zLWhvdmVyIiBmaWxsPSJub25lIj4KICAgIDxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjExIi8+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIGpwLWljb24tYWNjZW50Mi1ob3ZlciIgZmlsbD0iIzYxNjE2MSI+CiAgICA8cGF0aCBkPSJNMTkgNi40MUwxNy41OSA1IDEyIDEwLjU5IDYuNDEgNSA1IDYuNDEgMTAuNTkgMTIgNSAxNy41OSA2LjQxIDE5IDEyIDEzLjQxIDE3LjU5IDE5IDE5IDE3LjU5IDEzLjQxIDEyeiIvPgogIDwvZz4KCiAgPGcgY2xhc3M9ImpwLWljb24tbm9uZSBqcC1pY29uLWJ1c3kiIGZpbGw9Im5vbmUiPgogICAgPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iNyIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-code: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyOCAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTExLjQgMTguNkw2LjggMTRMMTEuNCA5LjRMMTAgOEw0IDE0TDEwIDIwTDExLjQgMTguNlpNMTYuNiAxOC42TDIxLjIgMTRMMTYuNiA5LjRMMTggOEwyNCAxNEwxOCAyMEwxNi42IDE4LjZWMTguNloiLz4KCTwvZz4KPC9zdmc+Cg==);
   --jp-icon-console: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwMCAyMDAiPgogIDxnIGNsYXNzPSJqcC1pY29uLWJyYW5kMSBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiMwMjg4RDEiPgogICAgPHBhdGggZD0iTTIwIDE5LjhoMTYwdjE1OS45SDIweiIvPgogIDwvZz4KICA8ZyBjbGFzcz0ianAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNmZmYiPgogICAgPHBhdGggZD0iTTEwNSAxMjcuM2g0MHYxMi44aC00MHpNNTEuMSA3N0w3NCA5OS45bC0yMy4zIDIzLjMgMTAuNSAxMC41IDIzLjMtMjMuM0w5NSA5OS45IDg0LjUgODkuNCA2MS42IDY2LjV6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-copy: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTExLjksMUgzLjJDMi40LDEsMS43LDEuNywxLjcsMi41djEwLjJoMS41VjIuNWg4LjdWMXogTTE0LjEsMy45aC04Yy0wLjgsMC0xLjUsMC43LTEuNSwxLjV2MTAuMmMwLDAuOCwwLjcsMS41LDEuNSwxLjVoOCBjMC44LDAsMS41LTAuNywxLjUtMS41VjUuNEMxNS41LDQuNiwxNC45LDMuOSwxNC4xLDMuOXogTTE0LjEsMTUuNWgtOFY1LjRoOFYxNS41eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-cut: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTkuNjQgNy42NGMuMjMtLjUuMzYtMS4wNS4zNi0xLjY0IDAtMi4yMS0xLjc5LTQtNC00UzIgMy43OSAyIDZzMS43OSA0IDQgNGMuNTkgMCAxLjE0LS4xMyAxLjY0LS4zNkwxMCAxMmwtMi4zNiAyLjM2QzcuMTQgMTQuMTMgNi41OSAxNCA2IDE0Yy0yLjIxIDAtNCAxLjc5LTQgNHMxLjc5IDQgNCA0IDQtMS43OSA0LTRjMC0uNTktLjEzLTEuMTQtLjM2LTEuNjRMMTIgMTRsNyA3aDN2LTFMOS42NCA3LjY0ek02IDhjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTAgMTJjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTYtNy41Yy0uMjggMC0uNS0uMjItLjUtLjVzLjIyLS41LjUtLjUuNS4yMi41LjUtLjIyLjUtLjUuNXpNMTkgM2wtNiA2IDIgMiA3LTdWM3oiLz4KICA8L2c+Cjwvc3ZnPgo=);
@@ -8829,11 +9125,15 @@ Licensed under the Apache License, Version 2.0.
   --jp-icon-new-folder: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIwIDZoLThsLTItMkg0Yy0xLjExIDAtMS45OS44OS0xLjk5IDJMMiAxOGMwIDEuMTEuODkgMiAyIDJoMTZjMS4xMSAwIDItLjg5IDItMlY4YzAtMS4xMS0uODktMi0yLTJ6bS0xIDhoLTN2M2gtMnYtM2gtM3YtMmgzVjloMnYzaDN2MnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-not-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI1IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMTkgMTcuMTg0NCAyLjk2OTY4IDE0LjMwMzIgMS44NjA5NCAxMS40NDA5WiIvPgogICAgPHBhdGggY2xhc3M9ImpwLWljb24yIiBzdHJva2U9IiMzMzMzMzMiIHN0cm9rZS13aWR0aD0iMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOS4zMTU5MiA5LjMyMDMxKSIgZD0iTTcuMzY4NDIgMEwwIDcuMzY0NzkiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDkuMzE1OTIgMTYuNjgzNikgc2NhbGUoMSAtMSkiIGQ9Ik03LjM2ODQyIDBMMCA3LjM2NDc5Ii8+Cjwvc3ZnPgo=);
   --jp-icon-notebook: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNFRjZDMDAiPgogICAgPHBhdGggZD0iTTE4LjcgMy4zdjE1LjRIMy4zVjMuM2gxNS40bTEuNS0xLjVIMS44djE4LjNoMTguM2wuMS0xOC4zeiIvPgogICAgPHBhdGggZD0iTTE2LjUgMTYuNWwtNS40LTQuMy01LjYgNC4zdi0xMWgxMXoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-numbering: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyOCAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTQgMTlINlYxOS41SDVWMjAuNUg2VjIxSDRWMjJIN1YxOEg0VjE5Wk01IDEwSDZWNkg0VjdINVYxMFpNNCAxM0g1LjhMNCAxNS4xVjE2SDdWMTVINS4yTDcgMTIuOVYxMkg0VjEzWk05IDdWOUgyM1Y3SDlaTTkgMjFIMjNWMTlIOVYyMVpNOSAxNUgyM1YxM0g5VjE1WiIvPgoJPC9nPgo8L3N2Zz4K);
+  --jp-icon-offline-bolt: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjE2Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyIDIuMDJjLTUuNTEgMC05Ljk4IDQuNDctOS45OCA5Ljk4czQuNDcgOS45OCA5Ljk4IDkuOTggOS45OC00LjQ3IDkuOTgtOS45OFMxNy41MSAyLjAyIDEyIDIuMDJ6TTExLjQ4IDIwdi02LjI2SDhMMTMgNHY2LjI2aDMuMzVMMTEuNDggMjB6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-palette: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE4IDEzVjIwSDRWNkg5LjAyQzkuMDcgNS4yOSA5LjI0IDQuNjIgOS41IDRINEMyLjkgNCAyIDQuOSAyIDZWMjBDMiAyMS4xIDIuOSAyMiA0IDIySDE4QzE5LjEgMjIgMjAgMjEuMSAyMCAyMFYxNUwxOCAxM1pNMTkuMyA4Ljg5QzE5Ljc0IDguMTkgMjAgNy4zOCAyMCA2LjVDMjAgNC4wMSAxNy45OSAyIDE1LjUgMkMxMy4wMSAyIDExIDQuMDEgMTEgNi41QzExIDguOTkgMTMuMDEgMTEgMTUuNDkgMTFDMTYuMzcgMTEgMTcuMTkgMTAuNzQgMTcuODggMTAuM0wyMSAxMy40MkwyMi40MiAxMkwxOS4zIDguODlaTTE1LjUgOUMxNC4xMiA5IDEzIDcuODggMTMgNi41QzEzIDUuMTIgMTQuMTIgNCAxNS41IDRDMTYuODggNCAxOCA1LjEyIDE4IDYuNUMxOCA3Ljg4IDE2Ljg4IDkgMTUuNSA5WiIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDZIOS4wMTg5NEM5LjAwNjM5IDYuMTY1MDIgOSA2LjMzMTc2IDkgNi41QzkgOC44MTU3NyAxMC4yMTEgMTAuODQ4NyAxMi4wMzQzIDEySDlWMTRIMTZWMTIuOTgxMUMxNi41NzAzIDEyLjkzNzcgMTcuMTIgMTIuODIwNyAxNy42Mzk2IDEyLjYzOTZMMTggMTNWMjBINFY2Wk04IDhINlYxMEg4VjhaTTYgMTJIOFYxNEg2VjEyWk04IDE2SDZWMThIOFYxNlpNOSAxNkgxNlYxOEg5VjE2WiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-paste: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTE5IDJoLTQuMThDMTQuNC44NCAxMy4zIDAgMTIgMGMtMS4zIDAtMi40Ljg0LTIuODIgMkg1Yy0xLjEgMC0yIC45LTIgMnYxNmMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjRjMC0xLjEtLjktMi0yLTJ6bS03IDBjLjU1IDAgMSAuNDUgMSAxcy0uNDUgMS0xIDEtMS0uNDUtMS0xIC40NS0xIDEtMXptNyAxOEg1VjRoMnYzaDEwVjRoMnYxNnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-pdf: url(data:image/svg+xml;base64,PHN2ZwogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMiAyMiIgd2lkdGg9IjE2Ij4KICAgIDxwYXRoIHRyYW5zZm9ybT0icm90YXRlKDQ1KSIgY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iI0ZGMkEyQSIKICAgICAgIGQ9Im0gMjIuMzQ0MzY5LC0zLjAxNjM2NDIgaCA1LjYzODYwNCB2IDEuNTc5MjQzMyBoIC0zLjU0OTIyNyB2IDEuNTA4NjkyOTkgaCAzLjMzNzU3NiBWIDEuNjUwODE1NCBoIC0zLjMzNzU3NiB2IDMuNDM1MjYxMyBoIC0yLjA4OTM3NyB6IG0gLTcuMTM2NDQ0LDEuNTc5MjQzMyB2IDQuOTQzOTU0MyBoIDAuNzQ4OTIgcSAxLjI4MDc2MSwwIDEuOTUzNzAzLC0wLjYzNDk1MzUgMC42NzgzNjksLTAuNjM0OTUzNSAwLjY3ODM2OSwtMS44NDUxNjQxIDAsLTEuMjA0NzgzNTUgLTAuNjcyOTQyLC0xLjgzNDMxMDExIC0wLjY3Mjk0MiwtMC42Mjk1MjY1OSAtMS45NTkxMywtMC42Mjk1MjY1OSB6IG0gLTIuMDg5Mzc3LC0xLjU3OTI0MzMgaCAyLjIwMzM0MyBxIDEuODQ1MTY0LDAgMi43NDYwMzksMC4yNjU5MjA3IDAuOTA2MzAxLDAuMjYwNDkzNyAxLjU1MjEwOCwwLjg5MDAyMDMgMC41Njk4MywwLjU0ODEyMjMgMC44NDY2MDUsMS4yNjQ0ODAwNiAwLjI3Njc3NCwwLjcxNjM1NzgxIDAuMjc2Nzc0LDEuNjIyNjU4OTQgMCwwLjkxNzE1NTEgLTAuMjc2Nzc0LDEuNjM4OTM5OSAtMC4yNzY3NzUsMC43MTYzNTc4IC0wLjg0NjYwNSwxLjI2NDQ4IC0wLjY1MTIzNCwwLjYyOTUyNjYgLTEuNTYyOTYyLDAuODk1NDQ3MyAtMC45MTE3MjgsMC4yNjA0OTM3IC0yLjczNTE4NSwwLjI2MDQ5MzcgaCAtMi4yMDMzNDMgeiBtIC04LjE0NTg1NjUsMCBoIDMuNDY3ODIzIHEgMS41NDY2ODE2LDAgMi4zNzE1Nzg1LDAuNjg5MjIzIDAuODMwMzI0LDAuNjgzNzk2MSAwLjgzMDMyNCwxLjk1MzcwMzE0IDAsMS4yNzUzMzM5NyAtMC44MzAzMjQsMS45NjQ1NTcwNiBRIDkuOTg3MTk2MSwyLjI3NDkxNSA4LjQ0MDUxNDUsMi4yNzQ5MTUgSCA3LjA2MjA2ODQgViA1LjA4NjA3NjcgSCA0Ljk3MjY5MTUgWiBtIDIuMDg5Mzc2OSwxLjUxNDExOTkgdiAyLjI2MzAzOTQzIGggMS4xNTU5NDEgcSAwLjYwNzgxODgsMCAwLjkzODg2MjksLTAuMjkzMDU1NDcgMC4zMzEwNDQxLC0wLjI5ODQ4MjQxIDAuMzMxMDQ0MSwtMC44NDExNzc3MiAwLC0wLjU0MjY5NTMxIC0wLjMzMTA0NDEsLTAuODM1NzUwNzQgLTAuMzMxMDQ0MSwtMC4yOTMwNTU1IC0wLjkzODg2MjksLTAuMjkzMDU1NSB6IgovPgo8L3N2Zz4K);
   --jp-icon-python: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1icmFuZDAganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMEQ0N0ExIj4KICAgIDxwYXRoIGQ9Ik0xMS4xIDYuOVY1LjhINi45YzAtLjUgMC0xLjMuMi0xLjYuNC0uNy44LTEuMSAxLjctMS40IDEuNy0uMyAyLjUtLjMgMy45LS4xIDEgLjEgMS45LjkgMS45IDEuOXY0LjJjMCAuNS0uOSAxLjYtMiAxLjZIOC44Yy0xLjUgMC0yLjQgMS40LTIuNCAyLjh2Mi4ySDQuN0MzLjUgMTUuMSAzIDE0IDMgMTMuMVY5Yy0uMS0xIC42LTIgMS44LTIgMS41LS4xIDYuMy0uMSA2LjMtLjF6Ii8+CiAgICA8cGF0aCBkPSJNMTAuOSAxNS4xdjEuMWg0LjJjMCAuNSAwIDEuMy0uMiAxLjYtLjQuNy0uOCAxLjEtMS43IDEuNC0xLjcuMy0yLjUuMy0zLjkuMS0xLS4xLTEuOS0uOS0xLjktMS45di00LjJjMC0uNS45LTEuNiAyLTEuNmgzLjhjMS41IDAgMi40LTEuNCAyLjQtMi44VjYuNmgxLjdDMTguNSA2LjkgMTkgOCAxOSA4LjlWMTNjMCAxLS43IDIuMS0xLjkgMi4xaC02LjJ6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-r-kernel: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjE5NkYzIiBkPSJNNC40IDIuNWMxLjItLjEgMi45LS4zIDQuOS0uMyAyLjUgMCA0LjEuNCA1LjIgMS4zIDEgLjcgMS41IDEuOSAxLjUgMy41IDAgMi0xLjQgMy41LTIuOSA0LjEgMS4yLjQgMS43IDEuNiAyLjIgMyAuNiAxLjkgMSAzLjkgMS4zIDQuNmgtMy44Yy0uMy0uNC0uOC0xLjctMS4yLTMuN3MtMS4yLTIuNi0yLjYtMi42aC0uOXY2LjRINC40VjIuNXptMy43IDYuOWgxLjRjMS45IDAgMi45LS45IDIuOS0yLjNzLTEtMi4zLTIuOC0yLjNjLS43IDAtMS4zIDAtMS42LjJ2NC41aC4xdi0uMXoiLz4KPC9zdmc+Cg==);
   --jp-icon-react: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMTUwIDE1MCA1NDEuOSAyOTUuMyI+CiAgPGcgY2xhc3M9ImpwLWljb24tYnJhbmQyIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzYxREFGQiI+CiAgICA8cGF0aCBkPSJNNjY2LjMgMjk2LjVjMC0zMi41LTQwLjctNjMuMy0xMDMuMS04Mi40IDE0LjQtNjMuNiA4LTExNC4yLTIwLjItMTMwLjQtNi41LTMuOC0xNC4xLTUuNi0yMi40LTUuNnYyMi4zYzQuNiAwIDguMy45IDExLjQgMi42IDEzLjYgNy44IDE5LjUgMzcuNSAxNC45IDc1LjctMS4xIDkuNC0yLjkgMTkuMy01LjEgMjkuNC0xOS42LTQuOC00MS04LjUtNjMuNS0xMC45LTEzLjUtMTguNS0yNy41LTM1LjMtNDEuNi01MCAzMi42LTMwLjMgNjMuMi00Ni45IDg0LTQ2LjlWNzhjLTI3LjUgMC02My41IDE5LjYtOTkuOSA1My42LTM2LjQtMzMuOC03Mi40LTUzLjItOTkuOS01My4ydjIyLjNjMjAuNyAwIDUxLjQgMTYuNSA4NCA0Ni42LTE0IDE0LjctMjggMzEuNC00MS4zIDQ5LjktMjIuNiAyLjQtNDQgNi4xLTYzLjYgMTEtMi4zLTEwLTQtMTkuNy01LjItMjktNC43LTM4LjIgMS4xLTY3LjkgMTQuNi03NS44IDMtMS44IDYuOS0yLjYgMTEuNS0yLjZWNzguNWMtOC40IDAtMTYgMS44LTIyLjYgNS42LTI4LjEgMTYuMi0zNC40IDY2LjctMTkuOSAxMzAuMS02Mi4yIDE5LjItMTAyLjcgNDkuOS0xMDIuNyA4Mi4zIDAgMzIuNSA0MC43IDYzLjMgMTAzLjEgODIuNC0xNC40IDYzLjYtOCAxMTQuMiAyMC4yIDEzMC40IDYuNSAzLjggMTQuMSA1LjYgMjIuNSA1LjYgMjcuNSAwIDYzLjUtMTkuNiA5OS45LTUzLjYgMzYuNCAzMy44IDcyLjQgNTMuMiA5OS45IDUzLjIgOC40IDAgMTYtMS44IDIyLjYtNS42IDI4LjEtMTYuMiAzNC40LTY2LjcgMTkuOS0xMzAuMSA2Mi0xOS4xIDEwMi41LTQ5LjkgMTAyLjUtODIuM3ptLTEzMC4yLTY2LjdjLTMuNyAxMi45LTguMyAyNi4yLTEzLjUgMzkuNS00LjEtOC04LjQtMTYtMTMuMS0yNC00LjYtOC05LjUtMTUuOC0xNC40LTIzLjQgMTQuMiAyLjEgMjcuOSA0LjcgNDEgNy45em0tNDUuOCAxMDYuNWMtNy44IDEzLjUtMTUuOCAyNi4zLTI0LjEgMzguMi0xNC45IDEuMy0zMCAyLTQ1LjIgMi0xNS4xIDAtMzAuMi0uNy00NS0xLjktOC4zLTExLjktMTYuNC0yNC42LTI0LjItMzgtNy42LTEzLjEtMTQuNS0yNi40LTIwLjgtMzkuOCA2LjItMTMuNCAxMy4yLTI2LjggMjAuNy0zOS45IDcuOC0xMy41IDE1LjgtMjYuMyAyNC4xLTM4LjIgMTQuOS0xLjMgMzAtMiA0NS4yLTIgMTUuMSAwIDMwLjIuNyA0NSAxLjkgOC4zIDExLjkgMTYuNCAyNC42IDI0LjIgMzggNy42IDEzLjEgMTQuNSAyNi40IDIwLjggMzkuOC02LjMgMTMuNC0xMy4yIDI2LjgtMjAuNyAzOS45em0zMi4zLTEzYzUuNCAxMy40IDEwIDI2LjggMTMuOCAzOS44LTEzLjEgMy4yLTI2LjkgNS45LTQxLjIgOCA0LjktNy43IDkuOC0xNS42IDE0LjQtMjMuNyA0LjYtOCA4LjktMTYuMSAxMy0yNC4xek00MjEuMiA0MzBjLTkuMy05LjYtMTguNi0yMC4zLTI3LjgtMzIgOSAuNCAxOC4yLjcgMjcuNS43IDkuNCAwIDE4LjctLjIgMjcuOC0uNy05IDExLjctMTguMyAyMi40LTI3LjUgMzJ6bS03NC40LTU4LjljLTE0LjItMi4xLTI3LjktNC43LTQxLTcuOSAzLjctMTIuOSA4LjMtMjYuMiAxMy41LTM5LjUgNC4xIDggOC40IDE2IDEzLjEgMjQgNC43IDggOS41IDE1LjggMTQuNCAyMy40ek00MjAuNyAxNjNjOS4zIDkuNiAxOC42IDIwLjMgMjcuOCAzMi05LS40LTE4LjItLjctMjcuNS0uNy05LjQgMC0xOC43LjItMjcuOC43IDktMTEuNyAxOC4zLTIyLjQgMjcuNS0zMnptLTc0IDU4LjljLTQuOSA3LjctOS44IDE1LjYtMTQuNCAyMy43LTQuNiA4LTguOSAxNi0xMyAyNC01LjQtMTMuNC0xMC0yNi44LTEzLjgtMzkuOCAxMy4xLTMuMSAyNi45LTUuOCA0MS4yLTcuOXptLTkwLjUgMTI1LjJjLTM1LjQtMTUuMS01OC4zLTM0LjktNTguMy01MC42IDAtMTUuNyAyMi45LTM1LjYgNTguMy01MC42IDguNi0zLjcgMTgtNyAyNy43LTEwLjEgNS43IDE5LjYgMTMuMiA0MCAyMi41IDYwLjktOS4yIDIwLjgtMTYuNiA0MS4xLTIyLjIgNjAuNi05LjktMy4xLTE5LjMtNi41LTI4LTEwLjJ6TTMxMCA0OTBjLTEzLjYtNy44LTE5LjUtMzcuNS0xNC45LTc1LjcgMS4xLTkuNCAyLjktMTkuMyA1LjEtMjkuNCAxOS42IDQuOCA0MSA4LjUgNjMuNSAxMC45IDEzLjUgMTguNSAyNy41IDM1LjMgNDEuNiA1MC0zMi42IDMwLjMtNjMuMiA0Ni45LTg0IDQ2LjktNC41LS4xLTguMy0xLTExLjMtMi43em0yMzcuMi03Ni4yYzQuNyAzOC4yLTEuMSA2Ny45LTE0LjYgNzUuOC0zIDEuOC02LjkgMi42LTExLjUgMi42LTIwLjcgMC01MS40LTE2LjUtODQtNDYuNiAxNC0xNC43IDI4LTMxLjQgNDEuMy00OS45IDIyLjYtMi40IDQ0LTYuMSA2My42LTExIDIuMyAxMC4xIDQuMSAxOS44IDUuMiAyOS4xem0zOC41LTY2LjdjLTguNiAzLjctMTggNy0yNy43IDEwLjEtNS43LTE5LjYtMTMuMi00MC0yMi41LTYwLjkgOS4yLTIwLjggMTYuNi00MS4xIDIyLjItNjAuNiA5LjkgMy4xIDE5LjMgNi41IDI4LjEgMTAuMiAzNS40IDE1LjEgNTguMyAzNC45IDU4LjMgNTAuNi0uMSAxNS43LTIzIDM1LjYtNTguNCA1MC42ek0zMjAuOCA3OC40eiIvPgogICAgPGNpcmNsZSBjeD0iNDIwLjkiIGN5PSIyOTYuNSIgcj0iNDUuNyIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-redo: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjE2Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgICA8cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTE4LjQgMTAuNkMxNi41NSA4Ljk5IDE0LjE1IDggMTEuNSA4Yy00LjY1IDAtOC41OCAzLjAzLTkuOTYgNy4yMkwzLjkgMTZjMS4wNS0zLjE5IDQuMDUtNS41IDcuNi01LjUgMS45NSAwIDMuNzMuNzIgNS4xMiAxLjg4TDEzIDE2aDlWN2wtMy42IDMuNnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-refresh: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTkgMTMuNWMtMi40OSAwLTQuNS0yLjAxLTQuNS00LjVTNi41MSA0LjUgOSA0LjVjMS4yNCAwIDIuMzYuNTIgMy4xNyAxLjMzTDEwIDhoNVYzbC0xLjc2IDEuNzZDMTIuMTUgMy42OCAxMC42NiAzIDkgMyA1LjY5IDMgMy4wMSA1LjY5IDMuMDEgOVM1LjY5IDE1IDkgMTVjMi45NyAwIDUuNDMtMi4xNiA1LjktNWgtMS41MmMtLjQ2IDItMi4yNCAzLjUtNC4zOCAzLjV6Ii8+CiAgICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-regex: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwIDIwIj4KICA8ZyBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiM0MTQxNDEiPgogICAgPHJlY3QgeD0iMiIgeT0iMiIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbi1hY2NlbnQyIiBmaWxsPSIjRkZGIj4KICAgIDxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjUuNSIgY3k9IjE0LjUiIHI9IjEuNSIvPgogICAgPHJlY3QgeD0iMTIiIHk9IjQiIGNsYXNzPSJzdDIiIHdpZHRoPSIxIiBoZWlnaHQ9IjgiLz4KICAgIDxyZWN0IHg9IjguNSIgeT0iNy41IiB0cmFuc2Zvcm09Im1hdHJpeCgwLjg2NiAtMC41IDAuNSAwLjg2NiAtMi4zMjU1IDcuMzIxOSkiIGNsYXNzPSJzdDIiIHdpZHRoPSI4IiBoZWlnaHQ9IjEiLz4KICAgIDxyZWN0IHg9IjEyIiB5PSI0IiB0cmFuc2Zvcm09Im1hdHJpeCgwLjUgLTAuODY2IDAuODY2IDAuNSAtMC42Nzc5IDE0LjgyNTIpIiBjbGFzcz0ic3QyIiB3aWR0aD0iMSIgaGVpZ2h0PSI4Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-run: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTggNXYxNGwxMS03eiIvPgogICAgPC9nPgo8L3N2Zz4K);
@@ -8844,8 +9144,12 @@ Licensed under the Apache License, Version 2.0.
   --jp-icon-spreadsheet: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNENBRjUwIiBkPSJNMi4yIDIuMnYxNy42aDE3LjZWMi4ySDIuMnptMTUuNCA3LjdoLTUuNVY0LjRoNS41djUuNXpNOS45IDQuNHY1LjVINC40VjQuNGg1LjV6bS01LjUgNy43aDUuNXY1LjVINC40di01LjV6bTcuNyA1LjV2LTUuNWg1LjV2NS41aC01LjV6Ii8+Cjwvc3ZnPgo=);
   --jp-icon-stop: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik02IDZoMTJ2MTJINnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-tab: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIxIDNIM2MtMS4xIDAtMiAuOS0yIDJ2MTRjMCAxLjEuOSAyIDIgMmgxOGMxLjEgMCAyLS45IDItMlY1YzAtMS4xLS45LTItMi0yem0wIDE2SDNWNWgxMHY0aDh2MTB6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-table-rows: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik0yMSw4SDNWNGgxOFY4eiBNMjEsMTBIM3Y0aDE4VjEweiBNMjEsMTZIM3Y0aDE4VjE2eiIvPgogICAgPC9nPgo8L3N2Zz4=);
+  --jp-icon-tag: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjgiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCA0MyAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTI4LjgzMzIgMTIuMzM0TDMyLjk5OTggMTYuNTAwN0wzNy4xNjY1IDEyLjMzNEgyOC44MzMyWiIvPgoJCTxwYXRoIGQ9Ik0xNi4yMDk1IDIxLjYxMDRDMTUuNjg3MyAyMi4xMjk5IDE0Ljg0NDMgMjIuMTI5OSAxNC4zMjQ4IDIxLjYxMDRMNi45ODI5IDE0LjcyNDVDNi41NzI0IDE0LjMzOTQgNi4wODMxMyAxMy42MDk4IDYuMDQ3ODYgMTMuMDQ4MkM1Ljk1MzQ3IDExLjUyODggNi4wMjAwMiA4LjYxOTQ0IDYuMDY2MjEgNy4wNzY5NUM2LjA4MjgxIDYuNTE0NzcgNi41NTU0OCA2LjA0MzQ3IDcuMTE4MDQgNi4wMzA1NUM5LjA4ODYzIDUuOTg0NzMgMTMuMjYzOCA1LjkzNTc5IDEzLjY1MTggNi4zMjQyNUwyMS43MzY5IDEzLjYzOUMyMi4yNTYgMTQuMTU4NSAyMS43ODUxIDE1LjQ3MjQgMjEuMjYyIDE1Ljk5NDZMMTYuMjA5NSAyMS42MTA0Wk05Ljc3NTg1IDguMjY1QzkuMzM1NTEgNy44MjU2NiA4LjYyMzUxIDcuODI1NjYgOC4xODI4IDguMjY1QzcuNzQzNDYgOC43MDU3MSA3Ljc0MzQ2IDkuNDE3MzMgOC4xODI4IDkuODU2NjdDOC42MjM4MiAxMC4yOTY0IDkuMzM1ODIgMTAuMjk2NCA5Ljc3NTg1IDkuODU2NjdDMTAuMjE1NiA5LjQxNzMzIDEwLjIxNTYgOC43MDUzMyA5Ljc3NTg1IDguMjY1WiIvPgoJPC9nPgo8L3N2Zz4K);
   --jp-icon-terminal: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiA+CiAgICA8cmVjdCBjbGFzcz0ianAtaWNvbjIganAtaWNvbi1zZWxlY3RhYmxlIiB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMikiIGZpbGw9IiMzMzMzMzMiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uLWFjY2VudDIganAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGQ9Ik01LjA1NjY0IDguNzYxNzJDNS4wNTY2NCA4LjU5NzY2IDUuMDMxMjUgOC40NTMxMiA0Ljk4MDQ3IDguMzI4MTJDNC45MzM1OSA4LjE5OTIyIDQuODU1NDcgOC4wODIwMyA0Ljc0NjA5IDcuOTc2NTZDNC42NDA2MiA3Ljg3MTA5IDQuNSA3Ljc3NTM5IDQuMzI0MjIgNy42ODk0NUM0LjE1MjM0IDcuNTk5NjEgMy45NDMzNiA3LjUxMTcyIDMuNjk3MjcgNy40MjU3OEMzLjMwMjczIDcuMjg1MTYgMi45NDMzNiA3LjEzNjcyIDIuNjE5MTQgNi45ODA0N0MyLjI5NDkyIDYuODI0MjIgMi4wMTc1OCA2LjY0MjU4IDEuNzg3MTEgNi40MzU1NUMxLjU2MDU1IDYuMjI4NTIgMS4zODQ3NyA1Ljk4ODI4IDEuMjU5NzcgNS43MTQ4NEMxLjEzNDc3IDUuNDM3NSAxLjA3MjI3IDUuMTA5MzggMS4wNzIyNyA0LjczMDQ3QzEuMDcyMjcgNC4zOTg0NCAxLjEyODkxIDQuMDk1NyAxLjI0MjE5IDMuODIyMjdDMS4zNTU0NyAzLjU0NDkyIDEuNTE1NjIgMy4zMDQ2OSAxLjcyMjY2IDMuMTAxNTZDMS45Mjk2OSAyLjg5ODQ0IDIuMTc5NjkgMi43MzQzNyAyLjQ3MjY2IDIuNjA5MzhDMi43NjU2MiAyLjQ4NDM4IDMuMDkxOCAyLjQwNDMgMy40NTExNyAyLjM2OTE0VjEuMTA5MzhINC4zODg2N1YyLjM4MDg2QzQuNzQwMjMgMi40Mjc3MyA1LjA1NjY0IDIuNTIzNDQgNS4zMzc4OSAyLjY2Nzk3QzUuNjE5MTQgMi44MTI1IDUuODU3NDIgMy4wMDE5NSA2LjA1MjczIDMuMjM2MzNDNi4yNTE5NSAzLjQ2NjggNi40MDQzIDMuNzQwMjMgNi41MDk3NyA0LjA1NjY0QzYuNjE5MTQgNC4zNjkxNCA2LjY3MzgzIDQuNzIwNyA2LjY3MzgzIDUuMTExMzNINS4wNDQ5MkM1LjA0NDkyIDQuNjM4NjcgNC45Mzc1IDQuMjgxMjUgNC43MjI2NiA0LjAzOTA2QzQuNTA3ODEgMy43OTI5NyA0LjIxNjggMy42Njk5MiAzLjg0OTYxIDMuNjY5OTJDMy42NTAzOSAzLjY2OTkyIDMuNDc2NTYgMy42OTcyNyAzLjMyODEyIDMuNzUxOTVDMy4xODM1OSAzLjgwMjczIDMuMDY0NDUgMy44NzY5NSAyLjk3MDcgMy45NzQ2MUMyLjg3Njk1IDQuMDY4MzYgMi44MDY2NCA0LjE3OTY5IDIuNzU5NzcgNC4zMDg1OUMyLjcxNjggNC40Mzc1IDIuNjk1MzEgNC41NzgxMiAyLjY5NTMxIDQuNzMwNDdDMi42OTUzMSA0Ljg4MjgxIDIuNzE2OCA1LjAxOTUzIDIuNzU5NzcgNS4xNDA2MkMyLjgwNjY0IDUuMjU3ODEgMi44ODI4MSA1LjM2NzE5IDIuOTg4MjggNS40Njg3NUMzLjA5NzY2IDUuNTcwMzEgMy4yNDAyMyA1LjY2Nzk3IDMuNDE2MDIgNS43NjE3MkMzLjU5MTggNS44NTE1NiAzLjgxMDU1IDUuOTQzMzYgNC4wNzIyNyA2LjAzNzExQzQuNDY2OCA2LjE4NTU1IDQuODI0MjIgNi4zMzk4NCA1LjE0NDUzIDYuNUM1LjQ2NDg0IDYuNjU2MjUgNS43MzgyOCA2LjgzOTg0IDUuOTY0ODQgNy4wNTA3OEM2LjE5NTMxIDcuMjU3ODEgNi4zNzEwOSA3LjUgNi40OTIxOSA3Ljc3NzM0QzYuNjE3MTkgOC4wNTA3OCA2LjY3OTY5IDguMzc1IDYuNjc5NjkgOC43NUM2LjY3OTY5IDkuMDkzNzUgNi42MjMwNSA5LjQwNDMgNi41MDk3NyA5LjY4MTY0QzYuMzk2NDggOS45NTUwOCA2LjIzNDM4IDEwLjE5MTQgNi4wMjM0NCAxMC4zOTA2QzUuODEyNSAxMC41ODk4IDUuNTU4NTkgMTAuNzUgNS4yNjE3MiAxMC44NzExQzQuOTY0ODQgMTAuOTg4MyA0LjYzMjgxIDExLjA2NDUgNC4yNjU2MiAxMS4wOTk2VjEyLjI0OEgzLjMzMzk4VjExLjA5OTZDMy4wMDE5NSAxMS4wNjg0IDIuNjc5NjkgMTAuOTk2MSAyLjM2NzE5IDEwLjg4MjhDMi4wNTQ2OSAxMC43NjU2IDEuNzc3MzQgMTAuNTk3NyAxLjUzNTE2IDEwLjM3ODlDMS4yOTY4OCAxMC4xNjAyIDEuMTA1NDcgOS44ODQ3NyAwLjk2MDkzOCA5LjU1MjczQzAuODE2NDA2IDkuMjE2OCAwLjc0NDE0MSA4LjgxNDQ1IDAuNzQ0MTQxIDguMzQ1N0gyLjM3ODkxQzIuMzc4OTEgOC42MjY5NSAyLjQxOTkyIDguODYzMjggMi41MDE5NSA5LjA1NDY5QzIuNTgzOTggOS4yNDIxOSAyLjY4OTQ1IDkuMzkyNTggMi44MTgzNiA5LjUwNTg2QzIuOTUxMTcgOS42MTUyMyAzLjEwMTU2IDkuNjkzMzYgMy4yNjk1MyA5Ljc0MDIzQzMuNDM3NSA5Ljc4NzExIDMuNjA5MzggOS44MTA1NSAzLjc4NTE2IDkuODEwNTVDNC4yMDMxMiA5LjgxMDU1IDQuNTE5NTMgOS43MTI4OSA0LjczNDM4IDkuNTE3NThDNC45NDkyMiA5LjMyMjI3IDUuMDU2NjQgOS4wNzAzMSA1LjA1NjY0IDguNzYxNzJaTTEzLjQxOCAxMi4yNzE1SDguMDc0MjJWMTFIMTMuNDE4VjEyLjI3MTVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzLjk1MjY0IDYpIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K);
   --jp-icon-text-editor: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-toc: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgoJPHBhdGggZD0iTTcsNUgyMVY3SDdWNU03LDEzVjExSDIxVjEzSDdNNCw0LjVBMS41LDEuNSAwIDAsMSA1LjUsNkExLjUsMS41IDAgMCwxIDQsNy41QTEuNSwxLjUgMCAwLDEgMi41LDZBMS41LDEuNSAwIDAsMSA0LDQuNU00LDEwLjVBMS41LDEuNSAwIDAsMSA1LjUsMTJBMS41LDEuNSAwIDAsMSA0LDEzLjVBMS41LDEuNSAwIDAsMSAyLjUsMTJBMS41LDEuNSAwIDAsMSA0LDEwLjVNNywxOVYxN0gyMVYxOUg3TTQsMTYuNUExLjUsMS41IDAgMCwxIDUuNSwxOEExLjUsMS41IDAgMCwxIDQsMTkuNUExLjUsMS41IDAgMCwxIDIuNSwxOEExLjUsMS41IDAgMCwxIDQsMTYuNVoiIC8+Cjwvc3ZnPgo=);
+  --jp-icon-tree-view: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik0yMiAxMVYzaC03djNIOVYzSDJ2OGg3VjhoMnYxMGg0djNoN3YtOGgtN3YzaC0yVjhoMnYzeiIvPgogICAgPC9nPgo8L3N2Zz4=);
   --jp-icon-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMiAxNy4xODQ0IDIuOTY5NjggMTQuMzAzMiAxLjg2MDk0IDExLjQ0MDlaIi8+CiAgICA8cGF0aCBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiMzMzMzMzMiIHN0cm9rZT0iIzMzMzMzMyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOCA5Ljg2NzE5KSIgZD0iTTIuODYwMTUgNC44NjUzNUwwLjcyNjU0OSAyLjk5OTU5TDAgMy42MzA0NUwyLjg2MDE1IDYuMTMxNTdMOCAwLjYzMDg3Mkw3LjI3ODU3IDBMMi44NjAxNSA0Ljg2NTM1WiIvPgo8L3N2Zz4K);
   --jp-icon-undo: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyLjUgOGMtMi42NSAwLTUuMDUuOTktNi45IDIuNkwyIDd2OWg5bC0zLjYyLTMuNjJjMS4zOS0xLjE2IDMuMTYtMS44OCA1LjEyLTEuODggMy41NCAwIDYuNTUgMi4zMSA3LjYgNS41bDIuMzctLjc4QzIxLjA4IDExLjAzIDE3LjE1IDggMTIuNSA4eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-vega: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbjEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjEyMTIxIj4KICAgIDxwYXRoIGQ9Ik0xMC42IDUuNGwyLjItMy4ySDIuMnY3LjNsNC02LjZ6Ii8+CiAgICA8cGF0aCBkPSJNMTUuOCAyLjJsLTQuNCA2LjZMNyA2LjNsLTQuOCA4djUuNWgxNy42VjIuMmgtNHptLTcgMTUuNEg1LjV2LTQuNGgzLjN2NC40em00LjQgMEg5LjhWOS44aDMuNHY3Ljh6bTQuNCAwaC0zLjRWNi41aDMuNHYxMS4xeiIvPgogIDwvZz4KPC9zdmc+Cg==);
@@ -8901,6 +9205,9 @@ Licensed under the Apache License, Version 2.0.
 }
 .jp-CloseIcon {
   background-image: var(--jp-icon-close);
+}
+.jp-CodeIcon {
+  background-image: var(--jp-icon-code);
 }
 .jp-ConsoleIcon {
   background-image: var(--jp-icon-console);
@@ -8992,11 +9299,20 @@ Licensed under the Apache License, Version 2.0.
 .jp-NotebookIcon {
   background-image: var(--jp-icon-notebook);
 }
+.jp-NumberingIcon {
+  background-image: var(--jp-icon-numbering);
+}
+.jp-OfflineBoltIcon {
+  background-image: var(--jp-icon-offline-bolt);
+}
 .jp-PaletteIcon {
   background-image: var(--jp-icon-palette);
 }
 .jp-PasteIcon {
   background-image: var(--jp-icon-paste);
+}
+.jp-PdfIcon {
+  background-image: var(--jp-icon-pdf);
 }
 .jp-PythonIcon {
   background-image: var(--jp-icon-python);
@@ -9006,6 +9322,9 @@ Licensed under the Apache License, Version 2.0.
 }
 .jp-ReactIcon {
   background-image: var(--jp-icon-react);
+}
+.jp-RedoIcon {
+  background-image: var(--jp-icon-redo);
 }
 .jp-RefreshIcon {
   background-image: var(--jp-icon-refresh);
@@ -9037,11 +9356,23 @@ Licensed under the Apache License, Version 2.0.
 .jp-TabIcon {
   background-image: var(--jp-icon-tab);
 }
+.jp-TableRowsIcon {
+  background-image: var(--jp-icon-table-rows);
+}
+.jp-TagIcon {
+  background-image: var(--jp-icon-tag);
+}
 .jp-TerminalIcon {
   background-image: var(--jp-icon-terminal);
 }
 .jp-TextEditorIcon {
   background-image: var(--jp-icon-text-editor);
+}
+.jp-TocIcon {
+  background-image: var(--jp-icon-toc);
+}
+.jp-TreeViewIcon {
+  background-image: var(--jp-icon-tree-view);
 }
 .jp-TrustedIcon {
   background-image: var(--jp-icon-trusted);
@@ -9625,6 +9956,64 @@ Licensed under the Apache License, Version 2.0.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-switch {
+  display: flex;
+  align-items: center;
+  padding-left: 4px;
+  padding-right: 4px;
+  font-size: var(--jp-ui-font-size1);
+  background-color: transparent;
+  color: var(--jp-ui-font-color1);
+  border: none;
+  height: 20px;
+}
+
+.jp-switch:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.jp-switch-label {
+  margin-right: 5px;
+}
+
+.jp-switch-track {
+  cursor: pointer;
+  background-color: var(--jp-border-color1);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 34px;
+  height: 16px;
+  width: 35px;
+  position: relative;
+}
+
+.jp-switch-track::before {
+  content: '';
+  position: absolute;
+  height: 10px;
+  width: 10px;
+  margin: 3px;
+  left: 0px;
+  background-color: var(--jp-ui-inverse-font-color1);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+.jp-switch[aria-checked='true'] .jp-switch-track {
+  background-color: var(--jp-warn-color0);
+}
+
+.jp-switch[aria-checked='true'] .jp-switch-track::before {
+  /* track width (35) - margins (3 + 3) - thumb width (10) */
+  left: 19px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
 /* Sibling imports */
 
 /* Override Blueprint's _reset.scss styles */
@@ -9757,13 +10146,6 @@ select {
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
 .jp-Collapse {
   display: flex;
   flex-direction: column;
@@ -9814,6 +10196,46 @@ select {
   /* This is needed so that all font sizing of children done in ems is
    * relative to this base size */
   font-size: var(--jp-ui-font-size1);
+}
+
+/*-----------------------------------------------------------------------------
+| Modal variant
+|----------------------------------------------------------------------------*/
+
+.jp-ModalCommandPalette {
+  position: absolute;
+  z-index: 10000;
+  top: 38px;
+  left: 30%;
+  margin: 0;
+  padding: 4px;
+  width: 40%;
+  box-shadow: var(--jp-elevation-z4);
+  border-radius: 4px;
+  background: var(--jp-layout-color0);
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette {
+  max-height: 40vh;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-close-icon::after {
+  display: none;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-header {
+  display: none;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-item {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+
+.jp-ModalCommandPalette
+  .lm-CommandPalette
+  .lm-CommandPalette-item.lm-mod-disabled {
+  display: none;
 }
 
 /*-----------------------------------------------------------------------------
@@ -10027,6 +10449,7 @@ select {
    * relative to this base size */
   font-size: var(--jp-ui-font-size1);
   color: var(--jp-ui-font-color1);
+  resize: both;
 }
 
 .jp-Dialog-button {
@@ -10043,7 +10466,16 @@ button.jp-Dialog-button:focus::-moz-focus-inner {
   border: 0;
 }
 
+button.jp-Dialog-close-button {
+  padding: 0;
+  height: 100%;
+  min-width: unset;
+  min-height: unset;
+}
+
 .jp-Dialog-header {
+  display: flex;
+  justify-content: space-between;
   flex: 0 0 auto;
   padding-bottom: 12px;
   font-size: var(--jp-ui-font-size3);
@@ -10616,6 +11048,11 @@ select.jp-mod-styled {
   min-height: var(--jp-toolbar-micro-height);
   padding: 2px;
   z-index: 1;
+  overflow-x: hidden;
+}
+
+.jp-Toolbar:hover {
+  overflow-x: auto;
 }
 
 /* Toolbar items */
@@ -10694,18 +11131,25 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   color: var(--jp-ui-font-color1);
 }
 
+#jp-main-dock-panel[data-mode='single-document']
+  .jp-MainAreaWidget
+  > .jp-Toolbar.jp-Toolbar-micro {
+  padding: 0;
+  min-height: 0;
+}
+
+#jp-main-dock-panel[data-mode='single-document']
+  .jp-MainAreaWidget
+  > .jp-Toolbar {
+  border: none;
+  box-shadow: none;
+}
+
 /*-----------------------------------------------------------------------------
 | Copyright (c) 2014-2017, Jupyter Development Team.
 |
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -10776,18 +11220,6 @@ body.lm-mod-override-cursor * {
   border: var(--jp-border-width) solid var(--jp-input-active-border-color);
   box-shadow: var(--jp-input-box-shadow);
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
 
 /* BASICS */
 
@@ -10955,17 +11387,17 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
 
 .CodeMirror-scroll {
   overflow: scroll !important; /* Things will break if this is overridden */
-  /* 30px is the magic margin used to hide the element's real scrollbars */
+  /* 50px is the magic margin used to hide the element's real scrollbars */
   /* See overflow: hidden in .CodeMirror */
-  margin-bottom: -30px; margin-right: -30px;
-  padding-bottom: 30px;
+  margin-bottom: -50px; margin-right: -50px;
+  padding-bottom: 50px;
   height: 100%;
   outline: none; /* Prevent dragging from highlighting the element */
   position: relative;
 }
 .CodeMirror-sizer {
   position: relative;
-  border-right: 30px solid transparent;
+  border-right: 50px solid transparent;
 }
 
 /* The fake, visible scrollbars. Used to force redraw during scrolling
@@ -11003,7 +11435,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   height: 100%;
   display: inline-block;
   vertical-align: top;
-  margin-bottom: -30px;
+  margin-bottom: -50px;
 }
 .CodeMirror-gutter-wrapper {
   position: absolute;
@@ -11193,740 +11625,6 @@ span.CodeMirror-selectedtext { background: none; }
   content: "\25B8";
 }
 
-/*
-  Name:       material
-  Author:     Mattia Astorino (http://github.com/equinusocio)
-  Website:    https://material-theme.site/
-*/
-
-.cm-s-material.CodeMirror {
-  background-color: #263238;
-  color: #EEFFFF;
-}
-
-.cm-s-material .CodeMirror-gutters {
-  background: #263238;
-  color: #546E7A;
-  border: none;
-}
-
-.cm-s-material .CodeMirror-guttermarker,
-.cm-s-material .CodeMirror-guttermarker-subtle,
-.cm-s-material .CodeMirror-linenumber {
-  color: #546E7A;
-}
-
-.cm-s-material .CodeMirror-cursor {
-  border-left: 1px solid #FFCC00;
-}
-
-.cm-s-material div.CodeMirror-selected {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material.CodeMirror-focused div.CodeMirror-selected {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material .CodeMirror-line::selection,
-.cm-s-material .CodeMirror-line>span::selection,
-.cm-s-material .CodeMirror-line>span>span::selection {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material .CodeMirror-line::-moz-selection,
-.cm-s-material .CodeMirror-line>span::-moz-selection,
-.cm-s-material .CodeMirror-line>span>span::-moz-selection {
-  background: rgba(128, 203, 196, 0.2);
-}
-
-.cm-s-material .CodeMirror-activeline-background {
-  background: rgba(0, 0, 0, 0.5);
-}
-
-.cm-s-material .cm-keyword {
-  color: #C792EA;
-}
-
-.cm-s-material .cm-operator {
-  color: #89DDFF;
-}
-
-.cm-s-material .cm-variable-2 {
-  color: #EEFFFF;
-}
-
-.cm-s-material .cm-variable-3,
-.cm-s-material .cm-type {
-  color: #f07178;
-}
-
-.cm-s-material .cm-builtin {
-  color: #FFCB6B;
-}
-
-.cm-s-material .cm-atom {
-  color: #F78C6C;
-}
-
-.cm-s-material .cm-number {
-  color: #FF5370;
-}
-
-.cm-s-material .cm-def {
-  color: #82AAFF;
-}
-
-.cm-s-material .cm-string {
-  color: #C3E88D;
-}
-
-.cm-s-material .cm-string-2 {
-  color: #f07178;
-}
-
-.cm-s-material .cm-comment {
-  color: #546E7A;
-}
-
-.cm-s-material .cm-variable {
-  color: #f07178;
-}
-
-.cm-s-material .cm-tag {
-  color: #FF5370;
-}
-
-.cm-s-material .cm-meta {
-  color: #FFCB6B;
-}
-
-.cm-s-material .cm-attribute {
-  color: #C792EA;
-}
-
-.cm-s-material .cm-property {
-  color: #C792EA;
-}
-
-.cm-s-material .cm-qualifier {
-  color: #DECB6B;
-}
-
-.cm-s-material .cm-variable-3,
-.cm-s-material .cm-type {
-  color: #DECB6B;
-}
-
-
-.cm-s-material .cm-error {
-  color: rgba(255, 255, 255, 1.0);
-  background-color: #FF5370;
-}
-
-.cm-s-material .CodeMirror-matchingbracket {
-  text-decoration: underline;
-  color: white !important;
-}
-/**
- * "
- *  Using Zenburn color palette from the Emacs Zenburn Theme
- *  https://github.com/bbatsov/zenburn-emacs/blob/master/zenburn-theme.el
- *
- *  Also using parts of https://github.com/xavi/coderay-lighttable-theme
- * "
- * From: https://github.com/wisenomad/zenburn-lighttable-theme/blob/master/zenburn.css
- */
-
-.cm-s-zenburn .CodeMirror-gutters { background: #3f3f3f !important; }
-.cm-s-zenburn .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: #999; }
-.cm-s-zenburn .CodeMirror-cursor { border-left: 1px solid white; }
-.cm-s-zenburn { background-color: #3f3f3f; color: #dcdccc; }
-.cm-s-zenburn span.cm-builtin { color: #dcdccc; font-weight: bold; }
-.cm-s-zenburn span.cm-comment { color: #7f9f7f; }
-.cm-s-zenburn span.cm-keyword { color: #f0dfaf; font-weight: bold; }
-.cm-s-zenburn span.cm-atom { color: #bfebbf; }
-.cm-s-zenburn span.cm-def { color: #dcdccc; }
-.cm-s-zenburn span.cm-variable { color: #dfaf8f; }
-.cm-s-zenburn span.cm-variable-2 { color: #dcdccc; }
-.cm-s-zenburn span.cm-string { color: #cc9393; }
-.cm-s-zenburn span.cm-string-2 { color: #cc9393; }
-.cm-s-zenburn span.cm-number { color: #dcdccc; }
-.cm-s-zenburn span.cm-tag { color: #93e0e3; }
-.cm-s-zenburn span.cm-property { color: #dfaf8f; }
-.cm-s-zenburn span.cm-attribute { color: #dfaf8f; }
-.cm-s-zenburn span.cm-qualifier { color: #7cb8bb; }
-.cm-s-zenburn span.cm-meta { color: #f0dfaf; }
-.cm-s-zenburn span.cm-header { color: #f0efd0; }
-.cm-s-zenburn span.cm-operator { color: #f0efd0; }
-.cm-s-zenburn span.CodeMirror-matchingbracket { box-sizing: border-box; background: transparent; border-bottom: 1px solid; }
-.cm-s-zenburn span.CodeMirror-nonmatchingbracket { border-bottom: 1px solid; background: none; }
-.cm-s-zenburn .CodeMirror-activeline { background: #000000; }
-.cm-s-zenburn .CodeMirror-activeline-background { background: #000000; }
-.cm-s-zenburn div.CodeMirror-selected { background: #545454; }
-.cm-s-zenburn .CodeMirror-focused div.CodeMirror-selected { background: #4f4f4f; }
-
-.cm-s-abcdef.CodeMirror { background: #0f0f0f; color: #defdef; }
-.cm-s-abcdef div.CodeMirror-selected { background: #515151; }
-.cm-s-abcdef .CodeMirror-line::selection, .cm-s-abcdef .CodeMirror-line > span::selection, .cm-s-abcdef .CodeMirror-line > span > span::selection { background: rgba(56, 56, 56, 0.99); }
-.cm-s-abcdef .CodeMirror-line::-moz-selection, .cm-s-abcdef .CodeMirror-line > span::-moz-selection, .cm-s-abcdef .CodeMirror-line > span > span::-moz-selection { background: rgba(56, 56, 56, 0.99); }
-.cm-s-abcdef .CodeMirror-gutters { background: #555; border-right: 2px solid #314151; }
-.cm-s-abcdef .CodeMirror-guttermarker { color: #222; }
-.cm-s-abcdef .CodeMirror-guttermarker-subtle { color: azure; }
-.cm-s-abcdef .CodeMirror-linenumber { color: #FFFFFF; }
-.cm-s-abcdef .CodeMirror-cursor { border-left: 1px solid #00FF00; }
-
-.cm-s-abcdef span.cm-keyword { color: darkgoldenrod; font-weight: bold; }
-.cm-s-abcdef span.cm-atom { color: #77F; }
-.cm-s-abcdef span.cm-number { color: violet; }
-.cm-s-abcdef span.cm-def { color: #fffabc; }
-.cm-s-abcdef span.cm-variable { color: #abcdef; }
-.cm-s-abcdef span.cm-variable-2 { color: #cacbcc; }
-.cm-s-abcdef span.cm-variable-3, .cm-s-abcdef span.cm-type { color: #def; }
-.cm-s-abcdef span.cm-property { color: #fedcba; }
-.cm-s-abcdef span.cm-operator { color: #ff0; }
-.cm-s-abcdef span.cm-comment { color: #7a7b7c; font-style: italic;}
-.cm-s-abcdef span.cm-string { color: #2b4; }
-.cm-s-abcdef span.cm-meta { color: #C9F; }
-.cm-s-abcdef span.cm-qualifier { color: #FFF700; }
-.cm-s-abcdef span.cm-builtin { color: #30aabc; }
-.cm-s-abcdef span.cm-bracket { color: #8a8a8a; }
-.cm-s-abcdef span.cm-tag { color: #FFDD44; }
-.cm-s-abcdef span.cm-attribute { color: #DDFF00; }
-.cm-s-abcdef span.cm-error { color: #FF0000; }
-.cm-s-abcdef span.cm-header { color: aquamarine; font-weight: bold; }
-.cm-s-abcdef span.cm-link { color: blueviolet; }
-
-.cm-s-abcdef .CodeMirror-activeline-background { background: #314151; }
-
-/*
-
-    Name:       Base16 Default Light
-    Author:     Chris Kempson (http://chriskempson.com)
-
-    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-*/
-
-.cm-s-base16-light.CodeMirror { background: #f5f5f5; color: #202020; }
-.cm-s-base16-light div.CodeMirror-selected { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-line::selection, .cm-s-base16-light .CodeMirror-line > span::selection, .cm-s-base16-light .CodeMirror-line > span > span::selection { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-line::-moz-selection, .cm-s-base16-light .CodeMirror-line > span::-moz-selection, .cm-s-base16-light .CodeMirror-line > span > span::-moz-selection { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-gutters { background: #f5f5f5; border-right: 0px; }
-.cm-s-base16-light .CodeMirror-guttermarker { color: #ac4142; }
-.cm-s-base16-light .CodeMirror-guttermarker-subtle { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-linenumber { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-cursor { border-left: 1px solid #505050; }
-
-.cm-s-base16-light span.cm-comment { color: #8f5536; }
-.cm-s-base16-light span.cm-atom { color: #aa759f; }
-.cm-s-base16-light span.cm-number { color: #aa759f; }
-
-.cm-s-base16-light span.cm-property, .cm-s-base16-light span.cm-attribute { color: #90a959; }
-.cm-s-base16-light span.cm-keyword { color: #ac4142; }
-.cm-s-base16-light span.cm-string { color: #f4bf75; }
-
-.cm-s-base16-light span.cm-variable { color: #90a959; }
-.cm-s-base16-light span.cm-variable-2 { color: #6a9fb5; }
-.cm-s-base16-light span.cm-def { color: #d28445; }
-.cm-s-base16-light span.cm-bracket { color: #202020; }
-.cm-s-base16-light span.cm-tag { color: #ac4142; }
-.cm-s-base16-light span.cm-link { color: #aa759f; }
-.cm-s-base16-light span.cm-error { background: #ac4142; color: #505050; }
-
-.cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC; }
-.cm-s-base16-light .CodeMirror-matchingbracket { color: #f5f5f5 !important; background-color: #6A9FB5 !important}
-
-/*
-
-    Name:       Base16 Default Dark
-    Author:     Chris Kempson (http://chriskempson.com)
-
-    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-*/
-
-.cm-s-base16-dark.CodeMirror { background: #151515; color: #e0e0e0; }
-.cm-s-base16-dark div.CodeMirror-selected { background: #303030; }
-.cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-gutters { background: #151515; border-right: 0px; }
-.cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
-.cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
-.cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
-.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0; }
-
-.cm-s-base16-dark span.cm-comment { color: #8f5536; }
-.cm-s-base16-dark span.cm-atom { color: #aa759f; }
-.cm-s-base16-dark span.cm-number { color: #aa759f; }
-
-.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute { color: #90a959; }
-.cm-s-base16-dark span.cm-keyword { color: #ac4142; }
-.cm-s-base16-dark span.cm-string { color: #f4bf75; }
-
-.cm-s-base16-dark span.cm-variable { color: #90a959; }
-.cm-s-base16-dark span.cm-variable-2 { color: #6a9fb5; }
-.cm-s-base16-dark span.cm-def { color: #d28445; }
-.cm-s-base16-dark span.cm-bracket { color: #e0e0e0; }
-.cm-s-base16-dark span.cm-tag { color: #ac4142; }
-.cm-s-base16-dark span.cm-link { color: #aa759f; }
-.cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
-
-.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
-.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
-
-/*
-
-    Name:       dracula
-    Author:     Michael Kaminsky (http://github.com/mkaminsky11)
-
-    Original dracula color scheme by Zeno Rocha (https://github.com/zenorocha/dracula-theme)
-
-*/
-
-
-.cm-s-dracula.CodeMirror, .cm-s-dracula .CodeMirror-gutters {
-  background-color: #282a36 !important;
-  color: #f8f8f2 !important;
-  border: none;
-}
-.cm-s-dracula .CodeMirror-gutters { color: #282a36; }
-.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
-.cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-dracula .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-dracula span.cm-comment { color: #6272a4; }
-.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 { color: #f1fa8c; }
-.cm-s-dracula span.cm-number { color: #bd93f9; }
-.cm-s-dracula span.cm-variable { color: #50fa7b; }
-.cm-s-dracula span.cm-variable-2 { color: white; }
-.cm-s-dracula span.cm-def { color: #50fa7b; }
-.cm-s-dracula span.cm-operator { color: #ff79c6; }
-.cm-s-dracula span.cm-keyword { color: #ff79c6; }
-.cm-s-dracula span.cm-atom { color: #bd93f9; }
-.cm-s-dracula span.cm-meta { color: #f8f8f2; }
-.cm-s-dracula span.cm-tag { color: #ff79c6; }
-.cm-s-dracula span.cm-attribute { color: #50fa7b; }
-.cm-s-dracula span.cm-qualifier { color: #50fa7b; }
-.cm-s-dracula span.cm-property { color: #66d9ef; }
-.cm-s-dracula span.cm-builtin { color: #50fa7b; }
-.cm-s-dracula span.cm-variable-3, .cm-s-dracula span.cm-type { color: #ffb86c; }
-
-.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
-.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
-
-/*
-
-    Name:       Hopscotch
-    Author:     Jan T. Sott
-
-    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-*/
-
-.cm-s-hopscotch.CodeMirror {background: #322931; color: #d5d3d5;}
-.cm-s-hopscotch div.CodeMirror-selected {background: #433b42 !important;}
-.cm-s-hopscotch .CodeMirror-gutters {background: #322931; border-right: 0px;}
-.cm-s-hopscotch .CodeMirror-linenumber {color: #797379;}
-.cm-s-hopscotch .CodeMirror-cursor {border-left: 1px solid #989498 !important;}
-
-.cm-s-hopscotch span.cm-comment {color: #b33508;}
-.cm-s-hopscotch span.cm-atom {color: #c85e7c;}
-.cm-s-hopscotch span.cm-number {color: #c85e7c;}
-
-.cm-s-hopscotch span.cm-property, .cm-s-hopscotch span.cm-attribute {color: #8fc13e;}
-.cm-s-hopscotch span.cm-keyword {color: #dd464c;}
-.cm-s-hopscotch span.cm-string {color: #fdcc59;}
-
-.cm-s-hopscotch span.cm-variable {color: #8fc13e;}
-.cm-s-hopscotch span.cm-variable-2 {color: #1290bf;}
-.cm-s-hopscotch span.cm-def {color: #fd8b19;}
-.cm-s-hopscotch span.cm-error {background: #dd464c; color: #989498;}
-.cm-s-hopscotch span.cm-bracket {color: #d5d3d5;}
-.cm-s-hopscotch span.cm-tag {color: #dd464c;}
-.cm-s-hopscotch span.cm-link {color: #c85e7c;}
-
-.cm-s-hopscotch .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
-.cm-s-hopscotch .CodeMirror-activeline-background { background: #302020; }
-
-/****************************************************************/
-/*   Based on mbonaci's Brackets mbo theme                      */
-/*   https://github.com/mbonaci/global/blob/master/Mbo.tmTheme  */
-/*   Create your own: http://tmtheme-editor.herokuapp.com       */
-/****************************************************************/
-
-.cm-s-mbo.CodeMirror { background: #2c2c2c; color: #ffffec; }
-.cm-s-mbo div.CodeMirror-selected { background: #716C62; }
-.cm-s-mbo .CodeMirror-line::selection, .cm-s-mbo .CodeMirror-line > span::selection, .cm-s-mbo .CodeMirror-line > span > span::selection { background: rgba(113, 108, 98, .99); }
-.cm-s-mbo .CodeMirror-line::-moz-selection, .cm-s-mbo .CodeMirror-line > span::-moz-selection, .cm-s-mbo .CodeMirror-line > span > span::-moz-selection { background: rgba(113, 108, 98, .99); }
-.cm-s-mbo .CodeMirror-gutters { background: #4e4e4e; border-right: 0px; }
-.cm-s-mbo .CodeMirror-guttermarker { color: white; }
-.cm-s-mbo .CodeMirror-guttermarker-subtle { color: grey; }
-.cm-s-mbo .CodeMirror-linenumber { color: #dadada; }
-.cm-s-mbo .CodeMirror-cursor { border-left: 1px solid #ffffec; }
-
-.cm-s-mbo span.cm-comment { color: #95958a; }
-.cm-s-mbo span.cm-atom { color: #00a8c6; }
-.cm-s-mbo span.cm-number { color: #00a8c6; }
-
-.cm-s-mbo span.cm-property, .cm-s-mbo span.cm-attribute { color: #9ddfe9; }
-.cm-s-mbo span.cm-keyword { color: #ffb928; }
-.cm-s-mbo span.cm-string { color: #ffcf6c; }
-.cm-s-mbo span.cm-string.cm-property { color: #ffffec; }
-
-.cm-s-mbo span.cm-variable { color: #ffffec; }
-.cm-s-mbo span.cm-variable-2 { color: #00a8c6; }
-.cm-s-mbo span.cm-def { color: #ffffec; }
-.cm-s-mbo span.cm-bracket { color: #fffffc; font-weight: bold; }
-.cm-s-mbo span.cm-tag { color: #9ddfe9; }
-.cm-s-mbo span.cm-link { color: #f54b07; }
-.cm-s-mbo span.cm-error { border-bottom: #636363; color: #ffffec; }
-.cm-s-mbo span.cm-qualifier { color: #ffffec; }
-
-.cm-s-mbo .CodeMirror-activeline-background { background: #494b41; }
-.cm-s-mbo .CodeMirror-matchingbracket { color: #ffb928 !important; }
-.cm-s-mbo .CodeMirror-matchingtag { background: rgba(255, 255, 255, .37); }
-
-/*
-  MDN-LIKE Theme - Mozilla
-  Ported to CodeMirror by Peter Kroon <plakroon@gmail.com>
-  Report bugs/issues here: https://github.com/codemirror/CodeMirror/issues
-  GitHub: @peterkroon
-
-  The mdn-like theme is inspired on the displayed code examples at: https://developer.mozilla.org/en-US/docs/Web/CSS/animation
-
-*/
-.cm-s-mdn-like.CodeMirror { color: #999; background-color: #fff; }
-.cm-s-mdn-like div.CodeMirror-selected { background: #cfc; }
-.cm-s-mdn-like .CodeMirror-line::selection, .cm-s-mdn-like .CodeMirror-line > span::selection, .cm-s-mdn-like .CodeMirror-line > span > span::selection { background: #cfc; }
-.cm-s-mdn-like .CodeMirror-line::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span > span::-moz-selection { background: #cfc; }
-
-.cm-s-mdn-like .CodeMirror-gutters { background: #f8f8f8; border-left: 6px solid rgba(0,83,159,0.65); color: #333; }
-.cm-s-mdn-like .CodeMirror-linenumber { color: #aaa; padding-left: 8px; }
-.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
-
-.cm-s-mdn-like .cm-keyword { color: #6262FF; }
-.cm-s-mdn-like .cm-atom { color: #F90; }
-.cm-s-mdn-like .cm-number { color:  #ca7841; }
-.cm-s-mdn-like .cm-def { color: #8DA6CE; }
-.cm-s-mdn-like span.cm-variable-2, .cm-s-mdn-like span.cm-tag { color: #690; }
-.cm-s-mdn-like span.cm-variable-3, .cm-s-mdn-like span.cm-def, .cm-s-mdn-like span.cm-type { color: #07a; }
-
-.cm-s-mdn-like .cm-variable { color: #07a; }
-.cm-s-mdn-like .cm-property { color: #905; }
-.cm-s-mdn-like .cm-qualifier { color: #690; }
-
-.cm-s-mdn-like .cm-operator { color: #cda869; }
-.cm-s-mdn-like .cm-comment { color:#777; font-weight:normal; }
-.cm-s-mdn-like .cm-string { color:#07a; font-style:italic; }
-.cm-s-mdn-like .cm-string-2 { color:#bd6b18; } /*?*/
-.cm-s-mdn-like .cm-meta { color: #000; } /*?*/
-.cm-s-mdn-like .cm-builtin { color: #9B7536; } /*?*/
-.cm-s-mdn-like .cm-tag { color: #997643; }
-.cm-s-mdn-like .cm-attribute { color: #d6bb6d; } /*?*/
-.cm-s-mdn-like .cm-header { color: #FF6400; }
-.cm-s-mdn-like .cm-hr { color: #AEAEAE; }
-.cm-s-mdn-like .cm-link { color:#ad9361; font-style:italic; text-decoration:none; }
-.cm-s-mdn-like .cm-error { border-bottom: 1px solid red; }
-
-div.cm-s-mdn-like .CodeMirror-activeline-background { background: #efefff; }
-div.cm-s-mdn-like span.CodeMirror-matchingbracket { outline:1px solid grey; color: inherit; }
-
-.cm-s-mdn-like.CodeMirror { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFcAAAAyCAYAAAAp8UeFAAAHvklEQVR42s2b63bcNgyEQZCSHCdt2vd/0tWF7I+Q6XgMXiTtuvU5Pl57ZQKkKHzEAOtF5KeIJBGJ8uvL599FRFREZhFx8DeXv8trn68RuGaC8TRfo3SNp9dlDDHedyLyTUTeRWStXKPZrjtpZxaRw5hPqozRs1N8/enzIiQRWcCgy4MUA0f+XWliDhyL8Lfyvx7ei/Ae3iQFHyw7U/59pQVIMEEPEz0G7XiwdRjzSfC3UTtz9vchIntxvry5iMgfIhJoEflOz2CQr3F5h/HfeFe+GTdLaKcu9L8LTeQb/R/7GgbsfKedyNdoHsN31uRPWrfZ5wsj/NzzRQHuToIdU3ahwnsKPxXCjJITuOsi7XLc7SG/v5GdALs7wf8JjTFiB5+QvTEfRyGOfX3Lrx8wxyQi3sNq46O7QahQiCsRFgqddjBouVEHOKDgXAQHD9gJCr5sMKkEdjwsarG/ww3BMHBU7OBjXnzdyY7SfCxf5/z6ATccrwlKuwC/jhznnPF4CgVzhhVf4xp2EixcBActO75iZ8/fM9zAs2OMzKdslgXWJ9XG8PQoOAMA5fGcsvORgv0doBXyHrCwfLJAOwo71QLNkb8n2Pl6EWiR7OCibtkPaz4Kc/0NNAze2gju3zOwekALDaCFPI5vjPFmgGY5AZqyGEvH1x7QfIb8YtxMnA/b+QQ0aQDAwc6JMFg8CbQZ4qoYEEHbRwNojuK3EHwd7VALSgq+MNDKzfT58T8qdpADrgW0GmgcAS1lhzztJmkAzcPNOQbsWEALBDSlMKUG0Eq4CLAQWvEVQ9WU57gZJwZtgPO3r9oBTQ9WO8TjqXINx8R0EYpiZEUWOF3FxkbJkgU9B2f41YBrIj5ZfsQa0M5kTgiAAqM3ShXLgu8XMqcrQBvJ0CL5pnTsfMB13oB8athpAq2XOQmcGmoACCLydx7nToa23ATaSIY2ichfOdPTGxlasXMLaL0MLZAOwAKIM+y8CmicobGdCcbbK9DzN+yYGVoNNI5iUKTMyYOjPse4A8SM1MmcXgU0toOq1yO/v8FOxlASyc7TgeYaAMBJHcY1CcCwGI/TK4AmDbDyKYBBtFUkRwto8gygiQEaByFgJ00BH2M8JWwQS1nafDXQCidWyOI8AcjDCSjCLk8ngObuAm3JAHAdubAmOaK06V8MNEsKPJOhobSprwQa6gD7DclRQdqcwL4zxqgBrQcabUiBLclRDKAlWp+etPkBaNMA0AKlrHwTdEByZAA4GM+SNluSY6wAzcMNewxmgig5Ks0nkrSpBvSaQHMdKTBAnLojOdYyGpQ254602ZILPdTD1hdlggdIm74jbTp8vDwF5ZYUeLWGJpWsh6XNyXgcYwVoJQTEhhTYkxzZjiU5npU2TaB979TQehlaAVq4kaGpiPwwwLkYUuBbQwocyQTv1tA0+1UFWoJF3iv1oq+qoSk8EQdJmwHkziIF7oOZk14EGitibAdjLYYK78H5vZOhtWpoI0ATGHs0Q8OMb4Ey+2bU2UYztCtA0wFAs7TplGLRVQCcqaFdGSPCeTI1QNIC52iWNzof6Uib7xjEp07mNNoUYmVosVItHrHzRlLgBn9LFyRHaQCtVUMbtTNhoXWiTOO9k/V8BdAc1Oq0ArSQs6/5SU0hckNy9NnXqQY0PGYo5dWJ7nINaN6o958FWin27aBaWRka1r5myvLOAm0j30eBJqCxHLReVclxhxOEN2JfDWjxBtAC7MIH1fVaGdoOp4qJYDgKtKPSFNID2gSnGldrCqkFZ+5UeQXQBIRrSwocbdZYQT/2LwRahBPBXoHrB8nxaGROST62DKUbQOMMzZIC9abkuELfQzQALWTnDNAm8KHWFOJgJ5+SHIvTPcmx1xQyZRhNL5Qci689aXMEaN/uNIWkEwDAvFpOZmgsBaaGnbs1NPa1Jm32gBZAIh1pCtG7TSH4aE0y1uVY4uqoFPisGlpP2rSA5qTecWn5agK6BzSpgAyD+wFaqhnYoSZ1Vwr8CmlTQbrcO3ZaX0NAEyMbYaAlyquFoLKK3SPby9CeVUPThrSJmkCAE0CrKUQadi4DrdSlWhmah0YL9z9vClH59YGbHx1J8VZTyAjQepJjmXwAKTDQI3omc3p1U4gDUf6RfcdYfrUp5ClAi2J3Ba6UOXGo+K+bQrjjssitG2SJzshaLwMtXgRagUNpYYoVkMSBLM+9GGiJZMvduG6DRZ4qc04DMPtQQxOjEtACmhO7K1AbNbQDEggZyJwscFpAGwENhoBeUwh3bWolhe8BTYVKxQEWrSUn/uhcM5KhvUu/+eQu0Lzhi+VrK0PrZZNDQKs9cpYUuFYgMVpD4/NxenJTiMCNqdUEUf1qZWjppLT5qSkkUZbCwkbZMSuVnu80hfSkzRbQeqCZSAh6huR4VtoM2gHAlLf72smuWgE+VV7XpE25Ab2WFDgyhnSuKbs4GuGzCjR+tIoUuMFg3kgcWKLTwRqanJQ2W00hAsenfaApRC42hbCvK1SlE0HtE9BGgneJO+ELamitD1YjjOYnNYVcraGhtKkW0EqVVeDx733I2NH581k1NNxNLG0i0IJ8/NjVaOZ0tYZ2Vtr0Xv7tPV3hkWp9EFkgS/J0vosngTaSoaG06WHi+xObQkaAdlbanP8B2+2l0f90LmUAAAAASUVORK5CYII=); }
-
-/*
-
-    Name:       seti
-    Author:     Michael Kaminsky (http://github.com/mkaminsky11)
-
-    Original seti color scheme by Jesse Weed (https://github.com/jesseweed/seti-syntax)
-
-*/
-
-
-.cm-s-seti.CodeMirror {
-  background-color: #151718 !important;
-  color: #CFD2D1 !important;
-  border: none;
-}
-.cm-s-seti .CodeMirror-gutters {
-  color: #404b53;
-  background-color: #0E1112;
-  border: none;
-}
-.cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
-.cm-s-seti .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-seti.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti .CodeMirror-line::-moz-selection, .cm-s-seti .CodeMirror-line > span::-moz-selection, .cm-s-seti .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
-.cm-s-seti span.cm-comment { color: #41535b; }
-.cm-s-seti span.cm-string, .cm-s-seti span.cm-string-2 { color: #55b5db; }
-.cm-s-seti span.cm-number { color: #cd3f45; }
-.cm-s-seti span.cm-variable { color: #55b5db; }
-.cm-s-seti span.cm-variable-2 { color: #a074c4; }
-.cm-s-seti span.cm-def { color: #55b5db; }
-.cm-s-seti span.cm-keyword { color: #ff79c6; }
-.cm-s-seti span.cm-operator { color: #9fca56; }
-.cm-s-seti span.cm-keyword { color: #e6cd69; }
-.cm-s-seti span.cm-atom { color: #cd3f45; }
-.cm-s-seti span.cm-meta { color: #55b5db; }
-.cm-s-seti span.cm-tag { color: #55b5db; }
-.cm-s-seti span.cm-attribute { color: #9fca56; }
-.cm-s-seti span.cm-qualifier { color: #9fca56; }
-.cm-s-seti span.cm-property { color: #a074c4; }
-.cm-s-seti span.cm-variable-3, .cm-s-seti span.cm-type { color: #9fca56; }
-.cm-s-seti span.cm-builtin { color: #9fca56; }
-.cm-s-seti .CodeMirror-activeline-background { background: #101213; }
-.cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
-
-/*
-Solarized theme for code-mirror
-http://ethanschoonover.com/solarized
-*/
-
-/*
-Solarized color palette
-http://ethanschoonover.com/solarized/img/solarized-palette.png
-*/
-
-.solarized.base03 { color: #002b36; }
-.solarized.base02 { color: #073642; }
-.solarized.base01 { color: #586e75; }
-.solarized.base00 { color: #657b83; }
-.solarized.base0 { color: #839496; }
-.solarized.base1 { color: #93a1a1; }
-.solarized.base2 { color: #eee8d5; }
-.solarized.base3  { color: #fdf6e3; }
-.solarized.solar-yellow  { color: #b58900; }
-.solarized.solar-orange  { color: #cb4b16; }
-.solarized.solar-red { color: #dc322f; }
-.solarized.solar-magenta { color: #d33682; }
-.solarized.solar-violet  { color: #6c71c4; }
-.solarized.solar-blue { color: #268bd2; }
-.solarized.solar-cyan { color: #2aa198; }
-.solarized.solar-green { color: #859900; }
-
-/* Color scheme for code-mirror */
-
-.cm-s-solarized {
-  line-height: 1.45em;
-  color-profile: sRGB;
-  rendering-intent: auto;
-}
-.cm-s-solarized.cm-s-dark {
-  color: #839496;
-  background-color: #002b36;
-  text-shadow: #002b36 0 1px;
-}
-.cm-s-solarized.cm-s-light {
-  background-color: #fdf6e3;
-  color: #657b83;
-  text-shadow: #eee8d5 0 1px;
-}
-
-.cm-s-solarized .CodeMirror-widget {
-  text-shadow: none;
-}
-
-.cm-s-solarized .cm-header { color: #586e75; }
-.cm-s-solarized .cm-quote { color: #93a1a1; }
-
-.cm-s-solarized .cm-keyword { color: #cb4b16; }
-.cm-s-solarized .cm-atom { color: #d33682; }
-.cm-s-solarized .cm-number { color: #d33682; }
-.cm-s-solarized .cm-def { color: #2aa198; }
-
-.cm-s-solarized .cm-variable { color: #839496; }
-.cm-s-solarized .cm-variable-2 { color: #b58900; }
-.cm-s-solarized .cm-variable-3, .cm-s-solarized .cm-type { color: #6c71c4; }
-
-.cm-s-solarized .cm-property { color: #2aa198; }
-.cm-s-solarized .cm-operator { color: #6c71c4; }
-
-.cm-s-solarized .cm-comment { color: #586e75; font-style:italic; }
-
-.cm-s-solarized .cm-string { color: #859900; }
-.cm-s-solarized .cm-string-2 { color: #b58900; }
-
-.cm-s-solarized .cm-meta { color: #859900; }
-.cm-s-solarized .cm-qualifier { color: #b58900; }
-.cm-s-solarized .cm-builtin { color: #d33682; }
-.cm-s-solarized .cm-bracket { color: #cb4b16; }
-.cm-s-solarized .CodeMirror-matchingbracket { color: #859900; }
-.cm-s-solarized .CodeMirror-nonmatchingbracket { color: #dc322f; }
-.cm-s-solarized .cm-tag { color: #93a1a1; }
-.cm-s-solarized .cm-attribute { color: #2aa198; }
-.cm-s-solarized .cm-hr {
-  color: transparent;
-  border-top: 1px solid #586e75;
-  display: block;
-}
-.cm-s-solarized .cm-link { color: #93a1a1; cursor: pointer; }
-.cm-s-solarized .cm-special { color: #6c71c4; }
-.cm-s-solarized .cm-em {
-  color: #999;
-  text-decoration: underline;
-  text-decoration-style: dotted;
-}
-.cm-s-solarized .cm-error,
-.cm-s-solarized .cm-invalidchar {
-  color: #586e75;
-  border-bottom: 1px dotted #dc322f;
-}
-
-.cm-s-solarized.cm-s-dark div.CodeMirror-selected { background: #073642; }
-.cm-s-solarized.cm-s-dark.CodeMirror ::selection { background: rgba(7, 54, 66, 0.99); }
-.cm-s-solarized.cm-s-dark .CodeMirror-line::-moz-selection, .cm-s-dark .CodeMirror-line > span::-moz-selection, .cm-s-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(7, 54, 66, 0.99); }
-
-.cm-s-solarized.cm-s-light div.CodeMirror-selected { background: #eee8d5; }
-.cm-s-solarized.cm-s-light .CodeMirror-line::selection, .cm-s-light .CodeMirror-line > span::selection, .cm-s-light .CodeMirror-line > span > span::selection { background: #eee8d5; }
-.cm-s-solarized.cm-s-light .CodeMirror-line::-moz-selection, .cm-s-ligh .CodeMirror-line > span::-moz-selection, .cm-s-ligh .CodeMirror-line > span > span::-moz-selection { background: #eee8d5; }
-
-/* Editor styling */
-
-
-
-/* Little shadow on the view-port of the buffer view */
-.cm-s-solarized.CodeMirror {
-  -moz-box-shadow: inset 7px 0 12px -6px #000;
-  -webkit-box-shadow: inset 7px 0 12px -6px #000;
-  box-shadow: inset 7px 0 12px -6px #000;
-}
-
-/* Remove gutter border */
-.cm-s-solarized .CodeMirror-gutters {
-  border-right: 0;
-}
-
-/* Gutter colors and line number styling based of color scheme (dark / light) */
-
-/* Dark */
-.cm-s-solarized.cm-s-dark .CodeMirror-gutters {
-  background-color: #073642;
-}
-
-.cm-s-solarized.cm-s-dark .CodeMirror-linenumber {
-  color: #586e75;
-  text-shadow: #021014 0 -1px;
-}
-
-/* Light */
-.cm-s-solarized.cm-s-light .CodeMirror-gutters {
-  background-color: #eee8d5;
-}
-
-.cm-s-solarized.cm-s-light .CodeMirror-linenumber {
-  color: #839496;
-}
-
-/* Common */
-.cm-s-solarized .CodeMirror-linenumber {
-  padding: 0 5px;
-}
-.cm-s-solarized .CodeMirror-guttermarker-subtle { color: #586e75; }
-.cm-s-solarized.cm-s-dark .CodeMirror-guttermarker { color: #ddd; }
-.cm-s-solarized.cm-s-light .CodeMirror-guttermarker { color: #cb4b16; }
-
-.cm-s-solarized .CodeMirror-gutter .CodeMirror-gutter-text {
-  color: #586e75;
-}
-
-/* Cursor */
-.cm-s-solarized .CodeMirror-cursor { border-left: 1px solid #819090; }
-
-/* Fat cursor */
-.cm-s-solarized.cm-s-light.cm-fat-cursor .CodeMirror-cursor { background: #77ee77; }
-.cm-s-solarized.cm-s-light .cm-animate-fat-cursor { background-color: #77ee77; }
-.cm-s-solarized.cm-s-dark.cm-fat-cursor .CodeMirror-cursor { background: #586e75; }
-.cm-s-solarized.cm-s-dark .cm-animate-fat-cursor { background-color: #586e75; }
-
-/* Active line */
-.cm-s-solarized.cm-s-dark .CodeMirror-activeline-background {
-  background: rgba(255, 255, 255, 0.06);
-}
-.cm-s-solarized.cm-s-light .CodeMirror-activeline-background {
-  background: rgba(0, 0, 0, 0.06);
-}
-
-.cm-s-the-matrix.CodeMirror { background: #000000; color: #00FF00; }
-.cm-s-the-matrix div.CodeMirror-selected { background: #2D2D2D; }
-.cm-s-the-matrix .CodeMirror-line::selection, .cm-s-the-matrix .CodeMirror-line > span::selection, .cm-s-the-matrix .CodeMirror-line > span > span::selection { background: rgba(45, 45, 45, 0.99); }
-.cm-s-the-matrix .CodeMirror-line::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span > span::-moz-selection { background: rgba(45, 45, 45, 0.99); }
-.cm-s-the-matrix .CodeMirror-gutters { background: #060; border-right: 2px solid #00FF00; }
-.cm-s-the-matrix .CodeMirror-guttermarker { color: #0f0; }
-.cm-s-the-matrix .CodeMirror-guttermarker-subtle { color: white; }
-.cm-s-the-matrix .CodeMirror-linenumber { color: #FFFFFF; }
-.cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00; }
-
-.cm-s-the-matrix span.cm-keyword { color: #008803; font-weight: bold; }
-.cm-s-the-matrix span.cm-atom { color: #3FF; }
-.cm-s-the-matrix span.cm-number { color: #FFB94F; }
-.cm-s-the-matrix span.cm-def { color: #99C; }
-.cm-s-the-matrix span.cm-variable { color: #F6C; }
-.cm-s-the-matrix span.cm-variable-2 { color: #C6F; }
-.cm-s-the-matrix span.cm-variable-3, .cm-s-the-matrix span.cm-type { color: #96F; }
-.cm-s-the-matrix span.cm-property { color: #62FFA0; }
-.cm-s-the-matrix span.cm-operator { color: #999; }
-.cm-s-the-matrix span.cm-comment { color: #CCCCCC; }
-.cm-s-the-matrix span.cm-string { color: #39C; }
-.cm-s-the-matrix span.cm-meta { color: #C9F; }
-.cm-s-the-matrix span.cm-qualifier { color: #FFF700; }
-.cm-s-the-matrix span.cm-builtin { color: #30a; }
-.cm-s-the-matrix span.cm-bracket { color: #cc7; }
-.cm-s-the-matrix span.cm-tag { color: #FFBD40; }
-.cm-s-the-matrix span.cm-attribute { color: #FFF700; }
-.cm-s-the-matrix span.cm-error { color: #FF0000; }
-
-.cm-s-the-matrix .CodeMirror-activeline-background { background: #040; }
-
-/*
-Copyright (C) 2011 by MarkLogic Corporation
-Author: Mike Brevoort <mike@brevoort.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
-.cm-s-xq-light span.cm-keyword { line-height: 1em; font-weight: bold; color: #5A5CAD; }
-.cm-s-xq-light span.cm-atom { color: #6C8CD5; }
-.cm-s-xq-light span.cm-number { color: #164; }
-.cm-s-xq-light span.cm-def { text-decoration:underline; }
-.cm-s-xq-light span.cm-variable { color: black; }
-.cm-s-xq-light span.cm-variable-2 { color:black; }
-.cm-s-xq-light span.cm-variable-3, .cm-s-xq-light span.cm-type { color: black; }
-.cm-s-xq-light span.cm-property {}
-.cm-s-xq-light span.cm-operator {}
-.cm-s-xq-light span.cm-comment { color: #0080FF; font-style: italic; }
-.cm-s-xq-light span.cm-string { color: red; }
-.cm-s-xq-light span.cm-meta { color: yellow; }
-.cm-s-xq-light span.cm-qualifier { color: grey; }
-.cm-s-xq-light span.cm-builtin { color: #7EA656; }
-.cm-s-xq-light span.cm-bracket { color: #cc7; }
-.cm-s-xq-light span.cm-tag { color: #3F7F7F; }
-.cm-s-xq-light span.cm-attribute { color: #7F007F; }
-.cm-s-xq-light span.cm-error { color: #f00; }
-
-.cm-s-xq-light .CodeMirror-activeline-background { background: #e8f2ff; }
-.cm-s-xq-light .CodeMirror-matchingbracket { outline:1px solid grey;color:black !important;background:yellow; }
-
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
@@ -11961,12 +11659,7 @@ THE SOFTWARE.
   padding: 0 8px;
 }
 
-.jp-CodeMirrorEditor-static {
-  margin: var(--jp-code-padding);
-}
-
-.jp-CodeMirrorEditor,
-.jp-CodeMirrorEditor-static {
+.jp-CodeMirrorEditor {
   cursor: text;
 }
 
@@ -12166,16 +11859,16 @@ THE SOFTWARE.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
 /*-----------------------------------------------------------------------------
 | RenderedText
 |----------------------------------------------------------------------------*/
+
+:root {
+  /* This is the padding value to fill the gaps between lines containing spans with background color. */
+  --jp-private-code-span-padding: calc(
+    (var(--jp-code-line-height) - 1) * var(--jp-code-font-size) / 2
+  );
+}
 
 .jp-RenderedText {
   text-align: left;
@@ -12192,7 +11885,6 @@ THE SOFTWARE.
   border: none;
   margin: 0px;
   padding: 0px;
-  line-height: normal;
 }
 
 .jp-RenderedText pre a:link {
@@ -12236,27 +11928,35 @@ THE SOFTWARE.
 
 .jp-RenderedText pre .ansi-black-bg {
   background-color: #3e424d;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-red-bg {
   background-color: #e75c58;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-green-bg {
   background-color: #00a250;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-yellow-bg {
   background-color: #ddb62b;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-blue-bg {
   background-color: #208ffb;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-magenta-bg {
   background-color: #d160c4;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-cyan-bg {
   background-color: #60c6c8;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-white-bg {
   background-color: #c5c1b4;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-black-intense-fg {
@@ -12286,27 +11986,35 @@ THE SOFTWARE.
 
 .jp-RenderedText pre .ansi-black-intense-bg {
   background-color: #282c36;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-red-intense-bg {
   background-color: #b22b31;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-green-intense-bg {
   background-color: #007427;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-yellow-intense-bg {
   background-color: #b27d12;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-blue-intense-bg {
   background-color: #0065ca;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-magenta-intense-bg {
   background-color: #a03196;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-cyan-intense-bg {
   background-color: #258f8f;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-white-intense-bg {
   background-color: #a1a6b2;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-default-inverse-fg {
@@ -12314,6 +12022,7 @@ THE SOFTWARE.
 }
 .jp-RenderedText pre .ansi-default-inverse-bg {
   background-color: var(--jp-inverse-layout-color0);
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-bold {
@@ -12735,33 +12444,9 @@ h6:hover .jp-InternalAnchorLink {
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
 .jp-MimeDocument {
   outline: none;
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -12801,7 +12486,7 @@ h6:hover .jp-InternalAnchorLink {
 
 .jp-BreadCrumbs {
   flex: 0 0 auto;
-  margin: 4px 12px;
+  margin: 8px 12px 8px 12px;
 }
 
 .jp-BreadCrumbs-item {
@@ -12830,18 +12515,57 @@ h6:hover .jp-InternalAnchorLink {
 
 .jp-FileBrowser-toolbar.jp-Toolbar {
   padding: 0px;
+  margin: 8px 12px 0px 12px;
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar {
-  justify-content: space-evenly;
+  justify-content: flex-start;
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item {
-  flex: 1;
+  flex: 0 0 auto;
+  padding-left: 0px;
+  padding-right: 2px;
 }
 
 .jp-FileBrowser-toolbar.jp-Toolbar .jp-ToolbarButtonComponent {
-  width: 100%;
+  width: 40px;
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar
+  .jp-Toolbar-item:first-child
+  .jp-ToolbarButtonComponent {
+  width: 72px;
+  background: var(--jp-brand-color1);
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar
+  .jp-Toolbar-item:first-child
+  .jp-ToolbarButtonComponent
+  .jp-icon3 {
+  fill: white;
+}
+
+/*-----------------------------------------------------------------------------
+| Other styles
+|----------------------------------------------------------------------------*/
+
+.jp-FileDialog.jp-mod-conflict input {
+  color: red;
+}
+
+.jp-FileDialog .jp-new-name-title {
+  margin-top: 12px;
+}
+
+.jp-LastModified-hidden {
+  display: none;
+}
+
+.jp-FileBrowser-filterBox {
+  padding: 0px;
+  flex: 0 0 auto;
+  margin: 8px 12px 0px 12px;
 }
 
 /*-----------------------------------------------------------------------------
@@ -12885,6 +12609,19 @@ h6:hover .jp-InternalAnchorLink {
   text-align: right;
 }
 
+.jp-id-narrow {
+  display: none;
+  flex: 0 0 5px;
+  padding: 4px 4px;
+  border-left: var(--jp-border-width) solid var(--jp-border-color2);
+  text-align: right;
+  color: var(--jp-border-color2);
+}
+
+.jp-DirListing-narrow .jp-id-narrow {
+  display: block;
+}
+
 .jp-DirListing-narrow .jp-id-modified,
 .jp-DirListing-narrow .jp-DirListing-itemModified {
   display: none;
@@ -12904,6 +12641,12 @@ h6:hover .jp-InternalAnchorLink {
   background-color: var(--jp-layout-color1);
 }
 
+.jp-DirListing-content mark {
+  color: var(--jp-ui-font-color0);
+  background-color: transparent;
+  font-weight: bold;
+}
+
 /* Style the directory listing content when a user drops a file to upload */
 .jp-DirListing.jp-mod-native-drop .jp-DirListing-content {
   outline: 5px dashed rgba(128, 128, 128, 0.5);
@@ -12919,6 +12662,10 @@ h6:hover .jp-InternalAnchorLink {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+.jp-DirListing-item[data-is-dot] {
+  opacity: 75%;
 }
 
 .jp-DirListing-item.jp-mod-selected {
@@ -12993,21 +12740,6 @@ h6:hover .jp-InternalAnchorLink {
   min-height: 120px;
   outline: none;
 }
-
-.jp-FileDialog.jp-mod-conflict input {
-  color: red;
-}
-
-.jp-FileDialog .jp-new-name-title {
-  margin-top: 12px;
-}
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -13167,8 +12899,12 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   flex: 1 1 auto;
 }
 
-.jp-OutputArea-executeResult.jp-RenderedText {
+/* Text output with the Out[] prompt needs a top padding to match the
+ * alignment of the Out[] prompt itself.
+ */
+.jp-OutputArea-executeResult .jp-RenderedText.jp-OutputArea-output {
   padding-top: var(--jp-code-padding);
+  border-top: var(--jp-border-width) solid transparent;
 }
 
 /*-----------------------------------------------------------------------------
@@ -13219,13 +12955,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-LinkedOutputView .jp-OutputArea-output:only-child {
   height: 100%;
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -13287,10 +13016,12 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-InputArea {
   display: flex;
   flex-direction: row;
+  overflow: hidden;
 }
 
 .jp-InputArea-editor {
   flex: 1 1 auto;
+  overflow: hidden;
 }
 
 .jp-InputArea-editor {
@@ -13433,13 +13164,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   margin-top: 5px;
 }
 
-/* Text output with the Out[] prompt needs a top padding to match the
- * alignment of the Out[] prompt itself.
- */
-.jp-OutputArea-executeResult .jp-RenderedText.jp-OutputArea-output {
-  padding-top: var(--jp-code-padding);
-}
-
 .jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
   overflow-y: auto;
   max-height: 200px;
@@ -13478,13 +13202,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
 
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
@@ -13771,6 +13488,15 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   line-height: 1.4;
 }
 
+.jp-NotebookTools .jp-select-wrapper {
+  margin-top: 4px;
+  margin-bottom: 0px;
+}
+
+.jp-NotebookTools .jp-Collapse {
+  margin-top: 16px;
+}
+
 /*-----------------------------------------------------------------------------
 | Presentation Mode (.jp-mod-presentationMode)
 |----------------------------------------------------------------------------*/
@@ -13784,18 +13510,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-mod-presentationMode .jp-Notebook .jp-Cell .jp-OutputPrompt {
   flex: 0 0 110px;
 }
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-/* This file was auto-generated by ensurePackage() in @jupyterlab/buildutils */
-
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
 
 </style>
 
@@ -14067,7 +13781,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
   --jp-cell-prompt-width: 64px;
-  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
+  --jp-cell-prompt-font-family: var(--jp-code-font-family-default);
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1;
   --jp-cell-prompt-not-active-opacity: 0.5;
@@ -14168,7 +13882,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 180px;
+  --jp-sidebar-min-width: 250px;
 
   /* Search-related styles */
 
@@ -14213,8 +13927,6 @@ a.anchor-link {
   }
 }
 </style>
-
-
 
 <!-- Load mathjax -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML-full,Safe"> </script>
@@ -14302,20 +14014,43 @@ a.anchor-link {
 <h4 id="Data-files">Data files<a class="anchor-link" href="#Data-files">&#182;</a></h4><p>Now lets download the data files we will need, if we haven't already</p>
 
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[2]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">base_url</span> <span class="o">=</span> <span class="s1">&#39;https://slac.stanford.edu/~echarles/qp_example&#39;</span>
-<span class="k">if</span> <span class="ow">not</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">exists</span><span class="p">(</span><span class="s1">&#39;qp_test_ensemble.hdf5&#39;</span><span class="p">):</span>
-    <span class="n">os</span><span class="o">.</span><span class="n">system</span><span class="p">(</span><span class="s1">&#39;curl -o </span><span class="si">%s</span><span class="s1"> -OL </span><span class="si">%s</span><span class="s1">/</span><span class="si">%s</span><span class="s1">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="s1">&#39;qp_test_ensemble.hdf5&#39;</span><span class="p">,</span> <span class="n">base_url</span><span class="p">,</span> <span class="s1">&#39;qp_test_ensemble.hdf5&#39;</span><span class="p">))</span>
+<span class="k">if</span> <span class="ow">not</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">exists</span><span class="p">(</span><span class="s1">&#39;qp_test_ensemble.hf5&#39;</span><span class="p">):</span>
+    <span class="n">os</span><span class="o">.</span><span class="n">system</span><span class="p">(</span><span class="s1">&#39;curl -o </span><span class="si">%s</span><span class="s1"> -OL </span><span class="si">%s</span><span class="s1">/</span><span class="si">%s</span><span class="s1">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="s1">&#39;qp_test_ensemble.hf5&#39;</span><span class="p">,</span> <span class="n">base_url</span><span class="p">,</span> <span class="s1">&#39;qp_test_ensemble.hf5&#39;</span><span class="p">))</span>
 </pre></div>
 
      </div>
 </div>
 </div>
+</div>
+
+<div class="jp-Cell-outputWrapper">
+
+
+<div class="jp-OutputArea jp-Cell-outputArea">
+
+<div class="jp-OutputArea-child">
+
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 45.9M  100 45.9M    0     0  84.8M      0 --:--:-- --:--:-- --:--:-- 84.7M
+</pre>
+</div>
+</div>
+
+</div>
+
 </div>
 
 </div>
@@ -14330,7 +14065,7 @@ a.anchor-link {
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[3]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">ens</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">read</span><span class="p">(</span><span class="s1">&#39;qp_test_ensemble.hdf5&#39;</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">ens</span> <span class="o">=</span> <span class="n">qp</span><span class="o">.</span><span class="n">read</span><span class="p">(</span><span class="s1">&#39;qp_test_ensemble.hf5&#39;</span><span class="p">)</span>
 </pre></div>
 
      </div>
@@ -14375,7 +14110,7 @@ a.anchor-link {
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Ensemble =  &lt;qp.ensemble.Ensemble object at 0x7fcbf4acb2e0&gt;
+<pre>Ensemble =  &lt;qp.ensemble.Ensemble object at 0x7f37ec131550&gt;
 Rep      =  interp
 NPDF     =  20000
 Metadata =  {&#39;pdf_name&#39;: [&#39;interp&#39;], &#39;pdf_version&#39;: [0], &#39;xvals&#39;: array([[0.005, 0.015, 0.025, 0.035, 0.045, 0.055, 0.065, 0.075, 0.085,
@@ -14458,7 +14193,7 @@ Note that the first call to the <code>plot</code> specifies the x-axis limits, b
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABFUUlEQVR4nO3dd3ic1Znw/++ZGfUujSQXWV2ugG1ZmGabhDWBNDCLF0hIcwImvbwhm+R9s+X37mazEPJmQza7ic0Gkk1CIGzikGYW2CTgELBlYRvjpmLLlmyr9z4z5/fHMyPLqlOeZ4p0f67Ll6yZZ85zNJi5dc65z32U1hohhBAi2tgi3QEhhBBiOhKghBBCRCUJUEIIIaKSBCghhBBRyRHpDgghxHxw8ODBPIfD8RhwBfLLfyA8wFGXy3Xfhg0bWic+IQFKCCFM4HA4Hlu0aNGq3NzcLpvNJunRfvJ4PKqtrW31xYsXHwNum/icRHkhhDDHFbm5ub0SnAJjs9l0bm5uD8bI8/LnItAfIYSYj2wSnILjfd+mxCOZ4hNCiHlg3759yQ888EDRHXfc0VlWVjZaX18fX1ZWNrpjx46uyc91dHTYAR588MH2ia/dsmVL78aNGwc7OjrsP//5z7NeeeWV2on3ePzxx7OysrJcdXV1Cb7XWkkClBBCzAObNm0aLCwsHLn11lv7Nm3aNAiQnp6+7t3vfnfvdM898sgjzkceecT54IMPtvuev/fee7t8z+fk5Lgntv/4449nAWzbtq3vkUceSdizZ0/atm3b+qz8mSRACSGEyb7wzOFlpy72JZvZ5vJFaYNf3772nFntfehDH+pav379qulGQvv27Uu+5pprBiY+tn///uR77723C6C8vHykuro6WQKUEEIIv7366qvJ7e3t9rq6uoRvfetbjU6n0z3ddU6n093U1JQw8bG9e/emvfrqq8lwafrPp6en57J40dHRYXn8kAAlhBAmM3OkE6hrr7120DtNN+vopr293V5QUDAy8bFbb721b+XKlSO/+tWv0idfn5GR4Wpvb7eb3N1ZSRafEEIsQE888UTWZz7zmYuTH3c6ne4dO3Z0TX5848aNg11dXQ6Aurq6hFtuuaXX6j5KgBJCiHlg3759yWfPnk348Y9/nDV5pON7bu/evWl79uxJe+SRR5xweRaf77XHjh2Ln679HTt2dNXX18fv2bMnrbu72271+hOAkvOghBAidIcPHz6zdu1ay1Ov56vDhw87165dWzzxMRlBCSGEiEoSoIQQQkQlCVBCCCGikgQoIYQQUUkClBBCiKgkAUoIIURUkkoSQggxD4Srmvnu3budkx+3igQoIYSYB6yuZg7GZt3du3c7w/UzSYASQgiz7fnEMlqPmVrNnLzVg2z7TsSqmUeCBCghhJhHrKpmHgkSoIQQwmwmjnQCZVU180iQLD4hhFiAAq1mHgkSoIQQYh6wupo5wJ49e9KOHj2a4jv+3WpSzVwIIUwg1cxDI9XMhRBCxAwJUEIIIaKSBCghhBBRSQKUEEKIqCQBSgghRFSKuY26TqdTFxcXR7obQghxmYcffphjx44VRbofMxkZGXGtX7/+cKT7EYiYC1DFxcVUV1dHuhtCCHGZ48ePs2rVqojdv6amhvvvv5+7776b0tJSGhoaKC0tZfv27dTU1HDvvffa7rzzznyzq5nv2bMnDeC5555L//d///dm33VZWVmuurq6BN89pntsLjLFJ4QQ80BlZSWlpaVs3bqV7du389d//dfcf//9dHd3U1lZSUFBgb711lv7duzY0eULEL4NuxOrmfuev//++6cEkckVJvbt25dcXV2dvG3btr7Dhw8nHzt2LN63iXfbtm19YASw6R7z52eKuRGUEEJEu4f2P8SJzhOmtrkyeyVf3PhF09ozo5r5pk2bBjdt2jTY3t5uLy4uHl29evXot7/97dx77723C6C8vHykuro6uaOjwzH5MV+wmo0EKCGEmEeqq6vp7OykoaGB3bt3k5mZOe11ZlYz37dvX3JpaekwQE9Pz2VxpaOjwzHdY/60KwFKCCFMZuZIJ1BVVVVUVlbOeZ2Z1cy3bdvW9/TTT2c//vjjWRkZGa7JtQCne8wfEqCEEGIBMqOa+cc+9rGlZWVlIw8++GB7RkaGq6Ojw75x48bBrq4uB0BdXV3CLbfc0tvV1eWY/Jg/7UuAEkKIeaCmpoaGhgaeeuopSktLL5vaq6mpoampSe3duzfNd5ghTF/NPDs727V69erR6e4xsZr5jh07uj71qU+1nTp1KmHPnj1pPT09jgcffLAZ4Ctf+Ur+nj170rq7u+2+tabpHptLzFUzr6qq0pJmLoSINpFOM5/L0aNHB6+44orjke7HTKSa+Swu9F/gR8d+xLBrONJdEUIIgUzx0THUwWNvPMZTJ59izDNGanwq28q3RbpbQgix4C3YEVTvaC+P1jzK23/+dp488SS3ld1GWnwah1oPRbprQogYFWtLJtHC4/EowDP58QU3ghpyDfGT4z/h+0e/T+9oL7cW38on1n2C4oxi2obaqGmtiXQXhRAxKDExkY6ODnJyclBKRbo7McPj8ai2trYM4Ojk5xZcgLrvufs40n6EzUs38+nKT7Mye+X4c+vz1vNS00t0DXeRlZgVwV4KIWJNQUEBTU1NtLW1Rbor07p48aLD7XY7I92PaXiAoy6X677JTyyoANU93M2R9iN8dO1H+cS6T0x5fn3eegAOtR7irYVvDXf3hBAxLC4ujpKSkkh3Y0arV69+Q2tdFel+BGJBrUGd6DJqY/kC0WRrctbgsDl4ve31cHZLCCHENBZUgDrZeRLgsmm9iRIdiazJWcPrLbEVoNweTc1ZvzZ+CyFEzFhQAep453HykvPITsye8Zr1eet5s+NNRtwjM14TbZ7cf5a//LdXeLk2Oue+hRAiGAsqQJ3sPMmq7Nl3eq/PW8+YZ4w3298MU69Ct+f1ZgB2vdQQ4Z4IIYR5FkyAGnYNc7rn9IzTez7r8tYB8HprbEzznescpLqxi2XZSbxc286b53si3SUhhDDFgglQtV21uLV7zgCVnZhNcXpxzASoXx05D8B337eBlHg7u2UUJYSYJ8IeoJRS25VSz8/w3ENW3deXwTdXgAJjmu9Q2yE8esrG5qjz7KHzbCjKYs2SDO7ZWMivjlyguXso0t0SQoiQhT1Aaa2fme5xpdRWoNSq+57oOEFaXBpLU5fOee36vPX0jPRwuue0Vd0xxYmLvZy42Mft65YAsOOGYgAe3xfd/RZCCH9ExRSfUqoUsHRu6kTXCVZkr/CrBEllvnEaZbRP8z176Dx2m+IdVy4GoCArmXddtZgn95+lZ2gswr0TQojQREWAAkq11jMGKKXUTqVUtVKqOpgyIm6Pm9quWr+m9wAK0wrJTsyO6gClteaXh86zqdyJMzVh/PGdW0oZGHXzk9fORrB3QggRuogHKKXUVq31C7Ndo7XepbWu0lpX5ebmBnyPxt5GhlxDfgcopRTr89ZHdYCqOdtFc/fQ+PSez5olGWwqd/L4n04z4nJHqHdCCBG6iAcooFMptVUptR0oVUpVmn2DE53+J0j4rM9bz7m+c7QPtZvdHVP88tB5Ehw23rZm0ZTndm4ppbVvhGcPnY9Az4QQwhyRyOLbClR5AxJa6xrvCCobyLTinic6TxBni6M00/8cDF+9vmgcRY25PfzmyAW2rsonNWFqvd/NFU5WLU5n98sNcj6NECJmRSKL7wWtddbkbD7vNF6Z1tr0A5lOdJ6gPLOcOFuc369Zlb2KBHsCNS3Rdz7Un+ra6RgYnTK956OUYueWEk619POHk1L+SAgRm6Jhis9SWmtOdJ5gVc7sJY4mi7PHcaXzyqg8YffZQ+dJT3Rw44qZ1+PeddUSFmck8r2X6sPYMyGEMM+8D1Atgy10jXSxImtFwK9dn7ee453HGRwbtKBnwRkadfPcmxd5x5WLSXDYZ7wuzm7jwzeU8GpDJ0eausPXQSGEMMm8D1C+IzYCHUGBEaDc2s3R9iknEUfMiydaGBh1c9sM03sT3bNxGWkJDikiK4SISfM+QB3vPI5CsTxrecCvXZu3FoWipjV61qF+eeg8+ekJXFOSM+e1aYlxvPOqxbxc2y7JEkKImDPvA9TJzpMUpheSEpcS8GvT49MpzyqPmky+nsEx/nCylXdftQS7be6KGAArF6XRMzRGW3/snG8lhBCwAALU8c7jAe1/mmx97noOtx3G7Yn8ptffHb3AmFtz+7q56wn6VOSnAVDX0m9Vt4QQwhLzOkD1jvbS3N8cWoDKX8/A2AC13bUm9iw4vzx0nlJnClcsTff7NRV5qQDUtkqAEkLElnkdoHwJEiEFqCjZsNs3PMarpzt451WL/Sp465OblkB6ooPa1j4LeyeEEOab1wEqmBJHky1JWUJech6vt0Q2QNW29qM1XFWQGdDrlFJU5KdRK1N8QogYM+8DlDPJiTPJGXQb44Vj2yIboHxrSMvzUwN+bUVeKnUyxSeEiDHzPkCFMnryWZOzhosDF+kZ6TGhV8E51dJHgsNGQVZywK8tz0ulY2CUDsnkE0LEkHkboEbdozR0N5gSoIrSiwA42xu5M5ZqW/spz0v1O718onJvooSMooQQsWTeBqi67jpc2mVqgGrsawy5rWDVtfaPZ+QFypdqLpl8QohYMm8DlC9BYlV24CWOJluWtgyForE3MgGqf8RFc/fQeKAJ1JKMRFLi7TKCEkLElKmHCc0TJzpPkBKXQkFaQchtxdvjWZK6JGIByhdYgh1BKaUoDyRRoq8FfrET4lIgfYn3z1LIWOr9ewE44oPqixBC+GteB6gVWSuwKXMGiUXpRRELULUtxh6mYEdQAOV5aeyr8/NsqFN7oeEP4FwOjftgeFJySHYZfOogBLAfSwghAjUvA5RHezjZeZLby283rc3CtEKOtB1Bax3QRlkz1Lb2E++wUZgdeAafT0V+Kv9V00TP0BgZSXMc3Nh0AJKy4BP7jSA00g99F6C3GY79Eqq/D11nILsk6P4IIcRc5uUa1Lm+cwy6Bk1Zf/Ipziimf6yfjuEO09r0V21LH2W5wWXw+VQEksnXdAAKrr40QkpIBWcFlL4FNnzIeKz5YNB9EUIIf4Q9QCmltiulnp/wfaZSqtL7+ENm3ON453EgtAoSkxWmFQKRSTU/1dIf1AbdiSryvEVj5yp5NNQNbSeMADWdvNXgSJIAJYSwXNgDlNb6mUkP3QVU+R5XSu0M9R4nO0/iUA7KMstCbWpccXoxQNjXoQZ8GXxBJkj4LM1KIjHONnfJo/Pes69mClD2OFi8VgKUEMJyEZ/i01rv0lrv8n5bCoR8/OvpntMsS19GvN28TLPFqYtxKEfYA1R9mxFQyvOCT5AAsNsUZbmpc++FaqoGFCytnPmapRvgwmFwj4XUJyGEmE3EA5SPUqoU6NRavzDNczuVUtVKqeq2trkz0Zr7m1mWtszU/jlsDgrSCsIeoE6FUINvMr9Szc/th9yVkJgx8zUFG8A1DC1vhtwnIYSYSdQEKGC71vqB6Z7wjrKqtNZVubm5szaitaapr4mlqf4f6uevovSisFeTqG3tI94eWgafT0VeKs3dQwyMuKa/QGsjQWLZDNN7Pks3GF+bq0PukxBCzCQqApRSarvW+mHv32eZW5pbz0gP/WP9FKSGvkF3sqL0Is72nsWjPaa3PZPaln5Kc1Nw2EP/T1U+nigxwyiqox6Gu2def/LJLIJkJzTXhNwnIYSYSSSy+LYCVUqp7RO+f0gpdVApdRDIDqX95v5mAFMqSExWlF7EiHuE1sFW09ueSW1rX0gbdCeqyJ8j1bxpv/F1rgCllDGKkkQJIYSFwr5R17vGlDXpe9PS7c71nwOwbIoP4EzvGRalLDK9/ckGR100dQ1x1wZz1tOKspOJs6uZEyWaDkBCOjhXzN3Y0g1Q+98w3AuJ/h9BL4QQ/oqKKT4zNfU1AdaNoCB8e6HqWwfQ+tLIJ1QOu41SZ+rMe6GaDhiBx+bHP4uCDYCG85E9yFEIMX/NuwDV3N9MdmI2KXEppredl5xHoj2RM71nTG97OrXeQBJqivlE5fkzpJqPDhhZeXNN7/ks8S4VSqKEEMIisRugPG5o/LOReTaBVRl8ADZlY1n6srCNoE619BNnVxTnhJ7B51ORl8rZzkGGx9yXP9FcA9rjf4BKzjaKxkqihBDCIrEboE7/ER6/FU7+9rKHm/qaLMng8ylOLw7bXqi61j5KnammZPD5VOSlofWlDcDjmg4YXwuq/G9s6QZjY++kXxKEEMIMsRughnuNr699d/whl8fFxYGLlqw/+RSmFdLU14TLM8NeIhOdauk3bf3JZ8ZMvqZqY0SUHEASZUEV9F+E3vMm9lAIIQyxG6B8ZXZOvwQtxwBoGWzBpV2WTfGBkSjh0i7O91v7oTw06uZc1+B4kVezFOekYLepy2vyjW/Q3RhYY7JhVwhhodgNUJ4JdeD2fw+wNoPPpzijGMDyRIn6tn5TM/h84h02inKSLx9BdTfCQGtg03sA+VeALU72QwkhLBG7Aco9anwt3wqHn4LBTks36fqE69gNXwafGTX4JqvISx1vH/AWiAUKAhxBxSXCoislUUIIYYkYDlDeEdR1nwTXELz+I5r6mrArO/nJ+ZbdNjsxm7S4NMsTJWq9GXxFOeany1fkpXGmY5BRl7dkU9MBiEs2znoK1NINxl4oj3vua4UQIgAxHKC8I6gl66BoE+zfTVPfORanLMZhs65AhlKKwvRCywPUqZZ+SpwpxJmYwedTkZ+K26M50zFgPHBuv7GvyR7E+1ZQBaP90HbS3E4KIRa8GA5Q3hGUPR6ueQB6ztLc9iZL06xLkPApSi/ibJ+1U3x1rX2mJ0j4lHsPP6xt6YexIbh4JPD1J5/xRAlZhxJCmGt+BKgV74CMZTT1N1u6B8qnKL2I8/3nGXGPWNL+8Jibxs7B8UBitrLcVJTyrnNdOAIeV+AZfD7ZZcbZUZLJJ4QwWQwHKO8Un80BdgeDGz5Ip/JQoMw7RXcmRelFaPR41qDZfBl8y02qYj5ZYpydwuxko+SRb4Pu0iBHUDabMT0oIyghhMliO0DZ4oyjH4CmircAUNB8xPJbT6xqbgXfHiWzU8wnqshLpa6l3zhiI7MQ0kJILCmoMvaijQ6a10EhxIIXuwHK4zKm97yaxoy06YKGfTDYaemtC9OtTTWvbe3DYVMUW5DB51Oel8bp9gF00wH/6+/NZOkG0G64cNiczgkhBLEcoNyjYI8b/3Z8D9TwALz+n5beOj0+nezEbMsy+Wpb+il2phDvsO4/T0VeKtnuNlTv+cD3P00miRJCCAvEeICaMILqayIlLoWMwuth/25wW1srryi9yLoA1dpPhUUJEj4V+amss9Ub34Q6gkrNg4xCSZQQQpgqhgPU2GUjqKZ+o4q52vgA9JyDU7+z9PaFadbshRoec9PYMWDaMe8zKctNpdJWi0vFG9UgQrVUEiWEEOYKe4BSSm1XSj0/zWNblVI7/W5oUoBq7ms2Shx5U87Zv8u8Tk+jOKOYtqE2BsfMTQxoaBvAo7F8BJWS4OCauHqaEivAYULmY0EVdJ+F/rbQ2xJCCCIQoLTWz0z8Xim13fv4C97vt/rV0IQpPq01zf3NRhVzuwPW3GEcZugem6OR4Plq8pk9irpUg8/aERQeDys5zVFVbk57sg4lhDBZNEzxXQ00eP/eAFT69Sr32HiAah9qZ9g9fKlI7KIrjWrn7bWmd9bHl2re2GdygGrpx25TFDvNO0V3Wr3NJOgRjgwvMqe9xWtB2WUdSghhmmgIUJmTvs+ZfIFSaqdSqlopVd3W5p1C8owZm3SZkMHnqyLhK3ra8qYV/QUupZo39pg/girKSSbBYTe13Sk66gB4Y9hJ/4gJCSXxKeBcDhePht6WEEIQHQGqG5j1GFet9S6tdZXWuio3N9d4cMIU37m+cwCX6vA5lxvBq9W6AJXkSCI/Od/0mny1LdZn8AHQaWTwNXgW0+grGhsqZ/l4u0IIEapoCFAHuDSKKgWen/nSCSZM8TX1GyWHxk/SdcQbQcp70q5VitKLTK0mMTzm5kzHgPXrTwAd9XgcSbSQRWOHSYke2WXQedryFH8hxMIQiSy+rUDVhOSIZ4BS7+OZvmSJOU3YqNvc10xech4J9oRLz+ettnSKD7xVzU2sJjGewReWAFWHzikH1KVjN0KVU25MvfacM6c9IcSCFoksvhe01lkTs/m01g97H3/Y74YmpJn79kBdJn8N9DbBULcp/Z5OUXoR3SPd9Iz0mNKelafoTtFRjz2nDGdqAo3tJo2gcsrH2xZCiFBFwxRfcCZO8fU1TT3mPX+N8bX1uGVdGM/kMynV3JfBV+K0rgYfYLx3XWcgp5zinGQTR1BlxldvAoYQQoQihgOUMcU36h6ldbB16gjKl8lnYaLEeCafSQHqVEsfxeHI4OtqNIq75pRTlJNi3hpUSi4kpEuihBDCFLEdoGxxnO8/j0ZPPUk3owASMixdh1qWugybspk3gmrtD1OChHeE4x1BXewdZmjUHXq7SkF2qYyghBCmiN0A5T1uw5fBN2UEpRTkr7Y0ky/OHseSlCWmZPKN1+ALY4o5OWUUeacTz3aauA4la1BCCBPEboDyTvE193k36U5egwJjmq/1GGhtWTeKM4pNGUHVt/WHNYOPpCxIzqY4x6hYYWomX/dZcI2Y054QYsGK8QBljKDibfE4k5xTr8lfAyO9lqY9l2SUcKbnDB7tCakd3ym6YZvi82bcFWUbIyjTNuvmlAHa2A8lhBAhiOEA5QJ7HE19TSxNW4pNTfOj+DL5LJzmK8koYdg9zMWBiyG14ztF1/IMPjCm4LwBKiM5jqzkOM6YlSjhy+STRAkhRIhiOEB5p/h8Vcynk7fK+GphJl9JegkAp3tCGzGcCsMpugCMDkJv86VAAhTmpJg3gsqWVHMhhDliM0BpDZ4xtC2Oc33npiZI+CRmGCe9WjyCgtADVG1LX3g26HZ6C8dnXwpQxTnJ5qWaJ2VCslMClBAiZLEZoLznPPUqTf9Y//QJEj751pY8yk7MJj0+PaQANTzmprFzkPK88KaY+xTlpHC+e4gRlwmp5r62Oxrmvk4IIWYRmwHKYwSoJs8wME2K+UR5q6GjFlyjlnRFKUVJRgmne4MPUHWt/WgdrhJH3gCVXTr+UHFOMh4NTV1D5twjp0xGUEKIkMVmgHIbwabJbXygzj6CWmPsmWo/aVl3SjJKQhpBhe0UXTCm+NKWQMKlYFiUY0EmX/9FGOkzpz0hxIIUowHKO4JyGanZMyZJQNgy+dqH2ukd7Q3q9bUt/ThsiuKccGTw1V2WIAFc2gtldtHYTpnmE0IEL0YDlDGCanYNkJmQSWr8LFNjOeVgiwtLJt+ZnjNBvf5USz8l4cjgg2kDVHZKPGkJDsnkE0JEFUegL1BKrcM4WLAU4zTcTqBBa33IzI7NyjeCGuuZff0JjCM5cleGLZPvqtyrAn59bWsfVyzJMLtbUw11wWDHZQkSYKyjFTmTzdsL5VvfkkQJIUQI/PqVXSlVrJT6rlLqOeABoAzoAZT37x9VSv23UurflVLFlvXWZ2KAmm39ySffW/LIIkvTluKwOYJahxoec3O2c5DycNTg8wWMSQEKjHUo08odxSdDeoGMoIQQIZlzBKWU+gKQDXxRaz3ryXxKqQxgp1KqS2v9mEl9nMo9ihu4MNrD22Zbf/LJWw1HnjJGEElZpncnzhZHYVphUAHqUgZfGFPMs8umPFWck8xzRy8y5vYQZzdhqjFHqpoLIUIz6yeRNzg9o7X+8lzBCUBr3aO1/jrwolLqQbM6OYVnjBaHHZf2+DmCCk+iRDBVzcN7im4dKBtkFU95qignBZdHc77brFTzcglQQoiQzBqgtNZf11oHPCzQWp/WWj8SfLfm4B6j2WEM/mbN4PMZP13X2gB1tu8sY949Wv461dJPnF1RHJYafHWQWQSO+ClPFWX7qpqbmMk33A2Dnea0J4RYcAKey7FijUkptV0ptVUptdOvF7hH6bUZXc9OzJ77+rTFkJhpaUWJkowSXB7X+PEf/qpt6aPEmWLOtNpcOuunXX8CxgOkZPIJIaJFMJ+KWUqp+3zfKKXuVErdFGwHlFJbMbIAXwAalFKVc77IPcqIUgDE26eOBqa5iTGKsjJABVk09lRLf3jOgNLaW8V86voTQF5aAolxNvP3QsnhhUKIIAUcoLTWrwPlvqCktf4v4G1KqY8E2Ydq4GfewFSqta6Z8xVu13iASrAn+HeX/DXQetyywwuLM4oBAip5NDTq5lzXYHhO0e1vgdH+GUdQShkbhU0bQWUVgbLLCEoIEbRgpvieAzRw0LsnCuBrwMPBdEBr3Q18D/gZsGGGe+5USlUrparb2trAPcpoICMoMDL5RvuM014tkBafRm5SbkAjqPq2CGTwzTCCAijKSabRrKPf7XFGkJJzoYQQQQpmiq8M+J43q095U8t3e/8EzDvF94LWugzoVkptn3yN1nqX1rpKa12Vm5t72RRfQCMosHwdKpAAdaolnBl83kAxwwgKoDgnhbMdg7g9Jo0yJZNPCBGCYALU24AvKqXSvdN9W4H9WusvBdmHygnTel/D2HM1O/fY+AjK7wAVjsMLvQFK+zmN6MvgKwpXDT57grGBdgZFOSmMuj1c7B02557ZZcbmYIumVYUQ81swa1ANWuuPaa17vd//F9ATQqLELu8U3lbgLq31rjlf4RkbH0HF2eL8u0tCmpFibfFeqN7RXjqGO/y6vralj1Jnangy+DrqjRJEtpnv5Ssa29huYlXzsQHou2hOe0KIBcWUT0at9W4gqPMmtNbd3im8F/wKTjA+xZdgi0d5A5Vf8tdYuheqOL0Y8L9o7KnWPsrDMb0H0xaJnazIm2pu6l4o372FECJApv3qHsyG3qB5p/j8TpDwyVsN7bXgGrGkW+NFY/3I5BscddHUNcTycJyi63FD1+lZ158AFqcnEu+wmXsuFEiAEkIEZc5SR8FszFVKlVha6sg9yogKYP3JJ38NaDe0WXN44aKURSTaE/1KlKhvHQjfKbo954wjSuYYQdlsisLsZPOKxqYXGOteksknhAjCnKWOgJuVUl/zJ1AppdKVUv8M3Gl1qaNRpUgIdARlcckjm7JRnFHsV4DyZfCFZZPueIr57CMoMNahGs2a4rPZvMe/S4ASQgRuzmrmWuvdSqkSjCM11gMNGOdA1QOZQI73a5n3sYctn+5zG0kS8fbEwF6XXWb8Rt9y1Jp+YVSUeKP9jTmvO9XaZ9Tg8yYmWMqPFHOfopwU9tW1o7UObH1vJtml0H4q9HaEEAuOXwcWegPOl8CYvuPSgYU9GMkRDd6U8/BwjzJis5HgCHCKz+4A53LLpvjAWIfae2YvI+6RWacga1v6KXWm4ghXBl9COqTkznlpcU4yw2MeWvtGyE8P8BeA6eSUw6nnjHUwmz309oQQC0bAJ+p6g9Vp4EXzu+MnzxijyhZ4kgRA7gpo2m9+n7xKMkrQaBp7G1metXzG62pb+1hbkGlZPy7TUWeMZPwYEfn2ZDV2DJoXoDxjRgWP7JLQ2xNCLBhB/fqulLrPuy51n1Iq3exOzck9xqjNFniSBBjHv3efhVGTEgEmmXj8+0wGR12c6xwKT4kj8KaYzz29B0Y1CcC8RInxTD5ZhxJCBCaYWnzfBcoxjnu/CzgdQqHY4LhHQxtBgWXrIoXphSjUrAGqrrUfCFMGn2vEyOLzM0AtyUzEYVMmppp77yuZfEKIAAUzgnpea/0l75+3YSRHVCil/tLkvs3MPcqITZFgC3IEBZatQyU5kliSumTWAHWqxQhQYcng6zoD2uN3gHLYbSzLTjZvs25KrrH+JXuhhBABCnmF3lsJ4ksY2Xzh4T1uI6gpvuwSsMVB2wnz++U1V6p59ZlO0hId49NplhpPMS/1+yVFOcnmjaCUMta/ZIpPCBGgYAJUg1LqgFLqjknrT/4VoDOD97iNOLufdfgmsscZo4k261KfS9JLONN7Bo/2TPv8K/UdXFuag91mQhr3XHwBKnv2TboTFeek0Ng+6HfR2zlJVXMhRBCCCVB3A08D7wHOeIPVUxhp5wCEcsKuX9yjjBBEJQmf3BWWjqBKMkoYcg3ROtg65blznYOc7RzkhrIwDTg76iDZCUmZfr+kMDuZvhEXnQOj5vQhp9xYB7OoxJQQYn4KJkDVAz/TWt+ltc4GdmKcivs2pVSHUuoA8JCZnZzCPcZoMKWOfHJXGLXpxkw6VmISXyZfQ0/DlOf+XG8MNK8vd1py7ynaTl1KDPFTsdPYPGxqJp/2GOthQgjhp2CO29gNZPlKH2mtX9daf11r/TatdQ7wANBlbjcn8YwxQgCn6U6Wu8L4wLRo2mm2VPNX6ttxpiaE55h3rY2RonPm/VjTqfAWsK31JnOEzJdq3l5rTntCiAUhqCQJb1A6M8NzNcAXQ+nUnPd3j4Q4gvJl8lkzzZeTmENaXNqUAKW15pX6Dq4vyzGnjNBcBtpguPvSz+unpZlJJMfbOXGxz5x++AJku3UVPIQQ848ldXasLns06h4DQhhB5ZSDslmWaq6UoiSjZMq5UPVt/bT2jXB9uNaffAE4wCk+m01RkZ82XtA2ZAlpRmVzC0tMCSHmnzAUgjPfiNtYvA96BOVIMFKfrU41n3Qu1Cu+9aeycK0/eQNCgCMogJVmBiiwPDFFCDH/xGSAGg01QIHxoW1x0djWwVYGxi4lGrxS10FBVhKF4ahgDkZASMiAtEUBv3T5ojTa+0dp7zcp8y5vlZGw4Zk+9V4IISaLigCllKpUSm1XSm335/oRT4hTfGD8Rt9ZDy6TUqkn8SVK+Kb5PB7Nnxs6wje9B0YAzl3uV5HYyVZ4q1ycMmsdKncFuIagu9Gc9oQQ815UBCjgy1rrZ4BspdScJQ98ASrkEZTHBZ1TU8HN4AtQdd1GpuCxC730DI2Fb3oPvAEqsPUnnxWLjAB10qxpPotLTAkh5p+IByil1E7ggFKqVGu9S2s9Z8QY1S7AhBEUWLYuUpRWRFpcGofbDgNGejkQvhHUYCcMtAa1/gTgTI0nOyXevHUoXyZf23Fz2hNCzHsRD1AYxWZzgE6l1PeUUpmTL1BK7VRKVSulqtva2hjxGAEqpBFUTgWgLPuN3m6zszZvLTUtNYCRIFGel0qeGWcs+SOEBAkwMhGX56eal2qelAlpS2QEJYTwWzQEKIB6rXU3cBCjMsVlvCOrKq11VW5uLqNmTPHFJ0NWkaWZZZV5ldT31NM60Mn+051hXn/y/lwBbtKdaEV+Gqcu9plXk08y+YQQAYiGAHVgwt8zge65XjCi3UCIU3wAzhWW/kZfmV8JwLPH/8TgqDu860/tpyAuGTKWBd3EikXpDIy6ae4eMqdPvsxJyeQTQvgh4gHKmxyRqZTa6v1+11yvGfUYASqkERQYv9F31ILbFVo7M7jCeQVxtjh+37gfpeDa0mxL7jMtX4kjW/D/iVcsMsoxnTRrmi9vJYwNGoVjhRBiDhEPUABa64e11i9orR/25/pRs0ZQuSvBPWpZEdMEewJrctZQ2/sGa5akk5kcYn8D0XYy6PUnH9+BipLJJ4SIhKgIUIEaUcaaSOgjKGtr8gFc6VzHoDrDxtL0uS82y3Av9DYHnWLuk54Yx9LMJHP3QoFk8gkh/BJ7AUprRrwbT+NtoY6gfKnP1gWoNL0cpdwsyWuz7B5TtHsPYwwxQAEsz0/lpFlVzZOyIHWRjKCEEH6JvQCFZtQXoEKd4gtDEdO2DqPM0Ig9jEeeh5hiPtHyRWnUt/Yz5jYpsUEy+YQQfoq9AKU9jHgr94Q8xQeWf2AePD1KvGcJRzsPWXaPKdpOgD0BMotCbmpFfhqjbg+NZh1e6MvkMyt1XQgxb8VegDJzBAXGB2b7KfBmBpqpd3iMN5q6KUm9gsOth3FbcI9ptZ0EZwXYHSE3NV7y6KJJ03x5K2G0H3qazGlPCDFvxV6A8q5BxSk7NmVC93NXgGsYus+G3tYkrzV04tGwadnV9I31jdfls1wQp+jOpCw3FZuCkxd7TWlPMvmEEP6K2QCVoEIfHQCWfmC+Ut9OgsPGtpU3AFDTWmP6PaYYHTSCrQkJEgCJcXaKnSkWpJpLJp8QYnaxF6C8U3zxNrMClHWZfH+u7+Dq4myKMgrIT84fr8tnqY5aQJuSIOGzclEap8zK5EvOhpQ8aJVECSHE7GIvQPlGULY4c9qzKPW5qWuQExf7uK4sB6UUlXmV1LTWmFfXbiYmZvD5LM9P40zHAMNjJq2h5a6AdpniE0LMLvYClHcEZVqAAks+MB99sZZ4u43b1y0BjLp8rYOtnB84b+p9pmg7ATaHcaS9SVbkp6E11Jo1ipJMPiGEH2IvQHlHUPGmBihzPzDrWvt45mAT77u2iIIs43j39XnrAayf5ms7aQQnh3lllZabfnjhChjphV6Lg7UQIqbFbIBKMCPF3Cd3hZH63NtsSnOPPHeK5HgHn3hr2fhj5ZnlpMWl8Xrr66bcY0ZtJ0xLkPApzkkh3mEz7/DCvFXGV9mwK4SYRewFqPEkCTMDlHk1+Q6d62bvmxe5f3MpOamXNhL7DjC0NEC5RqDztKnrTwB2m6Iiz8TDC8NQA1EIEftiL0BZMoIyJ9Vca81DvztBTko8H9lcMuX5DfkbqOuuo3u4O6T7zKijHrTb9AAFlw4vNEWKE5JzJEAJIWYVewEKjzGCMqPMkU9KDiQ7Q/7AfLm2nT83dPCpm8pJTZiaBu9bhzrUdiik+8zI13+Tp/jAWIe62DtMz+CYOQ3mrpLNukKIWcVegPKNoBwmBii4lCgRJI9H8/BzJyjISuI91xROe43vAEPLNuy2nQRlg5xy05teYUWiRNsJyeQTQswo9gKUL83czBEUhPyB+dujFzja3Mv/unk5CQ77tNf4DjB8vcWidai2E0aB2Lgk05teYcXhhcM90HfRnPaEEPNO7AUorRlVEG9PNLfd3BXGB2Z/S8AvHXN7eOS5k6xclMbt65bOem1lfiVHO44y7BoOtqczaz9lyfoTwOKMRNISHeatQ+VJooQQYnZRFaCUUg/NeZFvH5TpU3zedZvWYwG/9Onqc5zpGOQLt6zAblOzXluZV4nL4+Jo+9Fgejkztwvaay1ZfwJQSrEiP02OfxdChE3UBCil1FbAj/IH3ik+h8kjqMVrja9NBwN62dCom2+9UEtVURY3rcyb8/p1eesAzE837zoNnjHLRlBgJEqcvNhnTrmmlFyjzJQUjRVCzCAqApRSqhRo8Ovi8RGUyessSVnGh/u51wJ62eOvnKa1b4Qvvn0lSs0+egLISMigPLPc/EQJCzP4fFbkp9EzNEZr30jojSklmXxCiFlFRYACSrXWMwYopdROpVS1Uqq6f6AfrRQJZgcogIKroekAePw73vy1hg7+5YVatq7K5+ribL9vU5lXyaHWQ7g8rmB7OpUvQJl0DtR0lvsSJUzbsLsCWo9LJp8QYloRD1BKqa1a6xdmu0ZrvUtrXaW1rkpONgKT6SMogGXXwHC398iK2Z1q6eP+H1azLCuJr2+/KqDbbC7YTP9YP787/bsgOzqNtlOQsQwSUs1rc5JLp+uamcnXDf2t5rQnhJhXIh6ggE6l1Fal1HagVClVOdvFHm2MbkxfgwIjQAGc2z/rZRd6hvjg9/eTGGfnBx/eSFZKYFUtthRsYUXWCr57+LvmjaIsqME3WXZKPLlpCebuhQLJ5BNCTCviAUprXeMdQWUDmXNf7w1QZu+DAmODa2LmrOtQPUNjfOj7B+gbdvH4jqvHq5UHwqZsfGzdxzjbd5bfNPwmhA57edyWpphPtCI/zYKisbIOJYSYKuIBysc7jVemtZ41e0BjrFfEm1mLz8dmg2UbjXWoaYy43Oz8YTUN7f18930bWLMkI+hb3bTsJlZlr+J7R77HmCfE8kHdZ8E1bPkICozTdU9e7DPn8MLUfEjMkBGUEGJaUROg/OXxLqhbMoICI0C1nYChrsvv69F8/unDvHa6k69vX8umCmdIt1FK8fF1H+dc3zl+Xf/rkNq6lCBhfYC6riyHEZeHmsauuS+ei1LeElMSoIQQU8VcgPJN8VkyggIo2Gh8nbQf6p9+e5xfH7nAl9++km3rZ68W4a8bC25kTc6a0EdRZ18FWxwsusKUfs3mmtIcHDbFS7Xt5jQoAUoIMYPYC1BYPIJausEouDphHeqJP53msX2n+dD1xezcYt5R6r5RVHN/M7+s+2XwDZ3ZZ/Q7PsW0vs0kNcFBZWEW++razGkw/woY7ICuRnPaE0LMGzEXoCyf4ktIhfw10GRk8r3a0ME//OY4W1fl8zfvWu3XZtxAbF66mSudV7LryC7G3EGMokb64PzrULzJ1H7NZnOFkzfP99I5MBp6Y75+n3k59LaEEPNKzAUoS5MkfJZdA03VXOjq55M/qaEoJ5lv3r12zjp7wfCNoi4MXOAXdb8IvIGzrxmHFIYxQG2qcKI1/KnOhGm+vFXGWVynXwq9LSHEvBKzAcqyERQYAWq0n6/9cA/DYx52vb+KtMQ4y253w5IbuCr3KnYd2cWoO8BRyZmXjfUn3x6uMLiqIJP0RAf7zFiHUgpKtsDpl6WihBDiMjEXoHxTfJaOoAquBiCt9SDfuGst5XnWVWcAYxT1iXWfoGWwhZ/X/jywF595GQqqID7w/VjBstsU15c5ebm2zZzCsSVboO+8cWS9EEJ4xVyACscI6ienbLTpDN67+AK3rFlk2X0mum7xdazPW8/uN3Yz4vazGOtwL5w/FNbpPZ9NFU7O9wzT0D4QemMlW4yvp/8YeltCiHkj9gKUxUkSBxu7+LtfvUlj8hWs9oSvwoFvFNU62MqTx5/070Xnwr/+5LOlIhfAnGm+7FJIL5B1KCHEZWIuQHm8I6g4m/lrQq19w3z8xwdZkpnEmo1bUZ0N0G9SOrUfNi7ayLWLr+UbB7/BJ1/8JLVdcxStPfMy2OMv7d0Ko8KcZAqzk3nZtHWozUa6vJ+V5IUQ81/MBSjfiofZa1Bjbg+f+HENvUMuvvf+DSSVXW88MUPZIysopXj0pkf5TOVnqGmp4c5n7+Qr+77Chf4L07/gzD5YGt71p4k2VTh5taGDMbcJQaVkCwy2ywGGQohxjkh3IFBaaxyAw2Zu17/z+zoOnOni0fesZ+WidBhbZ2THnXsNVr7D1HvNJsmRxH1X3sf2iu38x9H/4CfHf8LvTv+O9656L/ddeR8ZCd76f771p82fB8DtcdM72kvXcBedw510jXSN/12jyU3KJS85j9ykXHKTc8lKyMJus4fU183lTn7y2lkOnesO6DysaRVvNr6efsnYhyaEWPBiLkB5gHiTB35vnu/hX/+njm3rlnDb2iXGg3GJxjHwYRxBTZSZmMnnqz7Pe1e+l+8c+g4/ePMHPHPqGZamLmXEPcLoSA+jBYsYufBLxn60hxH3yHgCiT/syk5OUg7XLr6Wu1fczZXOKwPehHx9mRObgpdr20MPUJnLjLWo0y/BtR8LrS0hxLwQcwFKo0lQ5gWoUZeHB392hMzkeP7u3ZN+c1+2Eaq/D+4xsFu3D2o2i1MX84+b/pEPrPkAP3jzB/SN9hFvjyeh5Rhxw80krH4P8XHJJNgTyErMIishi8zETLITs8lKyCIrMQuFon2onbahNloHW2kbaqNtsI3m/mZeaHyBZ+ufZVX2Ku5ZeQ9vL3k7SX4eBpmRHMdVBZnsq23jf91swkm+JVvg6C+M40NCHN0JIWJfDAYoiMe8D6/v/L6O4xd62fX+DVMPHly2EV79N7h4xKh1F0HLs5bz1U1fvfTArrdC0nK47m/8ev3i1MUsTl085fGBsQF+Xf9rfnryp/zdK3/HI9WPcHvZ7dy94m6KM4rnbHdzhZN/+0M9vcNjpIe6mbl4Mxx8Ai4chqWznlsphFgAYi5JwoMmQZkToN4838N3fl/H7euW8Lbp9jv5suPORWaab0bDvXDhkJH5FqKUuBTuXnk3P7/t5zxx6xNsWrKJn578KbftuY3vHPoObs/s5z5tKnfi9mj+XN8Rcl9kP5QQYqKYC1AaiDdh+mfi1N7fT57a88lYauzPmeWE3Yg4+2fQHlP3Pyml2JC/gYdvfJjntz/PbWW38d3D3+XjL36cruGZz35aX5hFSrydl2tNSMdPzYPcVUbZIyHEgheTAcqMEZRvau+f7rhi6tTeRMs2wrn9Id/PVOP7n662pHlnkpN/uOEf+Pvr/p7qi9Xc9eu7eKPtjWmvjXfYuLY0x5wNu2CMos6+Ci4TKqULIWJaxAOUUipTKVWplNqulHporuuNABXa0plvam/bTFN7Ey3bCL1N0NMc0j1NdWafEZzi/EtmCIZSijuX38kP3/FD7MrOB/Z+gJ+e+Om0tfc2VTg50zHIuc7B0G9cshnGBuB8TehtCSFiWsQDFHAXUKW1fgZAKbVztos9QHwIe6B8U3tZKfH8/W1+7LdZ5jthN0pGUcM9RhJBcejrT/5Yk7OGp971FNctvo6vvvZVvrzvywyOXR6INlc4AdhnxvEbRTcASsoeCSEiH6C01ru01ru835YCDbNeDySEUObo0tTelWQm+1GNIv9KcCRGT6JEo/nrT3PJSMjgX//iX/nkuk/y24bf8v7fvZ+OoUtJEWW5qSzOSDRnmi85GxZfJQFKCBH5AOWjlCoFOrXWL8x2nUdBfJAB6khTN9/5fR13rF/Kzavz/XuRIx6WVEZPosSZl8GeYNn600xsysYDax/g37b+G2d7z3L/8/ePJ08opdhU7mRfXTtuj0nHb5x7DcaGQm9LCBGzoiZAAdu11g9M94RSaqdSqlopVR3sCGpo1M3nnjpEblrCzFl7Mym81kjrDmPh2BmNrz8lRuT2m5Zu4tt/8W3O9p7lvv++j+7hbuPxCic9Q2Mcbe4J/SbFW8A9Gn3JKUKIsIqKAKWU2q61ftj79yk7NL3TgFVa6yqNCipAPbT3BPVtAzzyV2vJSA7w9WvvAY8LXv9hwPc11VC3sWnYhP1Pobh28bU8+tZHOdNzhvufv5+ekR5uKDfWoUxJNy+6DpRdpvmEWOAiHqCUUluBh5RSB5VSB4FZi7p5CLyS+Uun2njilTN8+IaS8Q/SgOSuMKadDnwf3K7AX28WC/Y/Bev6pdfz6E2PUt9dz/3/fT9xccNUFmbydHVT6NXNE9KMyh0SoIRY0CIeoLTWL2ity7TWG7x/Zl2D0gR2WGH34ChfeOYwFXmp/PWtK4Lv6MadRrr5qb3BtxGqM/uM9aelVZHrwwQ3LL2Bf3nrv1DbXcsDzz/Ajs2LONs5yC9qTEjJL9kCzQdhpC/0toQQMSniASpQWkGcn4Vbtdb8nz1H6egf5Zt3ryMxLoQNvsvfblSVOLA7+DZCdeZlI+09QutP09lSsIVvvuWbnOw6yU/OfoUrCuL59u9rQx9FlWw2Tgtu/LM5HRVCxJzYC1D4P4J69vB5fnPkAp+7eTlXLM0I7cZ2B1TtgIY/QNup0NoKRudpuHAkbPufAvGWZW/hGzd+gxMdJ1CLd3Ouu4uf1zSF1uiya4xqGWdkmk+IhSrmAhRAgn3uEcT57iG+sucoG4qy+OiNZebcuPKDxofmgcfMaS8QL30dHAlQ+YHw39sPNxXexNdv/DrnBk7hLPtPHv390dBGUXFJxlrbG89IurkQC1RMBqj4OUZQHo/mwZ8dxuPRfPOuddhtgR3EN6PUXFhzBxx+MrxrI+11xj2rPgLpU4/MiBZbi7by0JaHGHOcpjPt33nyQF1oDW7+PPRdiMwvBEKIiIvJAJXgmH0EtevlBl6p7+Bv372awpxkc29+9f0w0gtHnjK33dn88SGjmsWmz4bvnkG6pfgWvrb5aziSGvl/R75Iz3B/8I0Vb4Kym+Dl/2ccMSKEWFBiMkDFz3Li67OHz/PPvzvBO69czF1Vy8y/eUGVcRT8/sdgmsKppms9AW/8DDbebxxHEQPeUfoO3l/+JVzx9dz7q48y5Aphiu4v/haGOo2DI4UQC0pMBqiZRlCv1LXz+acPsbE4m2/ctRalTJram0gpI+W87Tg0/sn89if7w9cgPgWu/4z19zLRF254D3kjH6Rx4AifevHTDLuGg2toyXpYdRu88q8wYMKhiEKImDFvAtSx873s/M+DlDhT2P2BqtBSyudyxZ2QlAX7d819bSguHoVje+Caj0JKjrX3MplSir95y/sZunAnr118jc/+/rPBB6m3/h/jCI4/fdPcTgoholpMBqj4uMvXlZq6BvnQ4/tJTXDwxI6NgZcyClRcEqx/Hxz/NfSet+4+f/gaJKTD9Z+07h4WesvyXK5I30pi9z386fyf2LF3By0DLYE3lLcSrroH9u+29v0WQkSVmAxQCRPWoLoGRvnA9/czPObmBx/eyJJM6w7xu0zVR4yyQ9WPW9P++dfhxK/huk8Yo7UYpJTis1sraLuwljuXfoWGngbu+c09HG47HHhjb/kSeNxGur0QYkGIzQAVlwIYFco/8oMDNHUNsfsDVaxYlBa+TmSXQMXb4OAT1hxP/vuvQWImXPsx89sOoxuX57JuWSbPV+fy+C0/JNGeyI69O/hF7S8CayirCDZ8CGp+CJ2zHhkmhJgnYjJAxTuScbk9fOrJ13n9XDffunsd15RGYI1m404YaIXjz5rb7rkDUPsc3PBpSAyxAkaEKaX43M3Lae4e4vu/H+bH73iSDfkb+NtX/paH9j+EyxNA8d0tD4ItDv7wz9Z1WAgRNWIyQCXEJfOrI+d54XgLf/uu1bz9yghtXi27CXIqYO+XjDJEZvnDP0FyDmyc9nismHPj8lw+8xcVPHOwib/5eQPfest3eN+q9/Gj4z/io89/dPxMqTmlLYJrHoAjT0PLMUv7LISIvJgMUPHxKfzi9fMszUzig9cVR64jNhu850mjwvgT7zKnsGnjn6H+f+CGz0JCaujtRYnP3bycr7xzFb954wIf//EhPr3uQf7hhn+gprWGu359F3tP70X7s6/shs8Yx3H8/qvWd1oIEVExGaD6R+PZV9vG7euWYDOrjFGwnBXw4b1GGaT/vANqnw++rbOvwS8egJQ8uPo+8/oYJe7bXMo//+WV/PFUGx98fD9/UfBOfnDrD0iLT+MLL32B9/7mvRy4eGD2RpKz4fpPGwkktbOezCKEiHExGaBePNGNR8O29Usj3RVD5jLYsdcIVk/eYxQ4DYRrBJ7/O3j8VqM6xd0/gniTSzRFiXs2FvLoPeupaezi3sdeoyB5BU+/62n+8YZ/pG2ojQ8/92E++eInqeuapY7ftR8D53L4yV8ZySSRPERSCGEZ5de0ShRJKknSNz/4HGMuxe8+E2VHTwz3wJPvgcZX4J3fgKs/MvdrLhyBX3wUWt80KpXf8k/GFNY89+LxFj724xqKc5L50UeuIS89kWHXMD86/iP+443/YNA1yB3ld7Dzqp0sSV0ytYGRfvjtF+DwT6DwerhzN2QUhP8HESJGKKUOaq2j47RTP8VcgEouSdJ5dz/Dl9++kgfMOkbDTGND8LMPGSfv3vQVYy1pugMW3S7Y90344z8bCRG3fRuW3xLu3kbUK/Xt3PeDarJT4vnqHVdy4/JcALqGu9h1ZBc/PflTXB4XVzqv5Oaim9latJVlaZPqKx55Gn79ObA54PbvwKp3ReAnESL6SYAKg5TiJJ33nmd45Us3sTgjTJtyA+Uegz0fhzeeNr5PzIQUJ6TkGsEoJRcuHDI2415xJ7zjEWNtZQE6dK6bzz11iNPtA7z9ikV85V2rWerdbH2+/zy/Pf1bnm98nmMdRtbequxVbC3aytairZRmlBqNdNTDMx823tOr74O3fTWqTh0WIhpIgAq2E0ptB7qBUq31rAXuUouT9Lv+9//w053XhaVvQfN44Oh/GZtKB9qMP4MdMNAOg+3Gfp5bvgpX/GWkexpxIy43j718mm//Ty0KxSdvKue+zSUkOC7VU2zqa+LFsy/yfOPz45UoyjPLubnoZm4uupny1ELU//xf+PO/GutTV90NFTfDoquMAr9CLHASoILpgBGc0Fo/o5TaCTRorWdMz0orTtK7nz7JPRsLw9ZHER5NXYP846+Ps/fNi5Q4U/j/blvDFu+030QXBy7y4tkXeaHxBQ62HESjKU4v5uaim3mbLYMVrz2G8u1LS82H8q3Gn7K3xmzZKCFCJQEqmA4o9RDwlNa6Rim1FajUWj880/XpxUn63LFe6wvCioj546k2/v7ZNzndPkBBVtKsJyJ7bL2MJhxmNOEwrrhaUBrlTsehHSQwQqIeIYERbHgAhQsLq9wLEcWev//NmAtQjkh3AMic9P2UmkXekdVOgNxlqRKc5rkbl+ey97Ob+cErZzh2fq6TdDOBQuDdjOpe2jwH6badAi794uXGQ6KrlwxXO/E6hMMThRBhFQ0BqhuYNUPAuy61C6Cqqiryi2bCcgkOOzu3BJOleaPpfRFiPnjsgdhbi42GjboHuDSKKgVCKMUghBBivoh4gNJaPwOUetefMmdLkBBCCLFwRMMUHxOSIiQ4CSGEAKJgBCWEEEJMRwKUEEKIqCQBSgghRFSSACWEECIqSYASQggRlSJe6ihQSqk+4GSk+xElnEB7pDsRJeS9uETei0vkvbhkhdY6pg6bi4o08wCdjLV6UlZRSlXLe2GQ9+ISeS8ukffiEqVUdaT7ECiZ4hNCCBGVJEAJIYSISrEYoGY90HCBkffiEnkvLpH34hJ5Ly6Jufci5pIkhBBCLAyxOIISQgixAER1gFJKbVdKbfUeWBjw8/OJn+/FgjiqZLb3QimVqZSq9F7zUCT6F05+/LvY6v2z4N+LCdct+PdCKdWllHpeKfXX4e5bIKI2QCmltgP4jt/wHsfh9/PziT8/q/fYknnPj/fiLqDK937M519e/Ph/pBKo9D5fqZQqDX8vw8PfzwPv4/P2fQC/34u/0lrfPOEkiagUtQEKuBpo8P69AagM8Pn5ZCH9rHOZ9b3QWu/ynsAMxgdRA/PXXO9Fjdb6YaVUJtCgtV6w7wWAN0DP5/fAx5/Pi8xY+IUlmgNU5qTvcwJ8fj7JnPT9fP5Z55I56ftp3wvv/3yd8/wAzMxJ38/076IKqLe2KxGXOen76d6L0nkepH0yJ30/3XuRDXQqpb5nfXeCF80BqhvjTQz2+fmkm4Xzs86lG//ei+1a6wcs7kukdePHe+EN0mW+qZ95qptZ3gul1NZ5/svKRN3M8e/CO9PQDXRH87+LaA5QB7j0m0ApMDkBYK7n55OF9LPOZc73Qim13Te37l2Hma9mfS+UUg9NWIPrZn7/kjPXv4tOb9LAdqB0gf+72BkrP3/UBijvInepd4Evc8KC3/OzPT8fzfVeeP++FaiK5t+GzDDXe+F9/CGl1EGl1EHm8YeyH/8uvgc0THg+5jZq+suPz4sa72PZTJ0Cm1f8+HfxtPf77ROuj0qyUVcIIURUitoRlBBCiIVNApQQQoioJAFKCCFEVJIAJYQQIipJgBJCCBGVJEAJIYSIShKghBBCRCUJUEIIIaKSBCghhBBRSQKUECZQSpUqpeonlFya1+cvCREOEqCEMMcXgZuBGu+JrVUL5GgHISwjtfiEMIFSKlNr3e09HLBqPhcvFiJcJEAJYRLfEQZa65pI90WI+UCm+IQwgffoggZfcJrvx54IEQ4SoIQIkfdQwFJgt1Iq07sG1R3ZXgkR+yRACRECb6Zeg/cE3wbgNFAva1BChE7WoIQQQkQlGUEJIYSIShKghBBCRCUJUEIIIaKSBCghhBBRSQKUEEKIqCQBSgghRFSSACWEECIqSYASQggRlSRACSGEiEr/P6rl/yw71komAAAAAElFTkSuQmCC
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABF10lEQVR4nO3deZicVZnw/++pqt73PUsnvWeHJJ0mbAkoBgFlMI4ouItCEHdf13l1lt87OArqq4ODo4ERdURE8wriFobgApEldEISErL0knS6O+l937uqzu+Pp6q701ttz1NL9/25rlydrnrqPIeiU3efc+5zH6W1RgghhIg2tkh3QAghhJiNBCghhBBRSQKUEEKIqCQBSgghRFRyRLoDQgixEBw8eDDf4XA8DGxAfvkPhBs45nQ679yyZUvb1CckQAkhhAkcDsfDS5YsWZuXl9dts9kkPdpPbrdbtbe3r2tpaXkYuGXqcxKghBDCHBsiGZz279+f/O53v7v05ptv7t66devQgQMHkm+44Ya+nTt39k9/rrOz056Tk+O64447umd7bV1dXfwTTzyRffz48RNT7/HII49kZWVlOaurq5PvvffeVjP6bbPZdF5eXm9LS8uG6c9JgBJCCHPYIjly2rZt29D27dv73/ve93Zv27Zt6I477uhOT0/f1NfXd3j6cwD33HPP8qysLOfOnTv7t23bNrRhw4ahqc9Pt3///mSAnTt39tfW1ibs378/ea5rA+V532ZMi8o8qRBCLFAZGRnO119/PX625z75yU+2f+UrXymc7bmOjg57VVXVRcHn0UcfzcrKynIClJeXj+7duzfN/B5fTAKUEEIsQB0dHfb09HTXunXrxmZ7ft26dWONjY0Jsz3329/+Nn3nzp39Ux/r7e115Obmurzfd3Z2Wj4DJ1N8Qghhsi/sObLidEt/spltrlqSNvTNWzc2+rpu7969aR0dHfba2tqEv/71r6fnu7a/v98+/bXf//738yorKwdD7a8ZJEAJIcQCUlVVNeQZ/fTPd11HR4d93bp1F03j3Xjjjf3btm1rffLJJ2dM32VkZDg7OjrsAN3d3Y6cnBynqR2fhQQoIYQwmT8jnUj77ne/m/v5z3++Zbbnpk/vAbz3ve/tfumll5KB/rq6uvgbb7xx3gBoBglQQgixAOzfvz/5yJEjyWBk9E1dL9q/f3/y888/n5aRkeGsqalJqKuri8/MzLwozfzYsWPJjz76aFZ2drZztnWrbdu2Db300kvJTz75ZFpmZqbLrAy++Sg5bkMIIUJ35MiRsxs3buyIdD9i1ZEjR3I3btxYPPUxyeITQggRlSRACSGEiEoSoIQQQkQlCVBCCCGikgQoIYQQUUnSzIUQYgEIRzVz77XhSDEHCVBCCLEgWF3NHODJJ59M+8pXvlI4W+CygkzxCSHEAmVmNXMwKkxkZGRYXuLISwKUEEIsQGZXM48EmeITQgizPfnxFbS9bmo1c/LXDbHzQalmLoQQIjZZVc08EiRACSGE2fwY6URaoNXMI0EClBBCLABWVzMHeOSRR7KOHTuW8sgjj2R5X2slqWYuhBAmkGrmoZFq5kIIIWKGBCghhBBRSQKUEEKIqCQBSgghRFSSACWEECIqSZq5EEIsAJGqZu7d1Pv000+n/+d//mczGOnoWVlZzurq6uR77723da7HfIm5AJWbm6uLi4sj3Q0hhLjI/fffz+uvv14UqftnZ2dz5ZVX8qY3vWnJunXruPzyy7nyyiuXvPjii2RnZ3PZZZe5za5mvn///mRvYLr//vuX7N+/f6K8086dO/tra2sT5nrMnyM7Yi5AFRcXU11dHeluCCHERU6cOMHatWsj2oesrCxKS0tZt24dALm5uSQmJlJaWopSyj312k9+8pPt73znO8t27tw5Y5Q0XzXz+++/f6Ka+bZt24a8gaaxsTFh27ZtQ/fcc8/yG264oQ+gvLx8dO/evWmdnZ2O6Y/5E6BkDUoIIRagnp4eMjMzKS0tnfV5M6uZf/WrXy343ve+1wDQ29vrmFrForOz0zHbY/60G3MjKCGEiHb3HbiPk10nTW1zTfYavrT1Sz6v27dvH11dXdTX1/Pss8/Oe61Z1czvvffe1ptuuqnU7JN2JUAJIcQCUllZyY4dO3xeZ0Y1c+/60rZt24aKi4tHv/vd7+ZmZGQ4Ozo67ADd3d2OnJwcp/d+0x/zRQKUEEKYzJ+RTqSZUc187969ad61qt7eXsfWrVuHbrzxxv6XXnopGeivq6uLv/HGG/sBZnvMFwlQQgixABw6dGgigayqqorMzMyLnnv55Zftjz76aJaZ1cw/85nPdPz4xz/OeuSRRxwA3vZeeuml5CeffDItMzPT5Z32m+0xX2KumnlVVZWWLD4hRLSJhiy++Rw7dmxow4YNMzL2ooVUMxdCCBEzJEB5XBi4wM9e/xkjzpFId0UIIQSyBkXncCcPv/Ywj596nHH3OKnxqews3xnpbgkhxKK3aEdQfWN9PHDoAW769U08dvIxbim7hbT4NA63HY5014QQMSrW1vSjhdvtVoB7+uOLbgQ17Bzm5yd+zo+O/Yi+sT5uLL6Rj2/6OMUZxbQPt3Oo7VCkuyiEiEGJiYl0dnaSk5ODUirS3YkZbrdbtbe3ZwDHpj+36ALUnU/fydGOo2xfvp1PVX6KNdlrJp7bnL+Z55qeo3ukm6zErAj2UggRawoLC2lqaqK9vT3SXZlVS0uLw+Vy5Ua6H7NwA8ecTued059YVAGqZ6SHox1H+ejGj/LxTR+f8fzm/M0AHG47zBtXvjHc3RNCxLC4uDhKSkoi3Y05rVu37jWtdVWk+xGIRbUGdbLbqI3lDUTTrc9Zj8Pm4NX2V8PZLSGEELNYVAHqVNcpgIum9aZKdCSyPmc9r7bGVoByuTWHznVHuhtCCGGqRRWgTnSdID85n+zE7Dmv2Zy/meOdxxl1jYaxZ6F57MA5/v77L/B8TXTOfQshRDAWVYA61XWKtdnzlyLZnL+Zcfc4xzuOh6lXoXvy1WYAdj9XH+GeCCGEeSISoJRSlXM8/kWr7jniHOFM75k5p/e8NuVvAuDVttiY5mvsGqK6oZsV2Uk8X9PB8fO9ke6SEEKYIuwBSim1A3hojscvs+q+Nd01uLTLZ4DKTsymOL04ZgLUb4+eB+AH79tCSrydh2QUJYRYIMIeoLTW+4CucN/Xm8HnK0CBMc13uP0wbj1jY3PUeerwebYUZbF+WQa3b13Jb49eoLlnONLdEkKIkEXFGpRSqtITuCxzsvMkaXFpLE9d7vPazfmb6R3t5UzvGSu7FLKTLX2cbOnnbZuWAXDH1cUAPLI/uvsthBD+iIoABcydVmeSk90nWZ292q8SJJUFxhJZtE/zPXX4PHab4i2XLAWgMCuZmy9dymMHztE7PB7h3gkhRGgiHqD8GT0ppXYppaqVUtXBlBFxuV3UdNf4Nb0HsDJtJdmJ2VEdoLTW/ObwebaV55KbmjDx+K5rShkcc/Hzl89FsHdCCBG6iAcooFQpdatS6lbP32dk+Gmtd2utq7TWVXl5eQHfoKGvgWHnsN8BSinF5vzNUR2gDp3rprlneGJ6z2v9sgy2lefyyN/OMOp0Rah3QggRukhk8d0KVHm+orXeo7XegzHNl2nFPU92+Z8g4bU5fzON/Y10DHdY0aWQ/ebweRIcNt68fsmM53ZdU0pb/yhPHT4fgZ4JIYQ5IpHFt0drneUJSlMf3621LtNam37excmuk8TZ4ijNLPX7Nd56fdE4ihp3ufn90QvsWFtAasLMer/bK3JZuzSdh56vl/NphBAxKxqm+Cx3susk5ZnlxNni/H7N2uy1JNgTONQafedD/a22g87BsRnTe15KKXZdU8Lp1gH+ckrKHwkhYtOCD1Baa052nWRtzvwljqaLs8dxSe4lUXnC7lOHz5Oe6ODa1XOvx9186TKWZiTyw+fqwtgzIYQwz4IPUK1DrXSPdrM6a3XAr92cv5kTXScYGh+yoGfBGR5z8fTxFt5yyVISHPY5r4uz2/jw1SW8VN/F0aae8HVQCCFMsuADlPeIjUBHUGAEKJd2caxjxknEEfPsyVYGx1zcMsf03lS3b11BWoJDisgKIWLSgg9QJ7pOoFCsyloV8Gs35m9EoTjUFj3rUL85fJ6C9AQuL8nxeW1aYhxvvXQpz9d0SLKEECLmLPgAdarrFCvTV5ISlxLwa9Pj0ynPKo+aTL7eoXH+cqqNv7t0GXab74oYAGuWpNE7PE77QOycbyWEELAIAtSJrhMB7X+abnPeZo60H8Hljvym1z8eu8C4S/O2Tb7rCXpVFKQBUNs6YFW3hBDCEgs6QPWN9dE80BxagCrYzOD4IDU9NSb2LDi/OXye0twUNixP9/s1FfmpANS0SYASQsSWBR2gvAkSIQWoKNmw2z8yzktnOnnrpUv9KnjrlZeWQHqig5q2fgt7J4QQ5lvQASqYEkfTLUtZRn5yPq+2RjZA1bQNoDVcWpgZ0OuUUlQUpFEjU3xCiBiz4ANUblIuuUm5QbcxUTi2PbIByruGtKogNeDXVuSnUitTfEKIGLPgA1Qooyev9TnraRlsoXe014ReBed0az8JDhuFWckBv7Y8P5XOwTE6JZNPCBFDFmyAGnONUd9Tb0qAKkovAuBcX+TOWKppG6A8P9Xv9PKpyj2JEjKKEkLEkgUboGp7anFqp6kBqqG/IeS2glXbNjCRkRcob6q5ZPIJIWLJgg1Q3gSJtdmBlziabkXaChSKhr7IBKiBUSfNPcMTgSZQyzISSYm3ywhKCBFTZh4mtECc7DpJSlwKhWmFIbcVb49nWeqyiAUob2AJdgSllKI8kESJ/lZ4YhfEpUD6Ms+f5ZCx3PP3QnDEB9UXIYTw14IOUKuzVmNT5gwSi9KLIhagalqNPUzBjqAAyvPT2F/r59lQp/dC/V8gdxU07IeRackh2WXwyYMQwH4sIYQIVEQClFKqcurJuUqpXZ6/lmmtvxRq+27t5lTXKd5W/rZQm5qwMm0lR9uPorUOaKOsGWraBoh32FiZHXgGn1dFQSr/71ATvcPjZCT5OLix6RVIyoKPHzCC0OgA9F+AvmZ4/TdQ/SPoPgvZJUH3RwghfAn7GpRSagfw0LTv92mtdwOlnu9D0tjfyJBzyJT1J6/ijGIGxgfoHOk0rU1/1bT2U5YXXAafV0UgmXxNr0DhZZMjpIRUyK2A0jfAlg8ZjzUfDLovQgjhj7AHKK31PqBrykOlgDco1Xu+D8mJrhNAaBUkpluZthKITKr56daBoDboTlWR7yka66vk0XAPtJ80AtRs8teBI0kClBDCchHP4tNa7/aMngAqgepQ2zzVdQqHclCWWRZqUxOK04sBwr4ONejN4AsyQcJreVYSiXE23yWPzntmXucKUPY4WLpRApQQwnIRD1BeSqlK4Jmpa1PBOtN7hhXpK4i3m5dptjR1KQ7lCHuAqms3Akp5fvAJEgB2m6IsL9X3XqimakDB8sq5r1m+BS4cAdd4SH0SQoj5RE2AAnZore+f7Qml1C6lVLVSqrq93XcmWvNAMyvSVpjaOYfNQWFaYdgD1OkQavBN51eqeeMByFsDiRlzX1O4BZwj0Ho85D4JIcRcoiJAKaV2eYPTbEkSnmnAKq11VV5e3rxtaa1p6m9iear/h/r5qyi9KOzVJGra+om3h5bB51WRn0pzzzCDo87ZL9DaSJBYMcf0ntfyLcbX5pBnY4UQYk6RyOK7FajyfPUGpPuUUnVKqe5Q2+8d7WVgfIDC1NA36E5XlF7Eub5zuLXb9LbnUtM6QGleCg576P+ryicSJeYYRXXWwUjP3OtPXplFkJwLzSHPxgohxJwikcW3R2udpbXe4/l+n+f7Ms/XfaG03zzQDGBKBYnpitKLGHWN0jbUZnrbc6lp6w9pg+5UFQU+Us2bDhhffQUopYxRlCRKCCEsFBVTfGZqHGgEsGyKD+Bs31nT257N0JiTpu5hVoWYwedVlJ1MnF3NnSjR9AokpEPuat+NLd8C7adgpM+UvgkhxHQLLkA19TcB1o2gIHx7oeraBtF6cuQTKofdRmlu6tx7oZpeMQKPzY8fi8ItgIbzkT3IUQixcC24ANU80Ex2YjYpcSmmt52fnE+iPTFsI6gaTyAJNcV8qvKCOVLNxwaNrDxf03teyzxp6JIoIYSwSOwGKLcLGl40Ms+msCqDD8CmbKxIXxG2EdTp1gHi7IrinNAz+Lwq8lM51zXEyLjr4ieaD4F2+x+gkrONorGSKCGEsEjsBqgzf4VHboRTf7jo4ab+Jksy+LyK04vDtheqtq2f0txUUzL4vCry09B6cgPwhKZXjK+FVf43tnyLsbF32i8JQghhhtgNUN7F+Zd/MPGQ0+2kZbDFkvUnr5VpK2nqb8LpnmMvkYlOtw6Ytv7kNWcmX1O1MSJKzva/scIqGGiBvvMm9lAIIQyxG6C8ZXbOPAetrwPQOtSKUzstm+IDI1HCqZ2cH7D2Q3l4zEVj99BEkVezFOekYLepi2vyTWzQ3RpYY7JhVwhhodgNUO4pdeAO/BCwNoPPqzijGLA+1byufcDUDD6veIeNopzki0dQPQ0w2BbY9B5AwQawxcl+KCGEJWI3QLnGjK/lO+DI4zDUZekmXa9wHbvhzeAzowbfdBX5qRPtA54CsUBhgCOouERYcokkSgghLBHDAcozgrryE+Achld/RlN/E3ZlpyC5wLLbZidmkxaXZnmiRI0ng68ox/x0+Yr8NM52DjHm9JRsanoF4pKNs54CtXyLsRfK7fJ9rRBCBCCGA5RnBLVsExRtgwMP0dTfyNKUpThs1p1kr5RiZfpKywPU6dYBSnJTiDMxg8+roiAVl1tztnPQeKDxgLGvyR7E+1ZYBWMDRlUJIYQwUQwHKM8Iyh4Pl98Nvedobj/O8jTrEiS8itKLONdv7RRfbVu/6QkSXuWe0kk1rQMwPgwtRwNff/KaSJSQdSghhLkWRoBa/RbIWEHTQLOle6C8itKLOD9wnlHXqCXtj4y7aOgamggkZivLS0UpzzrXhaPgdgaeweeVXWacHSWZfEIIk8VwgPJM8dkcYHcwtOWDdCk3hcq8U3TnUpRehEZPZA2azZvBt8qkKubTJcbZWZmdbJQ88m7QXR7kCMpmM6YHZQQlhDBZbAcoW5xx9APQVPEGAAqbj1p+a6urmnv3KJmdYj5VRX4qta0DxhEbmSshLYTEksIqYy/a2JB5HRRCLHqxG6DcTmN6z6Np3EibLqzfD0Ndlt56Zbq1qeY1bf04bIpiCzL4vMrz0zjTMYhuesX/+ntzWb4FtAsuHDGnc0IIQSwHKNcY2OMmvp3YAzUyCK/+t6W3To9PJzsx27JMvprWAYpzU4h3WPe/pyI/lWxXO6rvfOD7n6aTRAkhhAUiEqCUUpXTvr9VKbVDKfVFvxtxjV08gupvIiUuhYyVV8GBh8Blba28ovQi6wJU2wAVFiVIeFUUpLLJVmd8E+oIKjUfMlZKooQQwlRhD1BKqR3AQ1O+rwTj6HegZ3rwmpNr/KIRVNOAUcVcbb0behvh9B/N7fg0K9Os2Qs1Mu6ioXPQtGPe51KWl0qlrQanijeqQYRquSRKCCHMFfYA5QlEUxeJbgN6PH+vB3b41dC0ANXc32yUOPKknHNgtzkdnkNxRjHtw+0MjZubGFDfPohbY/kIKiXBweVxdTQlVoDDhMzHwiroOQcD7aG3JYQQRMcaVCYXB6wcv141ZYpPa03zQLNRxdzugPVvNw4zdI37aCR43pp8Zo+iJmvwWTuCwu1mDWc4psrNaU/WoYQQJouGABUc1/hEgOoY7mDENTJZJHbJJUa1844ay27vTTVv6Dc5QLUOYLcpinPNO0V3Vn3NJOhRjo4sMae9pRtB2WUdSghhmmgIUD2A95S8TKBz+gVKqV1KqWqlVHV7u2cKyT1ubNJlSgaft4qEt+hp63HLOu1NNW/oNX8EVZSTTILDbmq7M3TWAvDaSC4DoyYklMSnQO4qaDkWeltCCEF0BKjHgVLP30uBfdMv0Frv1lpXaa2r8vLyjAenTPE19jcCTNbhy11lBK826wJUkiOJguQC02vy1bRan8EHQJeRwVfvXkqDt2hsqHLLJ9oVQohQRSKL71agyvMVrfUhz+M7gB7v9z5NmeJrGjBKDk2cpOuIN4KU56RdqxSlF5laTWJk3MXZzkHr158AOutwO5JoJYuGTpMSPbLLoOuM5Sn+QojFwbpzKeagtd4D7Jn2WOApd64xiDdGGs39zeQn55NgT5h8Pn8dnHsppL76UpRexDMNz5jW3kQGX1gCVC06pxwG1OSxG6HKKTemXnsbIbvEnDaFEItWNEzxBWdKmrl3D9RFCtZDXxMM91jWhaL0InpGe+gd7TWlPStP0Z2hsw57Thm5qQk0dJg0gsopn2hbCCFCFeMByjPF198085j3gvXG17YTlnVhIpPPpFRzbwZfSa51NfgA473rPgs55RTnJJs4giozvnoSMIQQIhQxHKCMWnxjrjHahtpmjqC8mXwWJkpMZPKZFKBOt/ZTHI4Mvu4Go7hrTjlFOSnmrUGl5EFCuiRKCCFMEdsByhbH+YHzaPTMk3QzCiEhw9JU8xWpK7Apm3kjqLaBMCVIeEY4nhFUS98Iw2Ou0NtVCrJLZQQlhDBF7AYoz3Eb3gy+GSMopaBgnaWZfHH2OJalLDMlk2+iBl8YU8zJKaPIM514rsvEdShZgxJCmCB2A5Rniq+537NJd/oaFBjTfG2vg9aWdaM4o9iUEVRd+0BYM/hIyoLkbIpzjIoVpmby9ZwD56g57QkhFq0YD1DGCCreFk9uUu7MawrWw2ifkfZskZKMEs72nsWt3SG14z1FN2xTfJ6Mu6JsYwRl2mbdnDJAG/uhhBAiBDEcoJxgj6Opv4nlacuxqVn+U7yZfBZO85VklDDiGqFlsCWkdryn6FqewQfGFJwnQGUkx5GVHMdZsxIlvJl8kighhAhRDAcozxSft4r5bPLXGl8tzOQrSTc2pJ7pDW3EcDoMp+gCMDYEfc2TgQRYmZNi3ggqW1LNhRDmiM0ApTW4x9G2OBr7G2cmSHglZhgnvVo8goLQA1RNa394Nuh21RtfsycDVHFOsnmp5kmZkJwrAUoIEbLYDFCec576lGZgfGD2BAmvgnWWpppnJ2aTHp8eUoAaGXfR0DVEeX54U8y9inJSON8zzKjThFRzb9ud9ea0JYRYtGIzQLmNANXkHgFmSTGfKn8ddNaAc8ySriilKMko4Uxf8AGqtm0ArcNV4sgToLJLJx4qzknGraGpe9ice+SUyQhKCBGy2AxQLiPYNLmMD9T5R1DrjT1THacs605JRklII6iwnaILxhRf2jJImAyGRTkWZPINtMBovzntCSEWpRgNUJ4RlNNIzZ4zSQLClsnXMdxB31hfUK+vaR3AYVMU54Qjg6/2ogQJYHIvlNlFY7tkmk8IEbwYDVDGCKrZOUhmQiap8fNMjeWUgy0uLJl8Z3vPBvX6060DlIQjgw9mDVDZKfGkJTgkk08IEVUCPg9KKVUMVGIc054J1GMcNPgnU3s2H+8Iarx3/vUnMI7kyFsTtky+S/MuDfj1NW39bFiWYXa3ZhruhqHOixIkwFhHK8pNNm8vlHd9SxIlhBAh8PtXdqXUF5RS/wPcB5QBCuj1/P3NSqn/UUr9p1JqkyU9nWpqgJpv/cmrwFPyyCLL05bjsDmCWocaGXdxrmuI8nDU4PMGjGkBCox1KNPKHcUnQ3qhjKCEECHxOYJSSpUAdwO/0Fp/08e1GcAupVSV1vphk/o4k2sMF3BhrJc3z7f+5JW/Do4+bowgkrJM706cLY6VaSuDClCTGXxhTDHPLpvxVHFOMk8fa2Hc5SbObsJUY45UNRdChGbeTyJPcHqT1vrLWuvDvhrTWvd6gtizSqk7TerjTO5xWh12nNrt5wgqPIkSwVQ1D+8purWgbJBVPOOpopwUnG7N+R6zUs3LJUAJIUIyb4DSWp8JZiQU6OuUUrcqpXYopXb59QLXOM0OY/A3bwaf18TputYGqHP95xj37NHy1+nWAeLsiuKw1OCrhcwicMTPeKoo21vV3MRMvpEeGOoypz0hxKIT8FyOUirdzA4opSqBeq31PqDe8/38XGP02YyuZydm+75J2lJIzLS0okRJRglOt3Pi+A9/1bT2U5KbYs60mi9ddbOuPwETAVIy+YQQ0SKYT8WyqYkQSqkSpdR1IfbjPs/XUq31IZ9Xu8YYVQqAePvM0cAMShmjKCsDVJBFY0+3DoTnDCitPVXMZ64/AeSnJZAYZzN/L5QcXiiECFLAAUpr/SpwmSfdHK31GSBLKfX1YDrgCUj1Sqk6wL/5IJdzIkAl2BP8u1HBemg7YdnhhcUZxQABlTwaHnPR2D0UnlN0B1phbGDOEZRSxkZh00ZQWUWg7DKCEkIELZgpvseBOqB7ynTfPsC/9aOZ7WUCPcAPgYeUUqWzXLNLKVWtlKpub28H1xhjgYygwMjkG+s3Tnu1QFp8GnlJeQGNoOraI5DBN8cICqAoJ5kGs45+t8cZQUrOhRJCBCmYKb4tQLXWuhdQntTyHcA3guzDLuDrWuv7gXcCt06/QGu9W2tdpbWuysvLu2iKL6ARFFi+DhVIgDrdGs4MPk+gmGMEBVCck8K5ziFcbpNGmZLJJ4QIQTAB6p14RkueIJUNZPnaI+UPT6JEj88LXeMTIyi/A1Q4Di/0BCjt5zSiN4OvKFw1+OwJxgbaORTlpDDmctPSN2LOPbPLjM3BFk2rCiEWtqDWoLTW35ry/RngYLAVJDwjp12eVPNdWuvdPl/kHp8YQcXZ4vy7UUKakWJt8V6ovrE+Okc6/bq+prWf0tzU8GTwddYZJYhsc9/LWzS2ocPEqubjg9DfYk57QohFJeBafLPRWr/qmeoL9vX3B/QCzxRfgi0e5QlUfilYb+leqOL0YsAoGpublOvz+tNt/VxamGlZfy7SWQu5FfNeUuRJNT/bOcRVc88E+m8ik68W0pea0KAQYjEx7Vd3z3RfeHim+PxOkPDKXwcdNeActaRbE0Vj/cjkGxpz0tQ9zKpwnKLrdkH3mXnXnwCWpicS77CZey4UyDqUECIoPksdBVOyKNjX+c01xqgKYP3Jq2A9aBe0W3N44ZKUJSTaE/1KlKhrGwzfKbq9jcYRJfNk8AHYbIqV2cnmFY1NLzTWvSSTTwgRBJ+ljjDq6v3An824Sql0pdQXMOr3WVgs1hhBJQQ6grK45JFN2SjOKPYrQHkz+MKySXcixdz3vF1xTjINZpU7stk8x79LgBJCBM7nGpQnSH1UKXWXUurLgAYOAd5MgByMc6HKMPZH3e95jXVcRpJEvD0xsNdllxm/0bces6ZfGBUlXut4zed1p9v6jRp8nsQES/mRYu5VlJPC/toOtNaBre/NJbsUOk6H3o4QYtHxO0lCa/0QxkbaDKAKIyhlA2cwaum9akkPZ+MaY9RmI8ER4BSf3QG5qyyb4gNjHWrv2b2MukbnnYKsaR2gNDcVR7gy+BLSISXP56XFOcmMjLtp6x+lID3AXwBmk1MOp5821sFs9tDbE0IsGgFn8XmSIZ61oC/+c48zpmyBJ0kA5K2GpgPm98mjJKMEjaahr4FVWavmvK6mrZ+N4czgyy41ahL64N2T1dA5ZF6Aco8bFTyyS0JvTwixaAT167tS6k7P6bl3ml3d3C+uccZstsCTJMA4/r3nHIyZlAgwzdTj3+cyNOaksWs4PCWOwAhQfkzvgVFNAjAvUWIik0/WoYQQgQmmFt83gHKM497fBZxRSn3E7I7NyzUW2ggKLFsXWZm+EoWaN0DVtg0AYcrgc44aWXx+BqhlmYk4bMrEVHPPfSWTTwgRoGBGUK94Ttj9stb6zRjJERVKqb83uW9zc40xalMk2IIcQYFl61BJjiSWpS6bN0CdbjUCVFgy+LrPgnb7HaAcdhsrspPNO7gwJc9Y/5K9UEKIAIW8Qq+17tFafxkjmy88PMdtBDXFl10CtjhoP2l+vzx8pZpXn+0iLdExMZ1mqYkU8xlF4udUlJNs3ghKKWP9S6b4hBABCiZA1SulXlFKvXHa+pN/BejM4DluI87uZx2+qexxxmii3brU55L0Es72ncWt3bM+/0JdJ1eU5mC3mZDG7Ys3QGXPv0l3quKcFBo6hvwueuuTVDUXQgQhmAB1G/BL4B7grCdYPQ2UKqXSACyf7nONMUoQlSS88lZbOoIqyShh2DlM21DbjOcau4Y41zXE1WVhGnB21kJyLiRl+v2SldnJ9I866RocM6cPOeXGOphFJaaEEAtTMAGqDviV1vpdWutsjKM39gFvBhqUUjVMHuFuDdc4Y8GUOvLKW23Uphs36ViJabyZfPW99TOee7HOGGheVe67mKwp2k9PJob4qTjX2DxsaiafdhvrYUII4adgjtt4COOI92LP969qrb+ptX6zJ2DdhrF51zrucUYJ4DTd6fJWGx+YFk07zZdq/kJdB7mpCeE55l1rY6SYO/d+rNlUeArY1niSOULmTTXvqDGnPSHEohBUkoQnKJ2d47lDwJdC6ZTP+7tGQxxBeTP5rJnmy0nMIS0ubUaA0lrzQl0nV5XlmFNGyJfBdhjpmfzv9dPyzCSS4+2cbOk3px/eANlhXQUPIcTCY0mdHavLHo25xoEQRlA55aBslqWaK6UoySjhbO/Zix6vax+grX+Uq8K1/uQNwAFO8dlsioqCtImCtiFLSDMqm1tYYkoIsfCEoRCc+UZdxuJ90CMoR4KR+mx1qvm0c6Fe8K4/lYVr/ckTEAIcQQGsMTNAgeWJKUKIhScqApRSqtJz5Put/lw/FmqAAuND2+KisW1DbQyOTyYavFDbSWFWEivDUcEcjICQkAFpSwJ+6aolaXQMjNExYFLmXf5aI2HDPXvqvRBCTBcVAQq4W2u9ByNVvdLXxaPuEKf4wPiNvqsOnCalUk/jTZTwTvO53ZoX6zvDN70HRgDOW+VXkdjpVnuqXJw2ax0qbzU4h6GnwZz2hBALXsQDlGfUVAegtb7fk2QxL2+ACnkE5XZC18xUcDN4A1Rtj5Ep+PqFPnqHx8M3vQeeABXY+pPX6iVGgDpl1jSfxSWmhBALT8QDFHAZkOOZ5vuiPy8Y007AhBEUWLYuUpRWRFpcGkfajwBGejkQvhHUUBcMtgW1/gSQmxpPdkq8eetQ3ky+9hPmtCeEWPCiIUABdHpHTrOtQymldimlqpVS1e3t7Yy6jQAV0ggqpwJQlv1Gb7fZ2Zi/kUOtxoDwhbpOyvNTyTfjjCV/hJAgAUYm4qqCVPNSzZMyIW2ZjKCEEH6LhgBVB3jn2eoxRlQX0Vrv1lpXaa2r8vLyGDNjii8+GbKKLM0sq8yvpK63jrbBLg6c6Qrz+pPnvyvATbpTrS5I43RLv3k1+SSTTwgRgGgIUPsAb6ntUuAVXy8Y1S4gxCk+gNzVlv5GX1lg5Hs8deJvDI25wrv+1HEa4pIhY0XQTaxeks7gmIvmnmFz+uTNnJRMPiGEHyIeoLTW9UCPd2rPk803rzG3EaBCGkGB8Rt9Zw24nKG1M4cNuRuIs8Xx54YDKAVXlGZbcp9ZeUsc2YL/X7x6iVGO6ZRZ03z5a2B8yCgcK4QQPkQ8QMHEFN4erfX9/lw/ZtYIKm8NuMYsK2KaYE9gfc56avpeY/2ydDKTQ+xvINpPBb3+5OU9UFEy+YQQkRAVASpQo8pYEwl9BGVtTT6AS3I3MaTOsrU03ffFZhnpg77moFPMvdIT41iemWTuXiiQTD4hhF9iL0Bpzahn42m8LdQRlDf12boAlaZXoZSLZfntlt1jhg7PYYwhBiiAVQWpnDKrqnlSFqQukRGUEMIvsReg0Ix5A1SoU3xhKGLa3mmUGRq1h/HI8xBTzKdatSSNurYBxl0mJTZIJp8Qwk+xF6C0m1FP5Z6Qp/jA8g/Mg2fGiHcv41jXYcvuMUP7SbAnQGZRyE2tLkhjzOWmwazDC72ZfGalrgshFqzYC1BmjqDA+MDsOA2ezEAz9Y2M81pTDyWpGzjSdgSXBfeYVfspyK0AuyPkpiZKHrWYNM2XvwbGBqC3yZz2hBALVuwFKM8aVJyyY1MmdD9vNThHoOdc6G1N83J9F24N21ZcRv94/0RdPssFcYruXMryUrEpONXSZ0p7ksknhPBXzAaoBBX66ACw9APzhboOEhw2dq65GoBDbT7r4IZubMgItiYkSAAkxtkpzk2xINVcMvmEEPOLvQDlmeKLt5kVoKzL5HuxrpPLirMpyiikILlgoi6fpTprAG1KgoTXmiVpnDYrky85G1LyoU0SJYQQ84u9AOUdQdnizGnPotTnpu4hTrb0c2VZDkopKvMrOdR2yLy6dnMxMYPPa1VBGmc7BxkZN2kNLW81dMgUnxBifrEXoDwjKNMCFFjygfnAszXE2228bdMywKjL1zbUxvnB86beZ4b2k2BzGEfam2R1QRpaQ41ZoyjJ5BNC+CH2ApRnBBVvaoAy9wOztq2fPQebeN8VRRRmGce7b87fDGD9NF/7KSM4Ocwrq7TK9MMLV8NoH/RZHKyFEDEtZgNUghkp5l55q43U575mU5r71tOnSY538PE3lk08Vp5ZTlpcGq+2vWrKPebUftK0BAmv4pwU4h028w4vzF9rfJUNu0KIecRegJpIkjAzQJlXk+9wYw97j7dw1/ZSclInNxJ7DzC0NEA5R6HrjKnrTwB2m6Ii38TDC8NQA1EIEftiL0BZMoIyJ9Vca819fzxJTko8H9leMuP5LQVbqO2ppWekJ6T7zKmzDrTL9AAFk4cXmiIlF5JzJEAJIeYVewEKtzGCMqPMkVdKDiTnhvyB+XxNBy/Wd/LJ68pJTZiZBu9dhzrcfjik+8zJ23+Tp/jAWIdq6Ruhd2jcnAbz1spmXSHEvGIvQHlHUA4TAxRMJkoEye3W3P/0SQqzknj35StnvcZ7gKFlG3bbT4GyQU656U2vtiJRov2kZPIJIeYUVQFKKfVF31d50szNHEFByB+Yfzh2gWPNffyv61eR4LDPeo33AMNXWy1ah2o/aRSIjUsyvenVVhxeONIL/S3mtCeEWHCiJkAppXYAl/m8UGvGFMTbE83tQN5q4wNzoDXgl4673Hzr6VOsWZLG2zYtn/fayoJKjnUeY8Q5EmxP59Zx2pL1J4ClGYmkJTrMW4fKl0QJIcT8oiZA+c27D8r0KT7Puk3b6wG/9JfVjZztHOILN6zGblPzXluZX4nT7eRYx7Fgejk3lxM6aixZfwJQSrG6IE2OfxdChE1UBCilVKXWep9/V3um+Bwmj6CWbjS+Nh0M6GXDYy7+fV8NVUVZXLcm3+f1m/I3AZifbt59Btzjlo2gwEiUONXSb065ppQ8o8yUFI0VQswhKgIUkO33lRMjKJPXWZKyjA/3xpcDetkjL5yhrX+UL920BqXmHz0BZCRkUJ5Zbn6ihIUZfF6rC9LoHR6nrX809MaUkkw+IcS8Ih6g/Bk9KaV2KaWqlVLVA4MDaKVIMDtAARReBk2vgNu/481fru/ku/tq2LG2gMuK/Y+xlfmVHG47jNPtDLanM3kDlEnnQM1mlTdRwrQNu6uh7YRk8gkhZhXxAAWUKqVuVUrd6vl75fQLtNa7tdZVWuuq5GQjMJk+ggJYcTmM9HiOrJjf6dZ+7vppNSuykvjmrZcGdJvthdsZGB/gj2f+GGRHZ9F+GjJWQEKqeW1OM3m6rpmZfD0w0GZOe0KIBSXiAUprvUdrvQdjmi/T1/VubYxuTF+DAiNAATQemPeyC73DfPBHB0iMs/OTD28lKyWwqhbXFF7D6qzV/ODID8wbRVlQg2+67JR48tISzN0LBZLJJ4SYVcQDlJdnlFSmtZ53cUZ7A5TZ+6DA2OCamDnvOlTv8Dgf+tEr9I84eeSOyyaqlQfCpmzcs+kezvWf4/f1vw+hwx5ul6Up5lOtLkizoGisrEMJIWaKmgDlL42xXhFvZi0+L5sNVmw11qFmMep0seun1dR3DPCD921h/bKMoG913YrrWJu9lh8e/SHj7hDLB/WcA+eI5SMoME7XPdXSb87hhakFkJghIyghxKxiLkC5PQvqloygwAhQ7SdhuPvi+7o1n/vlEV4+08U3b93ItorckG6jlOJjmz5GY38jv6v7XUhtTSZIWB+grizLYdTp5lBDt++LfVHKU2JKApQQYqaYC1DeKT5LRlAAhVuNr9P2Q/3bH07wu6MX+Ieb1rBz8/zVIvx1beG1rM9ZH/oo6txLYIuDJRtM6dd8Li/NwWFTPFfTYU6DEqCEEHOIvQCFxSOo5VuMgqtT1qF+/LczPLz/DB+6qphd15h3lLp3FNU80Mxvan8TfENn9xv9jk8xrW9zSU1wULkyi/217eY0WLABhjqhu8Gc9oQQC0bMBSjLp/gSUqFgPTQZmXwv1Xfyr78/wY61Bfzjzev82owbiO3Lt3NJ7iXsPrqbcVcQo6jRfjj/KhRvM7Vf89lekcvx8310DY6F3pi332efD70tIcSCEnMBytIkCa8Vl0NTNRe6B/jEzw9RlJPMd27b6LPOXjC8o6gLgxd4ovaJwBs497JxSGEYA9S2ily0hr/VmjDNl7/WOIvrzHOhtyWEWFBiNkBZNoICI0CNDfD1nz7JyLib3e+vIi0xzrLbXb3sai7Nu5TdR3cz5gpwVHL2eWP9ybuHKwwuLcwkPdHBfjPWoZSCkmvgzPNSUUIIcZGYC1DeKT5LR1CFxqkfaW0H+fa7NlKeb111BjBGUR/f9HFah1r5dc2vA3vx2eehsAriA9+PFSy7TXFVWS7P17SbUzi25BroP28cWS+EEB4xF6DCMYL6+Wkb7TqD9yy9wA3rl1h2n6muXHolm/M389BrDzHq8rMY60gfnD8c1uk9r20VuZzvHaG+YzD0xkquMb6e+WvobQkhFozYC1AWJ0kcbOjmn397nIbkDaxzh6/CgXcU1TbUxmMnHvPvRY3hX3/yuqYiD8Ccab7sUkgvlHUoIcRFYi5AuT0jqDib+WtCbf0jfOzRgyzLTGL91h2ornoYMCmd2g9bl2zliqVX8O2D3+YTz36Cmm4fRWvPPg/2+Mm9W2G0MieZldnJPG/aOtR2I13ez0ryQoiFL+YClHfFw+w1qHGXm48/eoi+YSc/fP8WksquMp6Yo+yRFZRSPHDdA3y68tMcaj3EO556B1/d/1UuDFyY/QVn98Py8K4/TbWtIpeX6jsZd5kQVEqugaEOOcBQCDHBEekOBEprjQNw2Mzt+oN/ruWVs9088O7NrFmSDuObjOy4xpdhzVtMvdd8khxJ3HnJndxacSv/dey/+PmJn/PHM3/kPWvfw52X3ElGgqf+n3f9afvnAHC5XfSN9dE90k3XSBfdo90Tf9do8pLyyE/OJy8pj7zkPLISsrDb7CH1dXt5Lj9/+RyHG3sCOg9rVsXbja9nnjP2oQkhFr2YC1BuIN7kgd/x8738x59q2blpGbdsXGY8GJdoHAMfxhHUVJmJmXyu6nO8Z817ePDwg/zk+E/Yc3oPy1OXM+oaZWy0l7HCJYxe+A3jP3uSUdfoRAKJP+zKTk5SDlcsvYLbVt/GJbmXBLwJ+aqyXGwKnq/pCD1AZa4w1qLOPAdX3BNaW0KIBSHmApRGk6DMC1BjTjef/9VRMpPj+ee/m/ab+4qtUP0jcI2D3bp9UPNZmrqUe7fdywfWf4CfHP8J/WP9xNvjSWh9nbiRZhLWvZv4uGQS7AlkJWaRlZBFZmIm2YnZZCVkkZWYhULRMdxB+3A7bUNttA+30z7UTvNAM/sa9vFU3VOszV7L7Wtu56aSm0jy8zDIjOQ4Li3MZH9NO//rehNO8i25Bo49YRwfEuLoTggR+2IwQEE85n14PfjnWk5c6GP3+7fMPHhwxVZ46fvQctSodRdBq7JW8bVtX5t8YPcbIWkVXPmPfr1+aepSlqYunfH44Pggv6v7Hb849Qv++YV/5lvV3+JtZW/jttW3UZxR7LPd7RW5fP8vdfSNjJMe6mbm4u1w8Mdw4Qgsn3GwshBikYm5JAk3mgRlToA6fr6XB/9cy9s2LePNs+138mbHNUZmmm9OI31w4bCR+RailLgUbltzG7++5df8+MYfs23ZNn5x6hfc8uQtPHj4QVzu+c992laei8utebGuM+S+yH4oIcRUMRegNBBvwvTP1Km9f5k+teeVsdzYnzPPCbsRce5F0G5T9z8ppdhSsIX7r72fZ259hlvKbuEHR37Ax579GN0jc5/9tHllFinxdp6vMSEdPzUf8tYaZY+EEIteVAQopdQuz5/7fF2rwZQRlHdq79/evmHm1N5UK7ZC44GQ72eqif1Pl1nSfG5SLv969b/yL1f+C9Ut1bzrd+/itfbXZr023mHjitIcczbsgjGKOvcSOE2olC6EiGkRD1BKqR3APq31bqDU8/2cjAAV2tKZd2pv51xTe1Ot2Ap9TdDbHNI9TXV2vxGc4vxLZgiGUop3rHoHP33LT7ErOx/Y+wF+cfIXs9be21aRy9nOIRq7hkK/ccl2GB+E84dCb0sIEdMiHqCAUsAblOo938/JDcSHsAfKO7WXlRLPv9zix36bFd4TdqNkFDXSayQRFIe+/uSP9Tnrefzmx7ly6ZV87eWv8Q/7/4Gh8YsD0faKXAD2m3H8RtHVgJKyR0KIyAcorfVuz+gJoBKonvd6ICGEMkeTU3uXkJnsRzWKgkvAkRg9iRIN5q8/+ZKRkMF/vOk/+MSmT/CH+j/w/j++n87hyaSIsrxUlmYkmjPNl5wNSy+VACWEiHyA8lJKVQLPaK3nndtxK4gPMkAdberhwT/X8vbNy7l+XYF/L3LEw7LK6EmUOPs82BMsW3+ai03ZuHvj3Xx/x/c513eOu565ayJ5QinFtvJc9td24HKbdPxG48swPhx6W0KImBU1AQrYobW+f7YnPAkU1Uqp6mBHUMNjLj77+GHy0hLmztqby8orjLTuMBaOndPE+lNiRG6/bfk2vvem73Gu7xx3/s+d9Iz0GI9X5NI7PM6x5t7Qb1J8DbjGoi85RQgRVlERoJRSu7zBabYkCc80YJXWukqjggpQ9+09SV37IN9650YykgN8/cbbwe2EV38a8H1NNdxjbBo2Yf9TKK5YegUPvPEBzvae5a5n7qJ3tJery411KFPSzYuuBGWXaT4hFrmIByhPQLpPKVWnlJp7w42Hm8ArmT93up0fv3CWD19dMvFBGpC81ca00ys/Apcz8NebxYL9T8G6avlVPHDdA9T11HHX/9xFXNwIlSsz+WV1U+jVzRPSjModEqCEWNQiHqC01vu01lla6zLP133zXk9ghxX2DI3xhT1HqMhP5Ys3rg6+o1t3Genmp/cG30aozu431p+WV0WuD1NcvfxqvvvG71LTU8Pdz9zNHduXcK5riCcOmZCSX3INNB+E0f7Q2xJCxKSIB6hAaQVxfhZu1VrzlSeP0Tkwxndu20RiXAgbfFfdZFSVeOWh4NsI1dnnjbT3CK0/zeaawmv4zhu+w6nuU/z83FfZUBjP9/5cE/ooqmS7cVpww4vmdFQIEXNiL0Dh/wjqqSPn+f3RC3z2+lVsWJ4R2o3tDqi6A+r/Au2nQ2srGF1n4MLRsO1/CsQbVryBb1/7bU52nkQtfYjGnm5+fagptEZXXG5Uyzgr03xCLFYxF6AAEuy+RxDne4b56pPH2FKUxUevLTPnxpUfND40X3nYnPYC8dw3wZEAlR8I/739cN3K6/jmtd+kcfA0uWX/zQN/PhbaKCouyVhre22PpJsLsUjFZICK9zGCcrs1n//VEdxuzXfetQm7LbCD+OaUmgfr3w5HHgvv2khHrXHPqo9A+swjM6LFjqId3HfNfYw7ztCV9p889kptaA1u/xz0X4jMLwRCiIiLyQCV4Jh/BLX7+XpeqOvkn/5uHStzks29+WV3wWgfHH3c3Hbn89f7jGoW2z4TvnsG6YbiG/j69q/jSGrg/x79Er0jA8E3VrwNyq6D5/+vccSIEGJRickAFT/Pia9PHTnPN/54krdespR3Va0w/+aFVcZR8AcehlkKp5qu7SS89ivYepdxHEUMeEvpW3h/+Zdxxtfx3t9+lGFnCFN0b/onGO4yDo4UQiwqMRmg5hpBvVDbwed+eZitxdl8+10bUcqkqb2plDJSzttPQMPfzG9/ur98HeJT4KpPW38vE33h6neTP/pBGgaP8slnP8WIcyS4hpZthrW3wAv/AYMmHIoohIgZCyZAvX6+j13/fZCS3BQe+kBVaCnlvmx4ByRlwYHdvq8NRcsxeP1JuPyjkJJj7b1MppTiH9/wfoYvvIOXW17mM3/+TPBB6o1fMY7g+Nt3zO2kECKqxWSAio+7eF2pqXuIDz1ygNQEBz++Y2vgpYwCFZcEm98HJ34Hfeetu89fvg4J6XDVJ6y7h4XesCqPDek7SOy5nb+d/xt37L2D1sHWwBvKXwOX3g4HHrL2/RZCRJWYDFAJU9agugfH+MCPDjAy7uInH97KskzrDvG7SNVHjLJD1Y9Y0/75V+Hk7+DKjxujtRiklOIzOypov7CRdyz/KvW99dz++9s50n4k8Mbe8GVwu4x0eyHEohCbASouBTAqlH/kJ6/Q1D3MQx+oYvWStPB1IrsEKt4MB39szfHkf/46JGbCFfeY33YYXbsqj00rMnmmOo9HbvgpifZE7th7B0/UPBFYQ1lFsOVDcOin0FVvSV+FENElJgNUvCMZp8vNJx97lVcbe/j32zZxeWkE1mi27oLBNjjxlLntNr4CNU/D1Z+CxBArYESYUorPXr+K5p5hfvTnER59y2NsKdjCP73wT9x34D6c7gCK717zebDFwV++YV2HhRBRIyYDVEJcMr89ep59J1r5p5vXcdMlEdq8WnYd5FTA3i8bZYjM8pd/g+Qc2Hq3eW1G0LWr8vj0myrYc7CJf/x1Pf/+hgd539r38bMTP+Ojz3x04kwpn9KWwOV3w9FfQuvrlvZZCBF5MRmg4uNTeOLV8yzPTOKDVxZHriM2G7z7MaPC+I9vNqewacOLUPcnuPozkJAaentR4rPXr+Krb13L71+7wMcePcynNn2ef736XznUdoh3/e5d7D2zF+3PvrKrP20cx/Hnr1nfaSFERMVkgBoYi2d/TTtv27QMm1lljIKVWwEf3muUQfrvt0PNM8G3de5leOJuSMmHy+40r49R4s7tpXzj7y/hr6fb+eAjB3hT4Vv5yY0/IS0+jS889wXe8/v38ErLK/M3kpwNV33KSCCpmfdkFiFEjIvJAPXsyR7cGnZuXh7prhgyV8Ade41g9djtRoHTQDhH4Zl/hkduNKpT3PYziDe5RFOUuH3rSh64fTOHGrp578MvU5i8ml/e/Evuvfpe2ofb+fDTH+YTz36C2u556vhdcQ/kroKfv9NIJonkIZJCCMsov6ZVokhSSZK+/vNPM+5U/PHTUXb0xEgvPPZuaHgB3vptuOwjvl9z4Sg88VFoO25UKr/h34wprAXu2ROt3PPoIYpzkvnZRy4nPz2REecIPzvxM/7rtf9iyDnE28vfzq5Ld7EsddnMBkYH4A9fgCM/h5VXwTsegozC8P+HCBEjlFIHtdbRcdqpn2IuQCWXJOn82/bwDzet4W6zjtEw0/gw/OpDxsm7133VWEua7YBFlxP2fwf++g0jIeKW78GqG8Ld24h6oa6DO39STXZKPF97+yVcuyoPgO6RbnYf3c0vTv0Cp9vJJbmXcH3R9ewo2sGKtGn1FY/+En73WbA54G0PwtqbI/BfIkT0kwAVbCeUuhXoASq11vfPd21KcZLOf/ceXvjydSzNCNOm3EC5xuHJj8FrvzS+T8yElFxIyTOCUUoeXDhsbMbd8A54y7eMtZVF6HBjD599/DBnOga5acMSvnrzOpZ7NlufHzjPH878gWcanuH1TiNrb232WnYU7WBH0Q5KM0qNRjrrYM+Hjff0sjvhzV+LqlOHhYgGEqCC6YBSlUCp1nqPUmoXUK21PjTX9anFSfrm//0nfrHryvB1MhhuNxz7f8am0sF2489QJwx2wFCHsZ/nhq/Bhr+PdE8jbtTp4uHnz/C9P9WgUHziunLu3F5CgmOynmJTfxPPnnuWZxqemahEUZ5ZzvVF13N90fWUp65E/en/wIv/YaxPXXobVFwPSy41CvwKschJgAqmA0rdBzyjtd6nlNqBj1FUWnGSfuiXp7h968rwdVKERVP3EPf+7gR7j7dQkpvC/3fLeq7xTPtN1TLYwrPnnmVfwz4Oth5EoylOL+b6out5sy2D1S8/jPLuS0stgPIdxp+yN8Zs2SghQiUBKpgOKPVD4Ida60OeAHW91vpLc12fXpykG1/vs74grIiYv55u51+eOs6ZjkEKs5LmPRHZbetjLOEIYwlHcMbVgNIoVzoO7SCBURL1KAmMYsMNKJxYWOVeiCj2zF3HYy5AOSLdAX94pv52AeStSJXgtMBduyqPvZ/Zzk9eOMvr532dpJsJrAT+jjHdR7v7ID2208DkL14u3CQ6+8hwdhCvQzg8UQgRVtEQoHoAb4ZAJjDjVDqt9W5gN0BVVVXkszqE5RIcdnZdE0yW5rWm90WIheDhu2NvLTYaNuo+DnjSsSgFpDyAEEKIyAcob8aeZ/2pZ74MPiGEEItHNEzxeafwhBBCiAkRH0EJIYQQs5EAJYQQIipJgBJCCBGVJEAJIYSIShKghBBCRKWIlzoKlFKqHzgV6X5EiVygI9KdiBLyXkyS92KSvBeTVmutY+qwuahIMw/QqVirJ2UVpVS1vBcGeS8myXsxSd6LSUqp6kj3IVAyxSeEECIqSYASQggRlWIxQEnViUnyXkyS92KSvBeT5L2YFHPvRcwlSSxWSqlbMSq/z3mgo1KqUmoZisXKn38jnuu+ON/zInpE9QhKKXWrUmqHUuqLwTy/UCilKgG01vuAHu/3067ZATwU7r5Fgh8/F7s8f+4Ld9/CzY/3Yofnz4J+L/z5N+K5bgdwWTj7Fgl+/Fzc5/m6K7w9C0zUBihfP3D+/kAuELdh/GYIUA/smH6B533oCmOfIsKPn4sdwD5PAeJSz/cLkp//Rq73PF+52P+NLBZ+fjbuUkrVYbxXUStqAxS+f+AW0w9kJhcHn5wI9SMa+Pr/XjrlsXomzxpbiOZ9L7TWh7TWX/J8W7rAp38z8fFvxDMFvhjOm/Pns/GdWuuyaH8/onkfVCbz/8D5el4sTJnM8/992tEtlRgHYi5Umfjxb8AzzXN3ODoU5bJ9X7IgZOL756JSKQU+1usiLZpHUGJSD5P/uDKBzoj1JEZ4pjWeWeCjBr94PoDuVkplRrovFuphnn8ji2j05Bet9f2e9yMnmqfBozlA9TD/h7Kv5xeSx5mcqioF9gEs8A+cufTg3//3HdH8m6FJevDxoTxl/aEeiOoF8RD5+jdS6kkcuNXz94W8HtfD/D8X3vcBz3NROw0ezQHK1w/crM8vRN5RgOc3nZ4po4Jnvdd4fuCqpvzgLVQ+g7VSapc3OEXzb4cm8PVe7ODiD6qoXhAPha9/I1rrPVrrPRjvR2ZEOhk+vn4u6pn8vCwDorYEUlTvg/KkQNZjLPDu9jx2UGu9Za7nxcI338+F5wPqVxhz8NkYi8EL9pcXH+9FJvAujPfieq21rEMtEn5+dnZ5no/amYaoDlBCCCEWr2ie4hNCCLGISYASQggRlSRACSGEiEoSoIQQQkQlCVBCCCGikgQoIYQQUUkClBBCiKgkAUoIIURUkgAlhBAiKkmAEsIEnsKsdUqpX035PjPC3RIipkmAEsIcO4AtwA+9x2hrrXsi2iMhYpzU4hPCRJ5RU7bWesFWDhciXCRACWES75SejJyEMIdM8QlhAqVUKUwGJ+/3QojgOSLdASFined01iqgSym1D2M9qocFfECgEOEgIyghQjBlWm83xumlZ4DLFvIhiUKEi6xBCSGEiEoyghJCCBGVJEAJIYSIShKghBBCRCUJUEIIIaKSBCghhBBRSQKUEEKIqCQBSgghRFSSACWEECIqSYASQggRlf5/hENxpOb+xxAAAAAASUVORK5CYII=
 "
 >
 </div>
@@ -14519,8 +14254,8 @@ Note that the first call to the <code>plot</code> specifies the x-axis limits, b
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 227 ms, sys: 80.2 ms, total: 307 ms
-Wall time: 310 ms
+<pre>CPU times: user 238 ms, sys: 206 ms, total: 444 ms
+Wall time: 444 ms
 </pre>
 </div>
 </div>
@@ -14557,8 +14292,8 @@ Wall time: 310 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 194 ms, sys: 37.2 ms, total: 231 ms
-Wall time: 231 ms
+<pre>CPU times: user 233 ms, sys: 198 ms, total: 431 ms
+Wall time: 430 ms
 </pre>
 </div>
 </div>
@@ -14594,8 +14329,8 @@ Wall time: 231 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 1.67 s, sys: 24.5 ms, total: 1.69 s
-Wall time: 1.7 s
+<pre>CPU times: user 1.62 s, sys: 23.3 ms, total: 1.64 s
+Wall time: 1.64 s
 </pre>
 </div>
 </div>
@@ -14632,8 +14367,8 @@ Wall time: 1.7 s
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 207 ms, sys: 66.9 ms, total: 274 ms
-Wall time: 274 ms
+<pre>CPU times: user 231 ms, sys: 229 ms, total: 460 ms
+Wall time: 459 ms
 </pre>
 </div>
 </div>
@@ -14670,8 +14405,8 @@ Wall time: 274 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 1.66 s, sys: 19.7 ms, total: 1.68 s
-Wall time: 1.68 s
+<pre>CPU times: user 1.62 s, sys: 18.8 ms, total: 1.63 s
+Wall time: 1.63 s
 </pre>
 </div>
 </div>
@@ -14708,8 +14443,8 @@ Wall time: 1.68 s
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 1.72 s, sys: 22.5 ms, total: 1.74 s
-Wall time: 1.74 s
+<pre>CPU times: user 1.72 s, sys: 29.6 ms, total: 1.75 s
+Wall time: 1.75 s
 </pre>
 </div>
 </div>
@@ -14751,8 +14486,8 @@ Wall time: 1.74 s
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 115 ms, sys: 55.4 ms, total: 171 ms
-Wall time: 171 ms
+<pre>CPU times: user 110 ms, sys: 76.1 ms, total: 186 ms
+Wall time: 186 ms
 </pre>
 </div>
 </div>
@@ -14789,8 +14524,8 @@ Wall time: 171 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 69.9 ms, sys: 19.1 ms, total: 89 ms
-Wall time: 89.8 ms
+<pre>CPU times: user 52.2 ms, sys: 58.1 ms, total: 110 ms
+Wall time: 110 ms
 </pre>
 </div>
 </div>
@@ -14802,9 +14537,9 @@ Wall time: 89.8 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/Users/echarles/software/vro/qp/qp/interp_pdf.py:82: RuntimeWarning: invalid value encountered in true_divide
+<pre>/afs/slac.stanford.edu/u/ek/echarles/vol2/vro/software/qp/qp/interp_pdf.py:82: RuntimeWarning: invalid value encountered in true_divide
   self._yvals = (self._yvals.T / self._ycumul[:,-1]).T
-/Users/echarles/software/vro/qp/qp/interp_pdf.py:83: RuntimeWarning: invalid value encountered in true_divide
+/afs/slac.stanford.edu/u/ek/echarles/vol2/vro/software/qp/qp/interp_pdf.py:83: RuntimeWarning: invalid value encountered in true_divide
   self._ycumul = (self._ycumul.T / self._ycumul[:,-1]).T
 </pre>
 </div>
@@ -14846,7 +14581,7 @@ Wall time: 89.8 ms
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA5zElEQVR4nO3deXzdZZ33/9d1TnKy7zlp6JY0aUs3mrQNWymiUkAcR3HsoKKOMoOAOqO/GVEHFXWUUVnmvr3H4YcUvFlUBhXHjqIMQxUcAYGetE2b7kmabjR70uzrue4/zsm+JydnSd7PxyOP5Hy/18n55BDy6XVdn+u6jLUWERGRcOMIdQAiIiJjUYISEZGwpAQlIiJhSQlKRETCUlSoAxARkekrLi7OioqKegzYQGR3NrxAaW9v721btmypGXpDCUpEJAJFRUU9lp2dvdbtdjc6HI6ILcf2er2mtrZ2XVVV1WPAe4fei+SsKyKykG1wu93NkZycABwOh3W73Rfw9QSH3wtBPCIiMnuOSE9O/fw/x6h8pAQlIiJz4vDhw64bb7wxb6bPV4ISEZE5sW7duu7nn3++YqbPV5GEiEiE+8KzJcuOV7XEB/J7rs5Oan9gR8GZido8+OCDmVdccUX766+/Hn/XXXfV7dq1K+n+++/P/uQnP1lXXl7uete73tXyxS9+cclrr712or99RkZGX3l5uSs/P7/71ltvbZzo+ytBiYjItH31q19d9K53vatl27Zt7XV1dc4HH3ww86677qr7u7/7u5yhiSclJaUPYNeuXUkZGRl9t956a+ONN96Yd++991ZP9hpKUCIiEW6yns5c+P3vf598yy23NAKsXr2665FHHnHfdddddRs2bGgfq/22bdva77nnnuxVq1Z1XXvttc1TeQ0lKBERmbaCgoL248ePx6xbt677+PHjMVu2bGmbqH1NTY3zhhtuaF6zZk3Xtm3bxkxiI6lIQkREpu3hhx8+5/F44nft2pXk8Xji77333updu3YllZaWxr/yyivxAK+88kp8aWlp/OHDh10AjzzyiPuzn/3s0htvvDGvv81EjM6DEhGJPCUlJZUFBQV1oY5jqj71qU8tefjhh8+N97ikpCSzoKAgd+hzNMQnIiJz7iMf+Ujj448/nrZq1aquEydOxHzkIx+ZsIIPlKBERCQItm3b1t4/96Q5KBERiWhKUCIiEpaUoEREJCwpQYmISFhSghIRkYBJTk4u3Lp166qvfvWri/qvPf7442lbt25dNd3vpSo+EREJmKeeeqr8pptuahl67dZbb2189NFHM6f7vZSgREQi3a7PLKPmcEB3MydrXTs3PTTpbuYjdydvbGyMOnz4sGvdunXdsw1BQ3wiIjJtQ3cnLy4uTujfwby+vt6ZlZXVd8stt+TM9jXUgxIRiXST9HTmwni7k9911111ACkpKb2PP/542mRnPk1EPSgREZm2obuT9yelBx98MHMqm8BOlRKUiIjMyMjdyT/xiU80gq9qD3zFEeAbDiwtLU3ovz5V2s1cRCQChXo388l2J58u7WYuIiIBMZPdyadLCUpERKZtJruTT5fmoEREJCwpQYmISFhSghIRkbAUcXNQmZmZNjc3N9RhiIiE1P3338/hw4envFtDV1dX76ZNm0rmMqZAi7gElZubi8fjCXUYIiIhdeTIEdauXTvl9qWlpbPeG28ydXV1zqNHj8acOHEi5s0334zvLzt//PHH0x599NHM11577cR0vp+G+EREJCCeeOKJtNdffz2+f4Hugw8+mAmDC3anK+J6UCIiMtx9b97H0YajE7ZpbWuNjaqMuniq33Nl2sr2b131rWntZt6/5RFAZWVlzA033NA80fMnox6UiIhM23i7mQMcPnzYlZaW1jfyXKjpUg9KRCTCfemyL03aprS0tHPDhg3HAvWa4+1mDvD000+nPf3006dm+xrqQYmIyLSNtZs5+Aoi7r333mqA2e5srgQlIiIzMnI38127diV97WtfW7J+/fq169evX1tXV+eEme9mriE+ERGZtu9///vu559/vqL/cf9u5jfddFPpyLY33XRTS3Nz8/7pvoYS1DzQ3NnDL/ee4yOXLyfKqU6xiMw97WYuU/LUa5U8+N/HSY2P5n2FS0IdjogsANrNXKbkuQPnAfjhKyfRAZQiC8d8+f/d6/UawDvyuhJUhCuraeFoVQvrFydz4OwFik8FvJctImEoNjaW+vr6iE9SXq/X1NbWpgCj5q40xBfhnjtwHmPgoVs2876HXuWHr5ykKDc91GGJyBxbunQpZ8+epba2dkrtq6qqovr6+jLnOKyZ8AKlvb29t428EfQEZYzZAdxhrb1ujHv3WWsnX3EmgK97/9yB81yWm05uZgIfvmw5O/+nnDMN7SxLn9XyAxEJc9HR0axYsWLK7detW3fQWls0hyEFXNCH+Ky1z4513RizHcgLcjgR7Vh1C2U1rbynYDEAH9+ag8MYnnytMrSBiYgEQFjMQRlj8oCKSRvKMM+VnMdh4F3rswG4KCWOd19yET/dc4bWrt4QRyciMjthkaCAPGvtuAnKGHO7McZjjPFMdbx1vrPW8puD57kyPwN3UszA9b/etoKWrl5+tmfCTYhFRMJeyBOUMWa7tXb3RG2stTuttUXW2iK32x2s0MLaobeaOVnXxns2Lh52vXBZKlty0njitUr6vJFd3SMiC1vIExTQYIzZ7i+eyDPGbA51QJHguQPncToMN/iH94b6m20rON3Qzu+OVIcgMhGRwAh6gvIXQxT5ExLW2r3+HlQ6kBrseCKRb3jvLa5amUl6gmvU/evXLWJJahw/fOVkCKITEQmMUFTx7bbWpo2s5vMP4+Vba/cGO6ZIc+DsBc73vULG4j+NeT/K6eATW3N542QDpecuBDk6EZHACIchPpmm5w68RUzGy7ze8AxeO2p3EABuvnQZ8S4n//dV9aJEJDIpQUUYr9fy69LjOGJqae1ppaJp7OLHlLhobi5axq9L3qKmpTPIUYqIzJ4SVITZd6aJut4jA4/31+4ft+0ntubS67X8+E+zPnlZRCTolKAizHMH3sKVWElcVBxpMWnsr9k/btvczATevtrNL/efC16AIiIBos1iI4jXa/ntwfMkLjnFpqxNuJwuSmpLJnzOpuVpvHy8lo7uPuJcziBFKiIye+pBRRDPqUZq2hro4BxFi4oodBdS2VxJY+f4R2yszErEWqioaw1ipCIis6cEFUGeO/AWsUm++aSi7CIK3AUAHKg9MO5z8t2JAJTVKEGJSGRRgooQvuG9KpYvPk+sM5YNGRtYn7meKBM14TBfbmY8DgPltW1BjFZEZPY0BxUhzjZ2UNfaRYqrjIL0AqKd0UQTzcXpF09YyRcT5WR5ejzltepBiUhkUQ8qQpTVtoCjndquSooWDZ45VphVSGldKb3e8Y/XyHcnUq4hPhGJMEpQEaKsphVnfCUWOyxBFbgL6Ojt4Hjj8XGfm5+VSEVdm3Y3F5GIogQVIcpr2khMOYXL4eIS9yUD1wvdhQATroda6U6ku9fLucaOOY5SRCRwlKAiRFltK67ESgqyCohxDh5QmJ2QTVZc1oSFEvlZCf7v0TLncYqIBIoSVASw1nKito5Ox+lhw3sAxhgKsgomTlD+UvPyGlXyiUjkUIKKAHWt3bSZEzBi/qlfgbuAc63nqGmvGfP5qfEuMhNdquQTkYiiBBUBfAUSJ4ky0Wx0bxx1vzCrEJh4wW6eO1GLdUUkoihBRYCy2laiEiq4OG0dsVGxo+6vTV+Ly+GauFAiK1E9KBGJKEpQEeBodS2O2HNsXXLZmPddThfrMtZNuGA3351IY3sP9a1dcxSliEhgKUFFgNL6EozxUpQ9ev6pX2FWIYfrD9Pd1z3m/Xy3r5JPWx6JSKQIeoIyxuwwxrw45HGqMWaz//p9wY4nEpxpL8XgHFjzNJYCdwE93h4O1x8e8/7KLH8ln4b5RCRCBD1BWWufHXHpZqCo/7ox5vZgxxTOWrt66XSeIMuVT3x0/Ljt+nc2H6/cfHFKHLHRDhVKiEjECPkQn7V2p7V2p/9hHlARynjCzeHzdTjizrIuffOE7dzxbpYkLhk3QTkchpUZccSdfgmstjwSkfAX8gTVzxiTBzRYa3ePce92Y4zHGOOpra0NQXSh84dTezCmj21Lxy6QGKrAXUBJTQl2nAT0sZiXuavmy1D5x0CHKSIScGGToIAd1to7xrrh72UVWWuL3G53sOMKqX21xVjr4Pr8KyZtW5hVSE1HDefbzo95/x2tvwWgt+zlQIYoIjInwiJBGWN2WGvv93898VjWAlPZVkp071JSY5Mmbds/DzXmeqi39pHVdgyvNXSVqwclIuEvFFV824EiY8yOIY/vM8YUG2OKgfRgxxSuuvq6aLHlZEWvm1L71WmriYuKG3seqvhJvFGxPNP3dmJr9kF3e4CjFREJrKCfqOufY0ob8Tg/2HFEguKq/WB6WZNaOKX2UY4oNmRuGL1gt6sVDj6LXfd+dhcv5RbvS3B2D+RdE+iQRUQCJiyG+GRsv6/8E9YaLlu8ZcrPKXQXcqzhGO09Q3pIh/4DultwFn2C8ymb8OKAU6/OQcQiIoGjBBXGPFUevF0XcclF2VN+TmFWIX22j0P1hwYvFj8JmRfDssu5KCuLMmceVL4yBxGLiASOElSY6u7rprL1CH1tKwbOc5qKjZm+3c4H5qGqD8E5D2z5BBhDvjuBP/aswZ7dAz06YVdEwpcSVJgqrSulj26SzRoSYqY+VZgam0puci4lNf4EVfwkOF1Q8CHAt+XRq71rMH3dcNYzF6GLiASEElSY8lR7wBpWJl8y7ecWuH0n7NrudjjwDKx9L8T7iiPz3Yl4vBdjjUPDfCIS1pSgwtSe83uw3dmsyZr6/FO/wqxCGrsaOb3/Cei8AFs+PnAv351IMwnUJV6sBCUiYU0JKgz1eHvYV7ufnrYVA7uQT8fAgt1Dz0B6HuRePXAvLcFFRoKLozEbfaXmPZ0Bi1tEJJCUoMLQobpDdPV10te+gpXTKJDol5+aT2JUPCWtp2Hzx8GY4ffdvnko+rp8BRQiImFICSoMeap9SaOvfWY9KIdxUOBIYH9sLBTeMup+flYiv7mwAjBwUtseiUh4UoIKQ55qD4mOJaTEpJGe4Jr+N+jtoqD+LGWuaFpccaNu57sTONPhojdrgxbsikjYUoIKM73eXvZV7yOqeyUr3YmYEcNzU3L0OQpaL2CBg3UHR93O9/fK6jIv0zyUiIQtJagwc6T+CO297bQ0LZ/R8B4AxU+yMSYLgxlcDzVE/7zW8bgC6O2Ec8WzCVlEZE4oQYWZ/vmnCw0zTFANFXDyDyRu/hgr01aOubP5klTf8e9v9l0MGJWbi0hYUoIKM55qD9lxy7F9SQNDcdOy90dgHLDpowMLdr3WO6yJw2HIy0yktNEB2Rt0wq6IhCUlqDDS5+1jb/VesmN85z9Nu8S8rwf2/RhW3QDJiyl0F9La00p5U/mopvlZiZTXtvrWSJ3dA71dgfgRREQCRgkqjBxrPEZrTysxPauIi3ayJHV0Bd6Ejv8XtNUM7BxRmFUIMOYwX747gbONHXQv3ap5KBEJS0pQYWRP1R4AWptzyHMn4HBMs4Kv+ElIWgwrrwNgedJy0mLSxjwCfmVWItZCRfxGNA8lIuFICSqMeKo9LEtaxpma6OkXSDSdgbLdsOmj4PTtfm6MGZiHGqn/CI8TLdGwaIMSlIiEHSWoMOG1XvZW76XQvZlzTR3TOgMKgH0/8n3e/LFhlwuyCqhsrqSps2nY9RWZCRgDZTWtkLsNzrypeSgRCStBT1DGmB3GmBfHuLbdGHN7sOMJFycaT9Dc3czS2A0A0+tBeft8xRH574TU5cNu9W8ce6DuwLDrsdFOFqfEcaq+DXKvgt4OOLd3dj+EiEgABT1BWWufHfrYGLPDf323//H2YMcUDvrXP8V7VwPTTFBlu6H5nO/U3BHWZ6zHaZxjzkPlZMRzqqEdcq7yXdAwn4iEkXAY4rsUqPB/XQFsDmEsIeOp8rAkcQl1TQk4HYbcjISpP7n4SUjIgotvHHUrPjqei9MvZn/t/lH3lqfHc6ah3XeY4aINcEoJSkTCRzgkqNQRjzNGNjDG3G6M8RhjPLW1tcGJKoistRRXF7Nl0RbKalrJSY/HFTXF/zTN533l5YW3gDN6zCaF7kJK60rp9fYOu748I5661m5au3p981Cn34De7tn+OCIiAREOCaoJSJ+ogbV2p7W2yFpb5Ha7gxNVEJU3ldPY1UjRoiLKalunt4PE/h+D7YPNfzVukwJ3AR29HRxvPD7s+vL0eABO1/uH+Xo74C3NQ4lIeAiHBLWHwV5UHvDi+E3npz3VvvVPhe4tVNa1TX3+yev1bW2UezVk5I/bbLwFuznpvmHE05qHEpEwFIoqvu1A0ZDiiGeBPP/11P5iiYXEU+VhUfwiervS6PVaVk01QZ18GZpOjVkcMdRFCRfhjnOPKpQY6EE1tEFCBmStV4ISkbARFewX9CegtBHX7vd/ueCSk7UWT7WHKxdf6dsbj2lU8BU/AXHpsPbPJ2xmjKEwq3BUDyolPpqUuGhfDwp85eb7fuybh4qawUGJIiIBFA5DfAvayeaTNHQ2+OafanwJakqLdFtr4ehvoeDDEBUzafMCdwHnWs9R2z68yCQnI55T9f0Jahv0tMNb+6b9c4iIBJoSVIh5qnzrn/oT1JLUOBJiptCxLXkavD0DG8NOpn/B7she1LL0+MEeVP88lMrNRSQMKEGFmKfagzvOTU5yztQr+Kz1rX1adgW4L57S66zLWEe0I3qMQol4zjV20NvnhYRMyFqneSgRCQtKUCFkraW4qpiiRUVY69sXb0pnQFW+Ag3lkxZHDOVyuliXsW7MQoler+X8hU7fhZyr4PTrvrOlRERCSAkqhM60nKGmo4ai7CLONXXQ2eOdWoHE3ichJgXWvW9ar1foLuRw/WG6+wYX4y7P6K/k0zyUiIQXJagQ6t9/r3+BLsCqRZMkqPYGOPwr2HgzuOKn9XoFWQV0e7s50nBk4FqOf0ulgUIJrYcSkTChBBVCe6r2kB6bzoqUFZT7K/gmHeIreQb6uqZcHDHUQKFEzeA8VHZyLNFOw6mGNt+FRDe41ypBiUjIKUGFSP/6py2LtmCM4UR1KxkJLtISJlh/ZK1veG/JFsi+ZNqvmRWfxZLEJcM2jnU6DMvS/JvG9svVPJSIhJ4SVIicaz1HVVsVRYuKAKZWwXfmTag9Cpun33vqt9G9kZKaEqy1A9eWpQ9ZCwX+eag2eGv/jF9HRGS2lKBCZGD+KbsIay1lNa2Tb3G090lwJcKGD8z4dQvdhdR01FDVVjVwLScjntP17YNJK2eb77PWQ4lICClBhYinykNKTAorU1dS29rFhY6eiSv4Oi9A6X/4klPMNI+DH6IgyzcPNXSYb3l6PC1dvTS1+4f0Et2QebHmoUQkpJSgQsRT7aFoUREO4xjY4mjCBHXgZ77jMKax9mksq9NWExcVN2zBbv+msacaRgzznX4d+npHfgsRkaBQggqBqrYqzrWeG5h/6q/gW5WVNPYT+neOyL4EFm+a1WtHO6JZn7F+2ILd/lLz0yMTVHcrnC9BRCQUlKBCYE+V7/ynomx/gURNK4kxUSxKHmfT17f2QvVBX3GEMbN+/cKsQo41HKOjtwOAZelxAJyubxtsNLAe6o+zfj0RkZlQggqB4upiklxJrEpdBcCJGl8Fnxkv+RQ/CVFxvsW5AVDoLqTX9nKo7hAA8a4o3Ekxw3tQSYsgc7XmoUQkZJSgQmBP1R62ZG3B6XACk+zB19UKpb+ADX8BsSkBef2N7o3A6EKJYaXmoHkoEQkpJaggq2mv4XTL6YHhvebOHmpausYvkCj9hW8uaBZrn0ZKi00jNzl3WKFEztBjN/rlboPuFqjSPJSIBJ8SVJANPf8JGKjgG3cN1N4nfVsPLbssoHGMXLC7PCOequZOOnv6Bhv1r4fSMJ+IhIASVJB5qj0kRCdwcbrvHKey6glKzKsOwrli3757ASiOGKowq5DGrkbOtJwBfEN81sLZxo7BRkmLIGMVVL4a0NcWEZmKKRzdOpwxphDI8380AQ1AhbV2fyADm6881R42ZW0iyuF768tqW3FFOViWPsbO5MVPgjMGNn4w4HH0bxy7v3Y/y5OXk+M/duNMQ/vwZJm7zTfM2NcLzmn/uoiIzNiUelDGmFxjzA+MMS8AdwD5wAXA+L++0xjz38aYh40xudMNwhizwxiz3Rhz+3SfG0nqOuo4eeEkl2ZfOnCtrKaVvMwEnI4RPaTudt/i3HXvg/j0gMeSn5JPYnTiwHqo5en9x260DW+Yuw26mqHqQMBjEBGZyKT/JDbGfAFIB75krb0wSdsU4HZjTKO19rGpBGCM2Y6vB7bXn6Q2W2v3TuW5kaa4uhgYnH8COFHTQsHS1NGND/8ndF2Y0bEaU+F0OH3zUP5CicxEF/Eu5/DdJGD4+VBLNs9JLCIiY5mwB+VPTs9aa++eLDkBWGsvWGsfAH5njLlrijF4gJ8bYzYDefM1OYGvQCIuKo61GWsB6Ozp42xjx9jzT8VPQMbKwQQxBwrcBZxoPEFrdyvGGJanjzh2AyD5Il8cpzQPJSLBNWGCstY+YK09Od1vaq09aa19cIptm4BHgJ8DW8ZqY4y53RjjMcZ4amtrpxtO2Oiff4p2RANQXtuKtWMUSNQchTOvw+a/CnhxxFCF7kIsloN1B4Exjt3ol7sNTr0G3r7R90RE5si0q/hmMsc0yffbDuy21uYDTcaYHSPbWGt3WmuLrLVFbrc7kC8fNI2djZQ1lQ0b3isbbw++vU+BIxoKbpnTmC5xX4LBDCzY7V8L5fXa4Q1zNA8lIsE3kzLzNGPMbf0PjDEfMMa8cxYxDJ1z+g6++a55Z2D+KXt4gnIYyM0cUsHX2wUl/w5r/sx37MUcSnIlkZ+aPzAPlZMRT1evl9rWruENc/vnoTTMJyLBM+0EZa3dB6zsT0rW2l8A1xtj/maGMez0D+FtB2621u6c4fcJa55qD7HOWDZkbBi4VlbTSk5GAjFRzsGGR34NHQ1zVhwxUmFWIQdqDuC13oFS91HDfMmLIT1fC3ZFJKhmMsT3AmCBYv+aKPD1fO6fSQDW2ib/EN7u+ZqcwFcgUeAuINoZPXCtrKaV/JF78BU/AanLYcXbgxJXgbuAlp4WKpoqxj52o5/moUQkyGYyxJcPPOKv6jP+0vJH/R8yhgtdFzjeeHzY8F5Pn5eTdW2sWjQkQdWX+4632PxX4AjOJh+F7kIASmpLWJIah8OMOHajX+7VvrL3qoNBiUtEZCZ/Ba8HvmSMSfYP920H3rTW/mNgQ5s/9lbvxWKHFUicqm+n12uH72K+9ykwTij8aNBiy0nOITUmlf21+3FFObgoJW70WigYnIdSubmIBMlM5qAqrLWfstY2+x//Argwy0KJec1T7cHlcHGJ+5KBa6OOee/rgf1Pw+p3+dYeBYkxhgJ3wbBCiTGH+JIXQ3qe5qFEJGgCMo5krX0UmPZ6qYXCU+1ho3sjMc7BE3PLa30JKr8/QR17HtpqglYcMVSBu4CTF05yoeuCL0GNtRYK/PNQr2oeSkSCImATHTNZ0LsQtHS3cLTh6LD5J4AT1S0sToklMca/21TxE5C8BFZuD3qMhVmFgG8eall6PPVt3bR2jXFIYe7V0HkBqg8FN0ARWZAm3epohpu/rpjGVkfz2r6afXitd9j8E/h2MR/oPTWegvLfw6aPgsM5xneZW+sz1uM0TvbX7CfHv2nsmL2oofvyiYjMsUm3OgKuM8Z8ZyqJyhiTbIz5LvCBqW51NN95qjxEOaIGjlkH8Hot5TVtg/NP+37s+7zpYyGIEOKj41mdtpqS2hKW+9dCnW4Yo5IvZQmkrVCCEpGgmHQ3c2vto8aYFfiO1NgEVOA7B6ocSAUy/J/z/dfu13DfIE+1h0syLyEuKm7g2rmmDjp6+nwJqq/Xl6BWbofUZSGLszCrkF1lu1ic5gLGWKzbL3ebbzGx1xu0UngRWZim9BfGv/nrP1prb8C3IHc3vrOgLuDbjXyntfZ6f3WfkpNfW08bh+sPjzm8B/49+MpehJa3QlIcMVSBu4CO3g5qOitJjY8eu5IP/PNQTVCjeSgRmVvTPiLVn4BOAr8LfDjzy/6a/fTZvlEFEkfPtwCwKisR/vNJSMjylZeH0NBCieXpSydIUEPmobIvGbuNiEgAzGiMxhhzm39e6jZjTHKgg5ovPNUeokzUwG4N/d44WU++O4G0vjo48YKvOGLIFkihsDhhMe44t+8I+PRx1kIBpCyFtFzNQ4nInJvJXnw/AFbiG+K7GTg5i41i5zVPlYd1meuIjx7crby3z8uekw1ckZcB+34C1gubQ1McMdTAgt2aEnIy4jnX2EFvn3fsxgProca5LyISADPpQb3on4/6R2vt9fiKI1YZY/4iwLFFtI7eDkrrSkfNPx16q5m27j6uWJHm29poxTW+HRrCQGFWIWdbz5Ke3Emv1/JWU+fYDXOvho5GqDkc3ABFZEGZdRmWfzfyf8RXzSd++2v202t7RyWo1yvqAbjaeRAunA55ccRQBe4CALqclQCcHGvTWNB6KBEJipkkqApjzB5jzPtHzD/VByqo+cBT7cFhHGzK2jTs+usVvvmn1MNPQ1w6rHlPiCIcbW3GWqId0TT0HQcG9wscJXUZpOb4dl4XEZkjM0lQHwR+BnwYqPQnq58CA+NU2jjWN/+0Nn0tia7B3cp7+7zsqWzk2mUGjv0WCm+BqJgJvktwxThjWJuxluNNpaQnuDhR3TJ+49yr/edDaR5KRObGTBJUOfBza+3N1tp04HZ8a6GuN8bUG2P2APcFMshI09nbycG6g2POP7V29XKTeRm8vbA5fIb3+hW6CzlUd4iVWbEcnzBBbfOd/Ft7JHjBiciCMpPjNh4F0vq3PrLW7rPWPuBfqJsB3AE0BjbMyHKw7iA93h4uzb502HXf/JNl9blfwvKt4F4dmgAnUJhVSLe3m8yMOk7UtGKtHbthruahRGRuzahIwp+UKse5txf40myCinSeKg8Gw6ZFo+ef/iKtgqimk2FVHDFUf6FEVPxpWjp7qW7uGrth6nLfhxKUiMyROdlMzX/S7pQZYzYbY3YYY3bMRTzB5qn2sCZ9DcmuwRqS3j4vnspGPh7zB4hNgXXvC2GE48uKz2JxwmKa7QmASYb5rtZ6KBGZM+Gy2+fd1tpngXRjTHgsCpqh7r5uSmpL2LJoy7Drh8834+xqZEPzH2DjhyA6bpzvEHoF7gJOtfnmlk6MV8kHvnmo9nqoPRqkyERkIQl5gjLG3A7sMcbkWWt3WmsrQh3TbBysO0hXX9eo/fder6jnA84/4vT2hO3wXr+CrALqOmpIS26buJKvfz3UqVeDE5iILCghT1D4dqLIABqMMY8YY1JHNjDG3G6M8RhjPLW1tUEPcDo8VR4AtmQN70G9Xl7Px2JehiVFsGh9CCKbuv6NYxe5qybuQaXlQMpyrYcSkTkRDgkKoNxa2wQU4ytbH8bfsyqy1ha53e6gBzcdnmoPq9JWkRqbOnCtt89LT+WfyPWeDfveE8DqtNXEOmOJSTzD8eqW8Sv5wDfMV/kKTNRGRGQGwiFB7RnydSq+wxAjUo+3h5LaklHrnw6fb+Z93t30RCXA+vDfsjDaEc2GzA20m/KJK/nAV26ueSgRmQMhT1D+4ohUY8x2/+OdIQ5pxg7VHaKjt2NUgtp7rJI/c7xOz7oPQEziOM8OLwXuAmq6K8D0cKJmkgW7oHJzEQm4kCcoAGvt/dba3dba+0Mdy2x4qv3zTyMq+KIOPUuc6Sb+ir8ORVgzUphViNf24Yw9y/HqCeahUnMgZZkSlIgEXFgkqPnCU+0hPyWfjLjBjd37+rwU1f+Kc7GrYfGmCZ4dXja6NwKQmHJ24ko+Y3zVfJqHEpEAU4IKkF5vL/uq940qLz954BXWmFPUXfyhEEU2M+mx6eQk5xCffHbiSj7wr4eqg9pjwQlORBYEJagAOdpwlPbe9lHzTz17HqfdxnDRtr8KUWQzV+AuoDvqJMermyev5AM4pWE+EQkcJagA2VPlK0Yc1oPqamHF+d/yh+htZIV5efxYCtwFdNtmWvtqqGmZoJIvLReSl2oeSkQCSgkqQDzVHnKTc8mMyxy45j34C2JtJ5U5kbnFYP+CXWfcqYn35DPGV26ueSgRCSAlqADo8/axt3rvqOq9zjf+L0e9y1i84W0himx28lPyiY9KwBl/auJKPvAN87XVQt2J4AQnIvOeElQAHGs8RmtP6/DhvaqDxNeW8EzfO7g8L3P8J4cxp8NJgXsjroQzE1fywZD1UNr2SEQCQwkqAPr33xtWIFH8BD0mmr2p15OdEhuiyGavIKsAos9zrKZu4oZpKyBpsRKUiASMElQAeKo9LE1cSnZCtu9Cdzv2wM94wV7O+vyc0AY3S4XuQjCWsguHJ67kM8a/L9+rmocSkYBQgpolr/Wyt2bv8OPdD+/CdDXzo653sG1l5FXvDXWJ+xIAuqIqJq7kA/88VA3UlwUhMhGZ75SgZulE4wkudF0YNv9ki5/kjGMJtelbuGH9ohBGN3vJrmQWx+fijDs9cSUfaB5KRAJKCWqW+vffG5h/qjmKOfM6T3Vdw+euW02UM/Lf4k1Zm3DGneJYVfPEDdPzIOkirYcSkYCI/L+eIVZcXczihMUsTlwMgLf4CXqIoiT93fz5xsUhji4wLl+8CePsZH/VJFsZaR5KRAJICWoWrLV4qjyDw3s9nfTsfZoX+rbw1zcU4XCY0AYYIP0Ldo82lk7eOHcbtFZBffncBiUi854S1CyUN5XT2NU4MLzXe/A/iOm5wJ9S38MN67NDHF3g5CbnEm0Sqe4+NnElH0CO5qFEJDCUoGZh2PxTRyM9L9xDqTeXa9/9lxgzP3pPAMYYlsWvoc9VOXklX0Y+JGbDqVeDE5yIzFtKULPgqfaQFZ/F0qSl9P3XV4juauCH6Z/nHWvmT++p3yWZBThjath39tzEDQfmobQvn4jMjhLUDA3MPy0qwlS8hLPkJzzS+x4+8Gfvnle9p35vz/Gt83rlzL7JG+dug5bz0FAxx1GJyHymBDVDlc2V1HfWc2nmRry/+hynWMxrS2/jqpUZkz85Am1dugmsg0P1JZM31nooEQmAsEpQxpj7Qh3DVA3MP5X/CceF03y+6zY+e/2Gedl7AoiPjifWLuVc55HJG2eshMRFvnJzEZEZCpsEZYzZDuSFOo6p8lR5yHSlsLz4x/zM3EDcym1cnjc/e0/9LopdQ4eppKevZ+KGA/NQf9Q8lIjMWFgkKGNMHhAxExa++ac9FLW10haTxT913Mw/XLc61GHNuXXpl4CjizfOHp68cc5VmocSkVkJiwQF5Flrx/1LZoy53RjjMcZ4amtrgxnXmM60nKGmo5aiC7X8ffutXLk2h03L00Id1pzbutS33usPp/dM3jj3at9nbXskIjMU8gRljNlurd09URtr7U5rbZG1tsjtDv3u4J7j/wlAa9clHE+6gvs+sDHEEQXHlctX4u1JYn/NFAolMldBQpbWQ4nIjEWFOgCgwT//lArkGWM2W2v3hjim8fX18mbJE6QaL493/w1P3HYpGYkxoY4qKNxJsTh7cjndNoUhvpHroeZp8YiIzJ2Q96CstXv9Pah0fEkqrPX96SH20k50+1Ie+Ng7WZmVGOqQgior+mLabQ11HZOcsAuQexU0n4PGk3MfmIjMOyFPUP38w3j54dx7svXlHP2f73I+Kootq97Llfnzu2pvLKtTfQcY7queynoozUOJyMyFTYIKe14vZ566jW9kpBBrErn7mg+HOqKQeGfeJqzXye8r35y8ceZqSHBrPZSIzIgS1BQd/NX/4QXKOBobzb1Xf4P02PRQhxQSb1t1Ed7OJRRXTWHLI2N85ebal09EZkAJagpKjxymr/RBHkpLZfuy67hhxQ2hDilkspJiSTIrqeosm3zBLvgKJZrPQmPlnMcmIvOLEtQk6ls6qf/53/LPWUkkuZK5Z+tXQx1SyG3MLMCaHg7UHpq8seahRGSGlKAm0Oe1PPP49ziafIKjMdHcs/XrC3Zob6jr8y8D4PkTr0/e2H0xxGcqQYnItClBTeCxF97k0paH+UFqKjfkXM/1udeHOqSwcP2ai/H2pPLGW1Och8q9yrdgV/NQIjINSlDj+J/jtWS+9nUecMeSFJPMl6/4SqhDChspcdEksZKz7VPY2Rx8w3wXzkDTqbkNTETmFSWoMZy/0MEvnnmM2oxDHI1xcc/WhVu1N5616RvpdTRS0XB28sb950Od1PlQIjJ1SlAj9PR5uetHr3Cz8zEeSU3lXTnXc13OdaEOK+xsX+Gbh/rlkdcmb+xeA/EZ2pdPRKZFCWqE7z5/lOur/n++544i2ZXMl69Q1d5Y3rt2C9YbzWtnPZM3HroeSkRkipSghnj+4HlKX/0t7Zke39DeVf9EWuz8P0ZjJpJiY0lgBZWt05yHatQ8lIhMjRKU35mGdr76rIe/TfkhO1NTuXH5dWzP2R7qsMLa6pQNdDlPc765efLG/fNQ6kWJyBQpQeE7IffLvzzIHfyUf033kuxK4u4r7wl1WGHvmpxLMcbLE/uen7yxew3EpStBiciUKUEBv9h7jsayN+lN+x+Oxrj42lXf0tDeFHxwwzuxXYv5aeUDlNaVTtzY4fCvh1KCEpGpWfAJqrali+/8+gCfT32MR1OTuXH5dq7NuTbUYUWEpJh4Nrm+gO1L5NO7P03lhcqJn5B7NTSd1jyUiEzJgk9Q//TrQ3yo7z94KK2TFFcSX77y66EOKaJck59H88lb8Vq4c/ed1LbXjt845yrfZ5Wbi8gULOgEtftwNUcOeojL3M2xGBf3bLuX1NjUUIcVUbbmZ2J7Mrl52Tdo6GzgU7s/RUt3y9iNs9ZBXJrmoURkShZsgmrp7OHru0r4fMqj/DAlkXcvu5Zrl2tob7rWZCeRnuCi8lw633v79yhvKudzL32Orr6u0Y0dDq2HEpEpW7AJ6r7/Osq1bb/ih+nNpEQncvfWb4Q6pIjkcBiuzM/g1fI6rlx8Jd/a9i32VO3h7j/eTZ+3b/QTcq/27cnXdDr4wYpIRAl5gjLGpBpjNhtjdhhj7gvGa+6pbODlN4rJzPotx2NcfG3btzW0NwtX5WdS3dxFRV0b78l7D3cV3cWLp17kO29+BztyB/Nc/zyUjoEXkUmEPEEBNwNF1tpnAYwxt8/li3X29PGlZ0v4XPKjPJ4Sz58tfQfvzHnnXL7kvLc1PwOA18rqAPj4+o/zifWf4KfHfsrOAzuHN85aD7GpGuYTkUmFPEFZa3daa/v/iuUBFXP5eg+9VEZh4294JqOO1KgE7t72rbl8uQUhJyOeJalxvFpWP3Dt77f8Pe/Jew//tv/f+MXxXww2djh8u0poPZSITCLkCaqfMSYPaLDW7p6r1yg9d4Gfv1zMsqxdvqG9q79DSkzKXL3cgmGMYWt+Bn+qqMfr9Q3pOYyDb171Ta5achXffP2bvHT6pcEn5FwFjZXQdCY0AYtIRAibBAXssNbeMdYNY8ztxhiPMcZTWzvBOpsJdPd6uevnJdyZ9ChPpsTy50uu4R0a2guYrSszuNDRw+Hzg/vyRTui+V/X/C/Wpa/jC//zBfbV+E/g7d+XT+uhRGQCYZGgjDE7rLX3+7/ePPK+fxiwyFpb5Ha7Z/Qa//b7EyyveZFfZb5FelQ8X7r6n2cZtQy1NT8TgFf981D94qPjeWj7Q2QnZPOZ332GssYyWLRB81AiMqmQJyhjzHbgPmNMsTGmGAj40bUHz17gRy+XsDr7Z5xwufja1d/W0F6ALUqOZe1Fyfxy37lRlXvpsen8YPsPiHHGcOfuO6nqqNF6KBGZVMgTlLV2t7U231q7xf8R0Dmort4+7vp5CXckP86Pk6N570XbeLuO0ZgTt21bwdGqFn53pGbUvaVJS/nB9h/Q1tPGHS/ewYVlW6DxJFw4F4JIRSQShDxBzbV//d0JMur+yAsZFWQ44/jiNd8NdUjz1nsLF7MsPY7vv1Q2ev0TcHH6xfzrO/+VMy1n+Nv6V+kwRvNQIjKueZ2gSs408dQfDlOY/RPKXC6+rqq9ORXtdPCpa1ZScqaJV0bMRfW7NPtS7nvbfZQ0lfHF7Gx6T/4hyFGKSKSYtwmqs8c3tPc3yT/i6SQH7110JW/L1dDeXPvAliVkJ8fyb78vG7fNdTnX8ZXLv8LLsdF8s+aPY/a2RETmbYL6P787QULdHl7OOEKGM5YvvuOBUIe0IMREObn9bXm8cbKBN082jNvug2s+yB3pm/mly/L9N74TxAhFJFLMywS173Qjj//hKJcvfpJyVzRf3/bPGtoLog9ftpyMBBff//2JCdt9ZvP/xweaW3n02L/z9JGngxSdiESKeZegqps7+fRP9vLx1Gf4aaLlfe7LeNuKG0Id1oIS53Jy29V5/PFEHSVnmsZtZy7ayFdb+3h7dCbfffO7vFD5QvCCFJGwN68SVFtXL3/9xB4WdRzjjfT9ZDhi+OL2/x3qsBakj16xnOTYKB56afy5KBxOonKu5IG6JgqzCrn7j3fz5vk3gxekiIS1eZOgevu8/N2/7+NEVRNbl/yQclc037jqWyS7kkMd2oKUFBvNrVet4L8PV3O0qnn8hrnbiG2o4PuXfoWc5Bw++9JnOVJ/JHiBikjYmhcJylrLN587zO+P1vDP61/kJzFd3JSxiavz3x3q0Ba0W6/KJcHl5KGXysdv5N+XL+X8QR7e/jBJriQ+tftTnGnRRrIiC928SFA/fOUkT/3pFP9QZPlJx4tkmmi+cN33Qx3Wgpca7+KjV+bw3IG3qKhtHbtR9kaISYbKP5KdkM0j2x+hx9vDnS/eSX1H/djPEZEFIeIT1AuHqvjn3x7hxnVZeFu/TXl0FN+48hskq2ovLNy2LQ+X08HDL4/Ti3I4YfmVA/vy5aXm8dC1D1HTXsNnfvcZ2nvagxitiISTiE5QJWea+Nwz+9i4NJVPLvtvHqeZ96ddwtWr3xfq0MTPnRTDhy9bzi/3neNkXdvYjXK3QX0ZtFQBUJhVyAPXPMDRhqP8/ct/T09fTxAjFpFwEbEJqqa5k7950kNmYgwPvzeTb5b/BLeJ4gs3/CDUockId1yTR7zLyUcfe4PT9WP0iHKv8n0esrv525e9na9f+XVee+s17nntHrzWG6RoRSRcRGyC+pnnDHWtXTz2V1v42Ut3UB7t5BuXf5WkGFXthZuLUuJ4+pNX0Nbdywd3/ml0Tyq7AFxJo47feP+q9/PZTZ/lNxW/4V88/xLEiEUkHERsgnruwHmKctLoOfUEj3vr+IvkNWxbsyPUYck4NixJ4enbrqCr18sHH/kTZTVDiiacUZBz5ZjnQ912yW3csuYWnjr8FE+UPhG8gEUk5CIyQR2vbuFoVQs3rXHw1UM7cePkrhsfDXVYMol1i5N55vYr8Fr40M7XOV7dMngzdxvUn4CW6mHPMcbwpcu+xA25N/Avxf/Cr8t/HeSoRSRUIjJBPVfyFg4D58/dQ0WUg3+69B9Jik0NdVgyBasXJfHM7VfgMPDhna9z5Lx/EW+Obz0Up0b3ohzGwbe3fZvLsy/na69+jVfO6SRekYUgMhPUgfP85dLX+HHveT6QuJKr1n841CHJNKzMSuSnd1xJtNPBhx99ndJzF+CiAnAljnsMvMvp4nvv+B4r01byDy//A6V1pUGOWkSCLeISVEdPHzX15zkcu4ss6+DzNz4W6pBkBlZkJvDTO64gwRXFh3a+zo/2nMMuH3seql+iK5GHtz9Memw6n979aSovVAYvYBEJuohLUBfae7hi0cNURjn4p82fJyk+I9QhyQzlZCTwszuvZOPSFO7ZVcpT55dC3XForRn3OZlxmey8bifGGO7cfSe17bVBjFhEgsmEw2mmxpgdQBOQZ63dOVHbjKUX2aX3ZvD++Fy+cfNzQYlP5pa1ll/uO8eu5/6Tp7xfpssRT3RiOo6YJIhJgphE32fX4NeHvB3c+tbzLItJ44kNnyEp3u1vO+QjKhaMCfWPJxIWjDHF1tqiUMcxHSFPUP7khLX2WWPM7UCFtXb3eO1TcuPsZV/L55cf/D2JCVlBi1PmXlNbJ6/86JvUni0jK6aHSy+KIsvVA10tgx/drb7PWF6Li+Uzi9wUdnbxg+oaYkb+Khvn8ITlShxMeK6RyS/RtyfgsMdDnhcdp2QnES0SE1RUqAMALgV+6v+6AtgMjJugug3cvf7TSk7zUGpCLO+589u8ebKBr/zyICfKWlmSGkeUc0hiiALj9BJLF3G2g8UXPHhSn2PrsouJsk4cWAwWgxcHFof1fW3owEE7pqsKR1d/G4uDqe5Q4fsu/c8UkbkXDgkqdcTjUZNK/p7V7QDuZYm88/JPByEsCZXLVqTzm89ezZOvVXLorQuTtM4jqW8Z9Y6SKX9/6/8A6MPisH04bS8OfJ+dA4+HfO3/7KR3yLNFZC6FQ4JqAtInauCfl9oJUFRUpL8OC4ArysEn35Y3xdab5jQWkfngsTsir+cfDlV8exjsReUBL4YuFBERCRchT1DW2meBPGPMdiB1ogIJERFZOMJhiA9r7f3+L5WcREQECIMelIiIyFiUoEREJCwpQYmISFhSghIRkbCkBCUiImEp5HvxTZcxpgU4Fuo4wkQmUBfqIMKE3otBei8G6b0YdLG1NinUQUxHWJSZT9OxSNvwcK4YYzx6L3z0XgzSezFI78UgY4wn1DFMl4b4REQkLClBiYhIWIrEBDXhgYYLjN6LQXovBum9GKT3YlDEvRcRVyQhIiILQyT2oEREZAEI6wRljNlhjNnuP7Bw2vfnkym+FwviqJKJ3gtjTKoxZrO/zX2hiC+YpvB7sd3/seDfiyHtFvx7YYxpNMa8aIz5YrBjm46wTVDGmB0A/cdv+I/jmPL9+WQqP6v/2JJ5bwrvxc1AUf/7MZ//8TKF/0c2A5v99zcbY6Z6AmTEmerfA//1efs+wJTfi7+01l435CSJsBS2CQq4FKjwf10BbJ7m/flkIf2sk5nwvbDW7vSfwAy+P0QVzF+TvRd7rbX3G2NSgQpr7YJ9LwD8CXo+vwf9pvL3IjUS/sESzgkqdcTjjGnen09SRzyezz/rZFJHPB7zvfD/z9cwzw/ATB3xeLzfiyKgfG5DCbnUEY/Hei/y5nmS7pc64vFY70U60GCMeWTuw5m5cE5QTfjexJnen0+aWDg/62SamNp7scNae8ccxxJqTUzhvfAn6fz+oZ95qokJ3gtjzPZ5/o+VoZqY5PfCP9LQBDSF8+9FOCeoPQz+SyAPGFkAMNn9+WQh/ayTmfS9MMbs6B9b98/DzFcTvhfGmPuGzME1Mb//kTPZ70WDv2hgB5C3wH8vbo+Unz9sE5R/kjvPP8GXOmTC78WJ7s9Hk70X/q+3A0Xh/K+hQJjsvfBfv88YU2yMKWYe/1Gewu/FI0DFkPsRt1Bzqqbw92Kv/1o6o4fA5pUp/F78zP94x5D2YUkLdUVEJCyFbQ9KREQWNiUoEREJS0pQIiISlpSgREQkLClBiYhIWFKCEhGRsKQEJSIiYUkJSkREwpISlIiIhCUlKJEAMMbkGWPKh2y5NK/PXxIJBiUokcD4EnAdsNd/YmvRAjnaQWTOaC8+kQAwxqRaa5v8hwMWzefNi0WCRQlKJED6jzCw1u4NdSwi84GG+EQCwH90QUV/cprvx56IBIMSlMgs+Q8FzAMeNcak+uegmkIblUjkU4ISmQV/pV6F/wTfCuAkUK45KJHZ0xyUiIiEJfWgREQkLClBiYhIWFKCEhGRsKQEJSIiYUkJSkREwpISlIiIhCUlKBERCUtKUCIiEpaUoEREJCz9PxH0w9l9o49SAAAAAElFTkSuQmCC
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA6mElEQVR4nO3deXib1Zk//O+RZNmWN1m2FGfxEtvZnMVK4rAkTmlpgKHDtOmUpWW6MWXC0nnb6TSlG3QBurD09/Y3HV5KoMNWOkDTIVMoLcUtUAIEIidx4jibt8RxYkved9mSzvvHI3m3Jdmynkf293NduWw9z5F1R7F955xzn3OElBJERERao1M7ACIioskwQRERkSYxQRERkSYxQRERkSYZ1A6AiIjCV15ebjMYDE8AWIfY7mz4AFR6PJ5bN2/e7Bx9gwmKiCgGGQyGJ7KystZYrdZ2nU4Xs+XYPp9PuFyuoqampicAfHz0vVjOukREC9k6q9XaFcvJCQB0Op20Wq2dUHqCY++pEA8REc2eTuvJqaqqynjttdfmB2vn/3tMyEdMUERENCeKiooGn3322bMzfT4TFBERzYmqqirjyZMn42f6fBZJEBHFuG/srcg+3dRtiuTXXJmV0vfQ9cUN07V5+OGHMy+77LK+AwcOmHbv3t3y5JNPpr/44ovpN954Y3tNTY3x5ptvbr/rrruWvvvuu2daWlr0P//5zzNLSkr6HA6HyWw2e3fv3t0y3ddngiIiorDdfffdi0pKSvpKS0v7Wlpa9A8//HDm7t27W773ve8t/eMf/1gbaJeWluYFgP3795vMZrN3586d3Y899ph1dJupMEEREcW4YD2duVBeXp508803twPAypUr3Y899ph19+7dLevWreubrP3OnTu7H3744fh9+/al/OxnPzsfymswQRERUdg2b97ce/r06fiioqLB06dPx2/evLl3uvb79+83fexjH+sqKioaDPU1WCRBRERhu//++5sdDodp3759KQ6Hw3T//fc379u3L6WystK0f/9+E6AkpcrKSlNVVZWxtLS074Ybbii49tpr8++4446lLS0t+mCvIXgeFBFR7KmoqKgvLi6etshAS+6+++5F//Zv/9aSmZnpraqqMv7iF7+wPvroo42B+xUVFZnFxcV5o5/DIT4iIppzJSUlfS+//HJqenq6p7293fBP//RP7cGewwRFRERzbufOnd3hPodzUEREpElMUEREpElMUEREpElMUEREFDF33HHHUkDZBmn09UDpeTiYoIiIKGKee+45a3Z29rrCwkJ34Nq+fftSbrvtttxwvxYTFBERRcwzzzxT09DQUDm6am/nzp3daWlpnnC/FsvMiYhi3b4vZ8NZFdHdzGEr6sPOR6bc42+q3ckdDocJAAK7S8wmBPagiIgobKN3Jy8vL08KHJ1x//33N+/cubO7tbXVsG/fvpTZvAZ7UEREsW6ans6cveQku5M/+eST6QBwyy23tGdkZHiqq6vjAYS9QDeACYqIiMI22e7kK1ascK9evdoNALW1tQl33nmnazavwQRFRERhKy0t7Vu7du2anJwcd15envu+++5rKi0t7Xv44YczMzIyvPn5+QOlpaV9gNKzqqysTHryySfTb7nllqB78AVwN3Miohik9m7mwXYnDxd3MyciooiYye7k4WKCIiKisM1kd/JwscyciIg0iQmKiIg0iQmKiIg0KebmoDIzM2VeXp7aYRARqerBBx9EVVVVyBuwut1uz8aNGyvmMiZgZBfzmpqa+NFVffv37zcFys5DFXMJKi8vDw6HQ+0wiIhUdeLECaxZsybk9pWVlYPBW83Ovn37UgKLd6+99tr8ffv2pezcubN73759Kd/97neXHT9+/EQ4X49DfEREFBHV1dXxr776aioA5OXluf1bHXE3cyKiheqBDx7AybaT07bp6e1JMNQbVoX6NQvTC/vu23Zf2LuZB+5XVFSYZrs2ij0oIiIK21S7mQfuXXnllV3hzjmNxx4UEVGM++Yl3wzaprKycmDdunWnIvWak+1mHvCnP/0pZbZnQQHsQRER0QwEdjPfuXNn9+gdzR9++OHMQHKa7XlQTFBERBS20tLSvhtuuKHg2muvzb/jjjuWtrS06Pft25dy7733LsvOzl6XmppqD7QdvZt5OK/BIT4iIgrb3Xffveitt946HdjN/J577sl69NFHG7u6uo6Mb3vLLbe0h3PMRgAT1DzQNTCElw414p8uzYFBz04xEc097mZOIXnm3Xo8/OfTMJvi8An7UrXDIaIFgLuZU0heOXoRAPCr/XXgAZREC8d8+Xn3+XwCgG/8dVUSlBBi0xTX74p2LLGu2tmNk03dWLskFUfPd6L8bMR72USkQQkJCWhtbY35JOXz+YTL5UoDUDn+XtSH+IQQOwA8AGDzJNe3RDueWPfK0YsQAnjk5k34xCPv4Ff761CSZ1E7LCKaY8uWLcP58+fhcrlCat/U1GTwer2ZcxzWTPgAVHo8nlvH34h6gpJSlgkh2qL9uvORlBKvHL2IS/IsyMtMwmcuycGev9Wgoa0P2RaT2uER0RyKi4vD8uXLQ25fVFR0TEpZMochRZwm5qCEEJuklGVqxxFrTjV3o9rZg+uKlwAAvrA1Fzoh8PS79eoGRkQUAZpIUAA4JjUDr1RchE4Af7c2CwCwOC0RH1u/GC8cbECPO+yNg4mINEX1BBVK70kIsUsI4RBCOEIdb53vpJT4w7GLuLwgA9aU+OHr/1y6HN1uD148OOUmxEREMUH1BAUgXwhxvRDiev/nEyr8pJR7pJQlUsoSq9WqQojac/xCF+paenHdhiVjrtuzzdicm46n3q2H1xfb1T1EtLBFPUH5E1GJ/yOklHullHuhDPOZox1PrHrl6EXodQLX+If3RvtS6XKca+vDX07MejNhIiLVRD1B+RNSuj8pjb6+R0pZIKU8FO2YYo0yvHcB2wozYUkyTrh/ddEiLDUn4lf761SIjogoMrQwxEdhOnq+Exe9+5Gx5L1J7xv0Onxxax7er2tDZWNnlKMjIooMJqgY9MrRC4jPeBMH2p6HT07YHQQAcOOWbJiMevzXO+xFEVFsYoKKMT6fxMuVp6GLd6FnqAe1HbWTtktLjMONJdl4ueICnN0DUY6SiGj2mKBizOGGDrR4Tgw/PuI6MmXbL27Ng8cn8ev3zkYhMiKiyGKCijGvHL0AY3I9Eg2JSI9PxxHnkSnb5mUm4cMrrXjpSGP0AiQiihCeBxVDfD6JV49dRPLSs9ho2wij3ogKV8W0z9mYk443T7vQP+hFolEfpUiJiGaPPagY4jjbDmdvG/rRiJJFJbBb7ajvqkf7wNRHbBTakiElUNvSE8VIiYhmjwkqhrxy9AISUpT5pJKsEhRbiwEAR11Hp3xOgTUZAFDtZIIiotjCBBUjlOG9JuQsuYgEfQLWZazD2sy1MAjDtMN8eZkm6ARQ4+qNYrRERLPHOagYcb69Hy09bqQZq1FsKUacPg5xiMMqy6ppK/niDXrkWEyocbEHRUSxhT2oGFHt6gZ0fXC561GyaOTMMbvNjsqWSnh8Ux+vUWBNRg2H+IgoxjBBxYhqZw/0pnpIyDEJqthajH5PP063n57yuQW2ZNS29HJ3cyKKKUxQMaLG2YvktLMw6oxYb10/fN1utQPAtOuhCq3JGPT40NjeP8dREhFFDhNUjKh29cCYXI9iWzHi9SMHFGYlZcGWaJu2UKLAluT/Gt1zHicRUaQwQcUAKSXOuFowoDs3ZngPAIQQKLYVT5+g/KXmNU5W8hFR7GCCigEtPYPoFWeAcfNPAcXWYjT2NMLZ55z0+WaTEZnJRlbyEVFMYYKKAUqBRB0MIg4brBsm3Lfb7ACmX7Cbb03mYl0iiilMUDGg2tUDQ1ItVqUXIcGQMOH+GssaGHXG6QslbMnsQRFRTFElQQkhNo17vMv/5wE14tG6k80u6BIasXXpJZPeN+qNKMoomnbBboE1Ge19Q2jtcc9RlEREkRX1BCWE2AHg8XGPy6SUewDk+x/TKJWtFRDCh5KsifNPAXabHVWtVRj0Dk56v8CqVPJxyyMiihVRT1BSyjIAbaMu5QMIJKVa/2MapaGvEgL64TVPkym2FmPIN4Sq1qpJ7xfa/JV8HOYjohih+hyUlHKPv/cEAJsAONSMR2t63B4M6M/AZiyAKc40ZbvAzuZTlZsvSUtEQpyOhRJEFDNUT1AB/nmp16WUh9SORUuqLrZAl3geRZZN07azmqxYmrx0ygSl0wkUZiQi8dwbgOSWR0SkfZpJUAB2SCkfnOyGv4DCIYRwuFyuaMelqrfOHoQQXpQum7xAYrRiazEqnBWQUySgz8W/id3O7wD1b0c6TCKiiNNEghJC7Aokp8mKJPzDgCVSyhKr1Rr9AFV02FUOKXW4uuCyoG3tNjuc/U5c7L046f2P9LwKAPBUvxnJEImI5oQaVXzXAyjxfwwkpAeEEDVCiKnPLl+g6nsrEedZBnNCStC2gXmoSddDXTgMW+8p+KSAu4Y9KCLSPjWq+PZKKdOllHv9j8v8jwv8H8uiHZNWub1udMsa2OKKQmq/Mn0lEg2Jk89DlT8NnyEBz3s/jATnYWCwL8LREhFFliaG+Ghy5U1HAOHBarM9pPYGnQHrMtdNXLDr7gGO7YUs+iTKZAn0viHg/MFIh0tEFFFMUBr21/r3IKXAJUs2h/wcu9WOU22n0Dc0qod0/H+AwW7oS76Ii2kb4YMOOPvOHERMRBQ5TFAa5mhywOdejPWLs0J+jt1mh1d6cbz1+MjF8qeBzFVA9qVYbLOhWp8P1O+fg4iJiCKHCUqjBr2DqO85AW/v8uHznEKxIVPZ7Xx4Hqr5ONDoADZ/ERACBdYkvD20GvL8QWCIJ+wSkXYxQWlUZUslvBhEqliNpHhDyM8zJ5iRl5qHCqc/QZU/DeiNQPGnAShbHr3jWQ3hHQTOc9MOItIuJiiNcjQ7AClQmLo+7OcWW5UTduVgH3D0eWDNxwGTBYCyq7nDtwpS6DjMR0SaxgSlUQcvHoQczMJqW+jzTwF2mx3t7nacO/IUMNAJbP7C8L0CazK6kISW5FVMUESkaUxQGjTkG8Jh1xEM9S4f3oU8HMMLdo8/D1jygbztw/fSk4zISDLiZPwGpdR8aCBicRMRRRITlAYdbzkOt3cA3r7lKAyjQCKgwFyAZIMJFT3ngE1fAIQYe9+qzEPB61YKKIiINIgJSoMczUrS8PbNrAelEzoU65JwJCEBsN884X6BLRl/6FwOQAB13PaIiLSJCUqDHM0OJOuWIi0+HZYkY/hfwONGcet5VBvj0G1MnHC7wJqEhn4jPLZ1XLBLRJrFBKUxHp8Hh5sPwzBYiEJrMsS44bmQnHwFxT2dkACOtRybcLvA3ytrybyE81BEpFlMUBpzovUE+jx96O7ImdHwHgCg/GlsiLdBQIyshxolMK91OrEY8AwAjeWzCZmIaE4wQWlMYP6ps22GCaqtFqh7C8mbPofC9MJJdzZfalaOf//AuwqAYLk5EWkSE5TGOJodyErMgfSmDA/FheXQs4DQARs/O7xg1yd9Y5rodAL5mcmobNcBWet4wi4RaRITlIZ4fV4caj6ErHjl/KewS8y9Q8DhXwMrrgFSl8ButaNnqAc1HTUTmhbYklHj6lHWSJ0/CHjckfgrEBFFDBOUhpxqP4WeoR7ED61AYpweS80TK/CmdfpPQK9zeOcIu80OAJMO8xVYk3C+vR+Dy7ZyHoqINIkJSkMONimHCPZ05SLfmgSdLswKvvKngZQlQOFVAICclBykx6dPegR8oS0ZUgK1pg3gPBQRaZEqCUoIsWnc4+uFEDuEEHepEY9WOJodyE7JRoMzLvwCiY4GoLoM2PhZQK/sfi6EGJ6HGi9whMeZ7jhg0TomKCLSnKgnKCHEDgCPj3q8CQCklGUAOsYnr4XCJ3041HwIdusmNHb0h3UGFADg8LPKx02fG3O52FaM+q56dAx0jLm+PDMJQgDVzh4grxRo+IDzUESkKVFPUP5E1Dbq0k0AOvyf1wLYEe2YtOBM+xl0DXZhWcI6AAivB+XzKsURBVcC5pwxtwIbxx5tOTrmekKcHkvSEnG2tRfI2wZ4+oHGQ7P7SxARRZAW5qDMGJuwMlSKQ1WB9U8m30oAYSao6jKgq1E5NXectRlroRf6SeehcjNMONvWB+RuUy5wmI+INEQLCYoAOJocWJq8FC0dSdDrBPIykkJ/cvnTQJINWHXthFumOBNWWVbhiOvIhHs5FhMa2vqUwwwXrQPOMkERkXZoIUF1ALD4PzcDaB3fQAixSwjhEEI4XC5XFEOLDiklypvLsXnRZlQ7e5BrMcFoCPGfpuuiUl5uvxnQx03axG61o7KlEh6fZ8z1nAwTWnoG0eP2KPNQ594HPIOz/esQEUWEFhLUCwDy/Z/nAygb30BKuUdKWSKlLLFarVENLhpqOmrQ7m5HyaISVLt6wttB4sivAekFNn1+yibF1mL0e/pxuv30mOs5FhMA4Fyrf5jP0w9c4DwUEWmDGlV81wMo8X+ElPKQ//oOAB2BxwvJwWZl/ZPduhn1Lb2hzz/5fMrWRnnbgYyCKZtNtWA316IMI57jPBQRaZAaVXx7pZTpUsq9o67tkVKWSSn3RDseLXA0ObDItAgedzo8PokVoSaoujeBjrOTFkeMtjhpMayJ1gmFEsM9qLZeICkDsK1lgiIizdDCEN+CJqWEo9mBkqwSZW88hFHBV/4UkGgB1vzDtM2EELDb7BN6UGmmOKQlxik9KEApN2/gPBQRaQMTlMrquurQNtCmzD85lQQV0iLdHhdw8lWg+DOAIT5o82JrMRp7GuHqG1tkkpthwtnWQIIqBYb6gAuHw/57EBFFGhOUyhxNyvqnQIJaak5EUrwh+BMrfgP4hoY3hg0msGB3fC8q22Ia6UEF5qFYbk5EGsAEpTJHswPWRCtyU3NDr+CTUln7lH0ZYF0V0usUZRQhThc3SaGECY3t/fB4fUBSJmAr4jwUEWkCE5SKpJQobypHyaISSKnsixfSGVD1+4G2mqDFEaMZ9UYUZRRNWijh8Ulc7BxQLuRuA84dUM6WIiJSEROUihq6G+Dsd6IkqwSNHf0YGPKFViBx6GkgPg0o+kRYr2e32lHVWoVB70gRRE5GoJKP81BEpC1MUCoK7L8XWKALACsWBUlQfW1A1e+BDTcCRlNYr1dsK8agbxAn2k4MX8v1b6k0XCjB9VBEpBFMUCo62HQQlgQLlqctR42/gi/oEF/F84DXHXJxxGjDhRLOkXmorNQExOkFzrb1KheSrYB1DRMUEamOCUolgfVPmxdthhACZ5p7kJFkRHqScbonKcN7SzcDWevDfk2byYalyUvHbByr1wlkp/s3jQ3I4zwUEamPCUoljT2NaOptQsmiEgAIrYKv4QPAdRLYFH7vKWCDdQMqnBWQUg5fy7aMWgsF+OeheoELR2b8OkREs8UEpZLh+aesEkgpUe3sCb7F0aGnAWMysO5TM35du9UOZ78TTb1Nw9dyM0w419o3krRyS5WPXA9FRCpiglKJo8mBtPg0FJoL4epxo7N/aPoKvoFOoPJ/lOQUH+Zx8KMU25R5qNHDfDkWE7rdHnT0+Yf0kq1A5irOQxGRqpigVOJodqBkUQl0Qje8xdG0Ceroi8pxGGGsfZrMyvSVSDQkjlmwG9g09mzbuGG+cwcAr2f8lyAiigomKBU09TahsadxeP4pUMG3wpYy+RMCO0dkrQeWbJzVa8fp4rA2Y+2YBbuBUvNz4xPUYA9wsQJERGpgglLBwSbl/KeSLH+BhLMHyfEGLEqdYtPXC4eA5mNKcYQQs359u82OU22n0O/pBwBkWxIBAOdae0caDa+HenvWr0dENBNMUCooby5HijEFK8wrAABnnEoFn5gq+ZQ/DRgSlcW5EWC32uGRHhxvOQ4AMBkNsKbEj+1BpSwCMldyHoqIVMMEpYKDTQex2bYZep0eQJA9+Nw9QOXvgHX/CCSkReT1N1g3AJhYKDGm1BzgPBQRqYoJKsqcfU6c6z43PLzXNTAEZ7d76gKJyt8pc0GzWPs0XnpCOvJS88YUSuSOPnYjIK8UGOwGmjgPRUTRxwQVZaPPfwIwXME35RqoQ08rWw9lXxLROMYv2M3JMKGpawADQ96RRoH1UBzmIyIVMEFFmaPZgaS4JKyyKOc4VTdPU2LedAxoLFf23YtAccRodpsd7e52NHQ3AFCG+KQEzrf3jzRKWQRkrADq34noaxMRhSKEo1vHEkLkAdgEwALADKAWQIeU8q8zDUIIcT2ADgD5Uso9M/06scDR7MBG20YYdMpbX+3qgdGgQ7Zlkp3Jy58G9PHAhpsiHkdg49gjriPISc1Brv/YjYa2vrHJMq9UGWb0egB92N8uREQzFnIPSgjxDSHEnwE8AKAAgADQ6f/8aiHEn4UQjwoh7OEEIITYBKBWSlkGoNb/eF5q6W9BXWcdtmRtGb5W7exBfmYS9LpxPaTBPmVxbtEnAJMl4rEUpBUgOS55eD1UjiVw7Ebv2IZ5pYC7C2g6GvEYiIimE/S/xEKI5QBuA/C8lPKhIG3TAOwSQpRIKZ8II44HAFwFpQdVFsbzYkp5czmAkfknADjj7EbxMvPExlX/C7g7Z3SsRij0Or0yD+UvlMhMNsJk1I/dTQIYez7U0nn7fwci0qBpe1D+5PRRKeW3pJRHgn0xKWWnP4n9RQhxaygBSCkPQek51QBoC+U5scrR5ECiIRFrMtYAAAaGvDjf3j/5/FP5U0BG4UiCmAPF1mKcaT+DnsEeCCGQYxl37AYApC5W4jjLeSgiiq5pE5SUsi7MnlDYzxNCmKHMPz0G4HEhRP4kbXYJIRxCCIfL5Qo3HM0IzD/F6eIAADWuHkg5SYGE8yTQcADY9PmIF0eMZrfaISFxrOUYgEmO3QjIKwXOvgv4vBPvERHNkbCr+IQQqRGOYReAn0gpHwRwA4DrxzeQUu6RUpZIKUusVmuEXz462gfaUd1RPWZ4r3qqPfgOPQPo4oDim+c0pvXW9RAQwwt2A2uhfD45tmEu56GIKPpmUmZeMLoQQgixXAhxZSSC8c8/dUTia2nN8PxT1tgEpRNAXuaoCj6PG6j4b2D13yvHXsyhFGMKCswFw/NQuRkmuD0+uHrcYxvmBeahOMxHRNETdoKSUh4GsMVfbg4pZR2AdCHET2YSgL/ntEsIcb0QYtd8LTN3NDuQoE/Auox1w9eqnT3IzUhCvEE/0vDEy0B/25wVR4xnt9lx1HkUPukbLnWfMMyXugSwFHDBLhFF1UyG+F4AUAOgfdRwXxmUoboZkVI+KKXcO1+TE6AUSBRbixGnjxu+Vu3sQcH4PfjKnwLMOcDyD0clrmJrMbqHulHbUTv5sRsBnIcioiibyRDfZgAOKWUnAOEvLd8B4KcRjWwe6XR34nT76THDe0NeH+paerFi0agE1VqjHG+x6fOALjqbfNitdgBAhasCS82J0Ilxx24E5G1Xyt6bjkUlLiKimfwWvAH+3pI/SVkApAdbI7WQHWo+BAk5pkDibGsfPD45dhfzQ88AQg/YPxu12HJTc2GON+OI6wiMBh0WpyVOXAsFjMxDsdyciKJkRnNQUsqHRz2uA1Ae7g4SC4mj2QGjzoj11vXD1yYc8+4dAo78Blj5d8raoygRQqDYWjymUGLSIb7UJYAln/NQRBQ1ERlH8hdO1EXia81HjmYHNlg3IF4/cmJujUtJUAWBBHXqj0CvM2rFEaMVW4tR11mHTnenkqAmWwsF+Oeh3uE8FBFFRcQmOvzDfTRO92A3TradHDP/BABnmruxJC0ByfH+3abKnwJSlwKFO6Ieo91mB6DMQ2VbTGjtHUSPe5JDCvO2AwOdQPPx6AZIRAtS0K2OQt2yKBLPm48OOw/DJ31j5p8AZRfz4d5T+1mg5q/Axs8COv0kX2Vurc1YC73Q44jzCHL9m8ZO2osavS8fEdEcC7rVEZR99X4ZymJcIUSqEOIbUPbvC3uLpPnI0eSAQWcYPmYdAHw+iRpn78j80+FfKx83fk6FCAFTnAkr01eiwlWBHP9aqHNtk1TypS0F0pczQRFRVATdzdyfpG4XQvyLEOJbACSAQwBa/U0yoJwLVQBlfdSD/ucQlPmn9ZnrkWhIHL7W2NGP/iGvkqC8HiVBFe4AzNmqxWm32bGveh+WpBsBTLJYNyCvVFlM7PNFrRSeiBamkH/DSCkfl1JeDeBGKAtz66CcB+UAsEdKebWU8g4mpxG9Q72oaq2adHgP8O/BV/060H1BleKI0Yqtxej39MM5UA+zKW7ySj7APw/VATg5D0VEcyvsI1L9xRB/mYNY5p0jziPwSu+EAomTF7sBACtsycD/Pg0k2ZTychWNLpTIsSybJkGNmofKWj95GyKiCJjRGI0Q4lb/6bm3zsHu5vOGo9kBgzAM79YQ8H5dKwqsSUj3tgBnXlOKI0ZtgaSGJUlLYE20KkfAW6ZYCwUAacuA9DzOQxHRnJvJXnw/BVAIZXjvRgB1QogvRTqw+cDR5EBRZhFMcSO7lXu8Physa8Nl+RnA4ecA6QM2qVMcMdrwgl1nBXIzTGhs74fH65u88fB6qCnuExFFwEx6UAf9J+x+yz8nVQBghRDiHyMcW0zr9/SjsqVywvzT8Qtd6B304rLl6crWRsuvUHZo0AC7zY7zPedhSR2AxydxoWNg8oZ524H+dsBZFd0AiWhBmXUZlpSyQ0r5LSjVfOR3xHkEHumZkKAO1CrFj9v1x4DOc6oXR4xWbC0GALj19QCAusk2jQW4HoqIomImCapWCHFQCPGRcfNPrVM+YwFyNDugEzpstG0cc/1ArTL/ZK76DZBoAVZfp1KEE63JWIM4XRzavKcBjOwXOIE5GzDnKjuvExHNkZkkqJsAvAjgDgD1/mT1GoB8IUQKAHC4T5l/WmNZg2TjyG7lHq8PB+vb8dFsAZx6FbDfDBjip/kq0RWvj8eajDU43VEJS5IRZ5q7p26ct91/PhTnoYhobswkQdUA+K2U8kYppQXK0RtlAK4GcFYIcQbAAxGMMeYMeAZwrOXYpPNPPW4Pdoo3AZ8H2KSd4b0Au9WO4y3HUWhLwOlpE1SpcvKv60T0giOiBWUmx208DuWI9zz/48NSyof8C3UtUHpYC3qx7rGWYxjyDWFL1pYx15X5J4mVjS8BOVsB60p1ApyG3WbHoG8QmRktOOPsgZRy8oZ5nIciork1oyIJf1Kqn+LeIQDfDOfrCSE2CSGuF0JcP5N4tMbR5ICAwMZFE+ef/jG9FoaOOk0VR4wWKJQwmM6he8CD5i735A3NOcofJigimiNzspma/3yocNwmpdwLZR5r01zEFE2OZgdWW1Yj1ThSQ+Lx+uCob8cX4t8CEtKAok+oGOHUbCYbliQtQZc8AwBBhvm2cz0UEc0Z1Xf79PeaagBASvmgvwcWswa9g6hwVWDzos1jrldd7ILe3Y51XW8BGz4NxCVO8RXUV2wtxtleZW7pzFSVfIAyD9XXCrhORikyIlpIVE9QALYAyPAP892ldjCzdazlGNxe94T99w7UtuJT+reh9w1pdngvoNhWjJZ+J9JTe6ev5Aushzr7TnQCI6IFRQsJCgBaAz2nyeahhBC7hBAOIYTD5XJFP7owOJocAIDNtrE9qAM1rfhc/JvA0hJg0VoVIgtdYOPYRdam6XtQ6blAWg7XQxHRnNBCgqoBUOv/vBZKj2oMKeUeKWWJlLLEarVGNbhwOZodWJG+AuYE8/A1j9eHofr3kOc7r/neEwCsTF+JBH0C4pMbcLq5e+pKPkAZ5qvfD0zXhohoBrSQoMoABDajywdwUMVYZmXIN4QKV8WE9U9VF7vwCV8ZhgxJwFrtr2GO08VhXeY69Ima6Sv5AKXcnPNQRDQHVE9QUspaAB2BoT1/NV9MOt5yHP2e/gkJ6tCpevy97gCGij4FxCdP8WxtKbYWwzlYC4ghnHEGWbALsNyciCJO9QQFDA/h7ZVSPqh2LLPhaPbPP42r4DMc34tEMQjTZf+sRlgzYrfZ4ZNe6BPO43TzNPNQ5lwgLZsJiogiThMJar5wNDtQkFaAjMSRjd29Xh9KWn+PxoSVwJKN0zxbWzZYNwAAktPOT1/JJ4RSzcd5KCKKMCaoCPH4PDjcfHhCeXnd0f1YLc6iZdWnVYpsZiwJFuSm5sKUen76Sj7Avx6qBXCdik5wRLQgMEFFyMm2k+jz9E2Yfxo6+CT6ZDwWl35epchmrthajEFDHU43dwWv5AOAsxzmI6LIYYKKkINNSvHhmB6UuxvLL76Kt+JKYdN4efxkiq3FGJRd6PE64eyeppIvPQ9IXcZ5KCKKKCaoCHE0O5CXmofMxMzha75jv0OCHEB9bmzugRtYsKtPPDv9nnxCKOXmnIcioghigooAr8+LQ82HJlTvDbz/Xzjpy8aSdR9SKbLZKUgrgMmQBL3p7PSVfIAyzNfrAlrORCc4Ipr3mKAi4FT7KfQM9Ywd3ms6BpOrAs97P4JL8zOnfrKG6XV6FFs3wJjUMH0lHzBqPRS3PSKiyGCCioDA/ntjCiTKn8KQiMMh89XISktQKbLZK7YVA3EXccrZMn3D9OVAyhImKCKKGCaoCHA0O7AseRmykrKUC4N9kEdfxGvyUqwtyFU3uFmyW+2AkKjurJq+kk8I/75873AeiogigglqlnzSh0POQ2OPd6/aB+HuwrPuj6C0MPaq90Zbb10PAHAbaqev5AP881BOoLU6CpER0XzHBDVLZ9rPoNPdOWb+SZY/jQbdUrgsm3HN2kUqRjd7qcZULDHlQZ94bvpKPoDzUEQUUUxQsxTYf294/sl5EqLhAJ5xX4GvXrUSBn3sv8UbbRuhTzyLU01d0ze05AMpi7keiogiIvZ/e6qsvLkcS5KWYEnyEgCAr/wpDMGACsvH8A8blqgcXWRcumQjhH4AR5qCbGXEeSgiiiAmqFmQUsLR5BgZ3hsawNCh3+A172b88zUl0OmEugFGSGDB7sn2yuCN80qBniagtWZugyKieY8JahZqOmrQ7m4fHt7zHPsfxA914j3zdbhmbZbK0UVOXmoe4kQymgdPTV/JBwC5nIcioshggpqFMfNP/e0Yeu0eVPry8NGP3QAh5kfvCQCEEMg2rYbXWB+8ki+jAEjOAs6+E53giGjeYoKaBUezAzaTDctSlsH7p+8izt2GX1m+jo+snj+9p4D1mcXQxztx+Hzj9A2H56G4Lx8RzY6mEpQQ4i61YwjV8PzTohKI2jegr3gOj3muw6f+/mPzqvcU8OFcZZ3X/obDwRvnlQLdF4G22jmOiojmM80kKCHEDgBbgjbUiPquerQOtGJL5gb4fv9VnMUSvLvsVmwrzAj+5Bi0ddlGQOpwvLUieGOuhyKiCNBMgoo1w/NPNe9B13kOX3ffiq9cvW5e9p4AwBRnQoJchsaBE8EbZxQCyYuUcnMiohnSRIISQmySUpapHUc4HE0OZBrTkFP+a7workFiYSkuzZ+fvaeAxQmr0S/qMeQdmr7h8DzU25yHIqIZ00SCAmBRO4BwKPNPB1HS24PeeBt+2H8j/v2qlWqHNeeKLOsBnRvvn68K3jh3G+ehiGhWVE9QofSehBC7hBAOIYTD5XJFK7QpNXQ3wNnvQkmnC1/ruwWXr8nFxpx0tcOac1uXKeu93jp3MHjjvO3KR257REQzpHqCApAvhLheCHG9//NN4xtIKfdIKUuklCVWq/q7gztO/y8AoMe9HqdTLsMDn9qgckTRcXlOIXxDKTjiDKFQInMFkGTjeigimjHVE5SUcq+Uci+UYT6zyuEE5/Xgg4qnYPb68OTgl/BfX9yCjOR4taOKCmtKAvRDeTjXG8IQH9dDEdEsqZ6gAvy9pAIp5SG1Y5mO971HcAh9iOtbhoc+dyUKbclqhxRVtrhV6JNOtPQHOWEXAPK2AV2NQHvd3AdGRPOOZhJULJCtNTj5t5/iosGAzSs+jssL5nfV3mRWmpUDDA83h7IeivNQRDRzTFCh8vnQ8Myt+EFGGhJEMr59xWfUjkgVV+ZvhPTp8df6D4I3zlwJJFm5HoqIZoQJKkTHfv9/8RqqcTIhDvdv/wEsCTFVGR8xH1qxGL6BpShvCmHLIyGUcnPOQxHRDDBBhaDyRBW8lQ/jkXQzdmRfhWuWX6N2SKqxpSQgRRSiaaA6+IJdQCmU6DoPtNfPeWxENL8wQQXR2j2A1t/+K35kS0GKMRX3bL1b7ZBUtyGzGFIM4ajrePDGnIciohligpqG1yfx/JM/x8nUMzgZH4d7tn5/wQ7tjXZ1wSUAgD+eORC8sXUVYMpkgiKisDFBTeOJ1z7Alu5H8UuzGdfkXo2r865WOyRNuHr1KviGzHj/QojzUHnblAW7nIciojAwQU3hb6ddyHz3+3jImoCU+FR857Lvqh2SZqQlxiEFhTjfF8LO5oAyzNfZAHScndvAiGheYYKaxMXOfvzu+SfgyjiOk/FG3LN14VbtTWWNZQM8unbUtp0P3jhwPlQdz4ciotAxQY0z5PVh97P7caP+CTxmNuPvcq/GVblXqR2W5uxYrsxDvXTi3eCNrasBUwb35SOisDBBjfPTP57E1U3/H35uNSDVmIrvXMaqvcl8fM1mSF8c3j3vCN549HooIqIQMUGN8sdjF1H5zqvoy3QoQ3vbfoj0hPl/jMZMpCQkIAnLUd8T5jxUO+ehiCg0TFB+DW19uHuvA/+a9ivsMZtxbc5V2JG7Q+2wNG1l2jq49edwsasreOPAPBR7UUQUIiYoKCfkfuelY7gNL+A/LD6kGlPw7cvvUTsszbsidwuE8OGpw38M3ti6Gki0MEERUciYoAD87lAj2qs/gCf9bzgZb8T3tt3Hob0Q3LTuSkj3ErxQ/xAqWyqnb6zT+ddDMUERUWgWfIJydbvxk5eP4uvmJ/C4ORXX5uzAR3M/qnZYMSEl3oSNxm9AepNxZ9mdqO+sn/4JeduBjnOchyKikCz4BPXDl4/j097/wSPpA0gzpuA7l39f7ZBiyhUF+eiquwU+Cdxedjtcfa6pG+duUz6y3JyIQrCgE1RZVTNOHHMgMbMMp+KNuKf0fpgTzGqHFVO2FmRCDmXixuwfoG2gDXeU3YHuwe7JG9uKgMR0zkMRUUgWbILqHhjC9/dV4Otpj+NXacn4WPZH8dEcDu2Fa3VWCixJRtQ3WvDzD/8cNR01+OobX4Xb657YWKfjeigiCpkmEpQQYpf/zwPRes0H/nQSH+39PX5l6UJaXDK+vfUH0XrpeUWnE7i8IAPv1LTg8iWX477S+3Cw6SC+/fa34fV5Jz4hb7uyJ1/HuegHS0QxRfUEJYTYAaBMSrkHQL7/8Zw6WN+GN98vR6btVZyON+J7pT/m0N4sbCvIRHOXG7Utvbgu/zrsLtmN18++jp988BPI8TuY5/nnoXgMPBEFoXqCApAPIJCUav2P58zAkBff3FuBr6Y+jifTTPj7ZR/BlblXzuVLzntbCzIAAO9WtwAAvrD2C/ji2i/ihVMvYM/RPWMb29YCCWYO8xFRUKonKCnlHn/vCQA2AQhhc7eZe+SNatjb/4DnM1pgNiTh26X3zeXLLQi5GSYsNSfinerW4Wtf2/w1XJd/Hf7zyH/id6d/N9JYp1N2leB6KCIKQvUEFSCE2ATgdSnlobl6jcrGTvz2zXJk2/YpQ3vbf4K0+LS5erkFQwiBrQUZeK+2FT6fMqSnEzrcu+1ebFu6DfceuBdvnHtj5Am524D2eqCjQZ2AiSgmaCZBAdghpXxwshv+AgqHEMLhck2zzmYagx4fdv+2ArenPI6n0xLwD0uvwEc4tBcxWwsz0Nk/hKqLI/vyxeni8H+u+D8oshThG3/7Bg47/SfwBvbl43ooIpqGJhKUEGJXIDlNViThHwYskVKWWK3WGb3Gf/71DHKcr+P3mRdgMZjwze0/mmXUNNrWgkwAwDv+eagAU5wJj+x4BFlJWfjyX76M6vZqYNE6zkMRUVCqJyh/QnpACFEjhGifi9c4dr4Tz75ZgZVZL+KM0Yjvbf8xh/YibFFqAtYsTsVLhxsnVO5ZEiz45Y5fIl4fj9vLbkdTv5ProYgoKNUTlJSyTEqZLqUs8H8si+TXd3u82P3bCtyW+iR+nRqHjy8uxYd5jMacuLV0OU42deMvJ5wT7i1LWYZf7vgleod6cdvrt6EzezPQXgd0NqoQKRHFAtUT1Fz7j7+cQUbL23gtoxYZ+kTcdcVP1Q5p3vq4fQmyLYn4xRvVE9c/AVhlWYX/uPI/0NDdgH9tfQf9QnAeioimNK8TVEVDB555qwr2rOdQbTTi+6zam1Nxeh3uuKIQFQ0d2D9uLipgS9YWPPChB1DRUY27srLgqXsrylESUayYtwlqYEgZ2vtS6rP4TYoOH190OT6Ux6G9ufapzUuRlZqA//xr9ZRtrsq9Ct+99Lt4MyEO9zrfnrS3RUQ0bxPU//3LGSS1HMSbGSeQoU/AXR95SO2QFoR4gx67PpSP9+va8EFd25Ttblp9E26zbMJLRolfvP+TKEZIRLFiXiaow+fa8eRbJ3HpkqdRY4zD90t/xKG9KPrMJTnISDLiF389M227L2/6N3yqqwePn/pv/ObEb6IUHRHFinmXoJq7BnDnc4fwBfPzeCFZ4hPWS/Ch5deoHdaCkmjU49bt+Xj7TAsqGjqmbCcWb8DdPV58OC4TP/3gp3it/rXoBUlEmjevElSv24N/fuogFvWfwvuWI8jQxeOuHf+v2mEtSJ+9LAepCQY88sbUc1HQ6WHIvRwPtXTAbrPj229/Gx9c/CB6QRKRps2bBOXx+vD//PdhnGnqwNalv0KNMQ4/2HYfUo2paoe2IKUkxOGWbcvx56pmnGzqmrphXikS2mrxiy3fRW5qLr7yxldwovVE9AIlIs2aFwlKSol7X6nCX0868aO1r+O5eDd2ZmzE9oKPqR3agnbLtjwkGfV45I2aqRv59+VLu3gMj+54FCnGFNxRdgcaurmRLNFCNy8S1K/21+GZ987i30sknut/HZkiDt+46hdqh7XgmU1GfPbyXLxy9AJqXT2TN8raAMSnAvVvIyspC4/teAxDviHc/vrtaO1vnfw5RLQgxHyCeu14E3706glcW2SDr+fHqIkz4AeX/wCprNrThFtL82HU6/Dom1P0onR6IOfy4X358s35eOSjj8DZ58SX//Jl9A31RTFaItKSmE5QFQ0d+Orzh7FhmRn/kv1nPIkufDJ9Pbav/ITaoZGfNSUen7kkBy8dbkRdS+/kjfJKgdZqoLsJAGC32fHQFQ/hZNtJfO3Nr2HIOxTFiIlIK2I2QTm7BvClpx3ITI7Hox/PxL01z8EqDPjGNb9UOzQa57Yr8mEy6vHZJ97HudZJekR525SPo3Y3/3D2h/H9y7+Pdy+8i3vevQc+6YtStESkFTGboF50NKClx40nPr8ZL75xG2ri9PjBpXcjJZ5Ve1qzOC0Rv/mXy9A76MFNe96b2JPKKgaMKROO3/jkik/iKxu/gj/U/gE/c/wsihETkRbEbIJ65ehFlOSmY+jsU3jS14J/TF2N0tXXqx0WTWHd0jT85tbL4Pb4cNNj76HaOapoQm8Aci+f9HyoW9ffiptX34xnqp7BU5VPRS9gIlJdTCao083dONnUjZ2rdbj7+B5Yocfuax9XOywKomhJKp7fdRl8Evj0ngM43dw9cjOvFGg9A3Q3j3mOEALfvOSbuCbvGvys/Gd4ueblKEdNRGqJyQT1SsUF6ARwsfEe1Bp0+OGWbyElwax2WBSClYtS8Pyuy6ATwGf2HMCJi/5FvLnKeiicndiL0gkdflz6Y1yadSm+9873sL+RJ/ESLQSxmaCOXsQNy97Frz0X8ankQmxb+xm1Q6IwFNqS8cJtlyNOr8NnHj+AysZOYHExYEye8hh4o96In3/k5yhML8S/v/nvqGypjHLURBRtMZeg+oe8cLZeRFXCPtikDl+/9gm1Q6IZWJ6ZhBduuwxJRgM+vecAnj3YCJkz+TxUQLIxGY/ueBSWBAvuLLsT9Z310QuYiKJOEwlKCHG9EGKHEOKuYG07+4Zw2aJHUW/Q4Yebvo4UU0Y0QqQ5kJuRhBdvvxwblqXhnn2VeObiMqDlNNDjnPI5mYmZ2HPVHgghcHvZ7XD1uaIYMRFFk1D7NFMhxCYA+VLKvUKIXQAcUspDU7XPWLZYLrs/A5805eEHN74SvUBpzkgp8dLhRux75X/xjO87cOtMiEu2QBefAsSnAPHJykfjyOfHff245cIfkR2fjqfWfRkpJqu/7ag/hgRACLX/ekSaIIQol1KWqB1HOLSQoB4A8LqUskwIsQPAJinlg1O1T8tLlJd8rwAv3fRXJCfZohcozbmO3gHsf/ZeuM5XwxY/hC2LDbAZhwB398ifwR7lIyTeTUzAlxdZYR9w45fNTsSP/1YW+rEJy5g8kvCM45NfsrIn4JjHo54Xl8hkRzEtFhOUQe0AAJgBjD4bfNoxu0EBfHvtnUxO85A5KQHX3f5jfFDXhu++dAxnqnuw1JwIg35UYjAAQu9DAtxIlP1Y0umAw/wKtmavgkHqoYOEgISADzpI6KTyuUA/dOiDcDdB5w60kdAh1B0qlK8SeCYRzT0tJKig/EN/uwDAmp2MKy+9U+WIaC5dstyCP3xlO55+tx7HL3QGaZ2PFG82WnUVIX996f8DAF5I6KQXeumBDspH/fDjUZ/7P+rhGfVsIppLWkhQHQAs/s/NACacsSCl3ANgDwCUlJTwt8MCYDTo8C8fyg+x9cY5jYVoPnjittjr+Wuhiu8FAIHfRPkAylSMhYiINEL1BBWo2PMXSHRMV8FHREQLhxaG+AJDeERERMNU70ERERFNhgmKiIg0iQmKiIg0iQmKiIg0iQmKiIg0SfW9+MIlhOgGcErtODQiE0CL2kFoBN+LEXwvRvC9GLFKSpmidhDh0ESZeZhOxdqGh3NFCOHge6HgezGC78UIvhcjhBAOtWMIF4f4iIhIk5igiIhIk2IxQXHXiRF8L0bwvRjB92IE34sRMfdexFyRxEIlhLgeys7vUx7oKITYxL0MaaEK5WfE3+6u6e6Tdmi6ByWEuF4IsUMIcddM7s8XQohNACClLAPQEXg8rs0OAI9HOzY1hPB9scv/54FoxxZtIbwXO/x/5vV7EcrPiL/dDgBbohmbGkL4vnjA/3FXdCMLj2YTVLBvuFC/IeeJm6D8zxAAagHsGN/A/z60jb8+34TwfbEDQJl/A+J8/+N5KcSfkav89zct9J+RhSLE3427hBA1UN4rzdJsgkLwb7iF9A1pxtjkk6FSHFoQ7N89f9S1WoycNTYfTfteSCkPSSm/6X+YP8+Hf80I8jPiHwJfCOfNhfK78QYpZYHW3w8tr4MyY/pvuGD3aX4yY5p/93FHt2yCciDmfGVGCD8D/mGe26IRkMZZgjeZF8wI/n2xSQgBBJmvU5uWe1A0ogMjP1xmAK2qRRIj/MMar8/zXkNI/L+AbhNCmNWOZQ51YJqfkQXUewqJlPJB//uRoeVhcC0nqA5M/0s52P355AWMDFXlAygDgHn+C2cqHQjt332Hlv9nGCEdCPJLedT8Qy0ATU+Iz1Kwn5F8f+HA9f7P5/N8XAem/74IvA/w39PsMLiWE1Swb7hJ789HgV6A/386HaN6BX8JtPF/w5WM+sabr4ImayHErkBy0vL/DiMg2HuxA2N/UWl6Qnw2gv2MSCn3Sin3Qnk/zKoEGT3Bvi9qMfL7sgCAZrdA0vQ6KH8JZC2UCd49/mvlUsrNU92n+W+67wv/L6jfQhmDt0CZDJ63/3kJ8l6YAdwI5b24SkrJeagFIsTfnW3++5odadB0giIiooVLy0N8RES0gDFBERGRJjFBERGRJjFBERGRJjFBERGRJjFBERGRJjFBERGRJjFBERGRJjFBERGRJjFBEUWAf2PWGiHEb0c9NqscFlFMY4IiiowdADYDeCxwjLaUskPViIhiHPfiI4ogf6/JIqWctzuHE0ULExRRhASG9NhzIooMDvERRYAQIh8YSU6Bx0Q0cwa1AyCKdf7TWUsAtAkhyqDMR3VgHh8QSBQN7EERzcKoYb09UE4vrQOwZT4fkkgULZyDIiIiTWIPioiINIkJioiINIkJioiINIkJioiINIkJioiINIkJioiINIkJioiINIkJioiINIkJioiINOn/BxlVPPWk3mpqAAAAAElFTkSuQmCC
 "
 >
 </div>
@@ -14895,8 +14630,8 @@ Wall time: 89.8 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 1.61 s, sys: 9.59 ms, total: 1.62 s
-Wall time: 1.62 s
+<pre>CPU times: user 1.59 s, sys: 0 ns, total: 1.59 s
+Wall time: 1.59 s
 </pre>
 </div>
 </div>
@@ -14933,8 +14668,8 @@ Wall time: 1.62 s
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 1.58 s, sys: 2.42 ms, total: 1.58 s
-Wall time: 1.58 s
+<pre>CPU times: user 1.54 s, sys: 472 µs, total: 1.54 s
+Wall time: 1.54 s
 </pre>
 </div>
 </div>
@@ -14975,7 +14710,7 @@ Wall time: 1.58 s
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAwVUlEQVR4nO3de3xcZ33v+88zMxppdB2NNLIk3yU78S1xYisht5ZAnRvQEopJIfTsklfBEFq6T882l56mpfs0PTQh3e0+lAbbQIANeXFJ2S6FcokJBUxiEjmJHcd2LEu+6i6NRvfbzDznjxnFjpGt22jWGun7fr38imbNmrV+WpH91fOsZz2PsdYiIiLiNh6nCxAREZmMAkpERFxJASUiIq6kgBIREVfyOV2AiIjM3MGDByt8Pt8XgU1kd2MjARyJxWIf3Lp1a8fFbyigRESykM/n+2JlZeX6cDjc4/F4snY4diKRMJ2dnRva2tq+CPzexe9lc+qKiCxmm8LhcF82hxOAx+Ox4XC4l2RL8I3vOVCPiIjMnSfbw2lC6vv4jTxSQImIyLw4evSo/5577qmZ7ecVUCIiMi82bNgw9sMf/rBptp/XIAkRkSz38acOLT/R1p+fzmNeVVk09Nntm89daZ/HHnus/Kabbho6cOBA/s6dO7v27t1b9Oijj1Z+6EMf6mpsbPTffffd/Z/4xCeWPvvssw0T+5eVlcUbGxv9tbW1Yw888EDPlY6vgBIRkRl76KGHltx99939t91221BXV5f3scceK9+5c2fXxz72sZUXB09JSUkcYO/evUVlZWXxBx54oOeee+6pefjhh9unOocCSkQky03V0pkPzzzzTPH999/fA3DVVVeN7tq1K7xz586uTZs2DU22/2233Tb0V3/1V5Vr164d/Z3f+Z2+6ZxDASUiIjO2efPmoRMnTuRu2LBh7MSJE7lbt24dvNL+HR0d3rvuuqtv3bp1o7fddtukIXYpDZIQEZEZe/zxx5vr6+vz9+7dW1RfX5//8MMPt+/du7foyJEj+fv3788H2L9/f/6RI0fyjx496gfYtWtX+M/+7M+W3XPPPTUT+1yJ0XpQIiLZ59ChQ6c3b97c5XQd0/Xggw8uffzxx5sv9/rQoUPlmzdvXnXxZ9TFJyIi8+79739/zxNPPFG6du3a0YaGhtz3v//9VxzBBwooERHJgNtuu21o4t6T7kGJiEhWU0CJiIgrKaBERMSVFFAiIuJKCigREUmb4uLi62655Za1Dz300JKJbU888UTpLbfcsnamx9IoPhERSZuvfe1rjffee2//xdseeOCBnj179pTP9FgKKBGRbLf3T5bTcTSts5lTsWGIez9/xTn+HnzwwaV33XVXH8DJkydzd+7c2dXT0+M7evSof8OGDWNzLUFdfCIiMmOPPfZYeW1t7ehEaykajXoBuru7vRUVFfH7779/5VzPoRaUiEi2m6KlMx9++tOfFv/lX/5lG0B5eXl8YvvOnTu7AEpKSmJPPPFE6VRrPl2JWlAiIjJjW7duHTxw4EA+QFdXlxeSrarpTAI7XQooERGZsYcffrg9Go169+/fn19fX58P8IEPfKAHkqP2IDk4ApKLFR45cqRgYvt0aTZzEZEs5KbZzPfv35//ox/9qGg6q+RezmSzmasFJSIic/KNb3yj9ODBgwUTXX3pokESIiIyJxev65ROakGJiIgrKaBERMSVFFAiIuJKWXcPqry83K5atcrpMkREHPXoo49y9OjRac/WMDo6Grv++usPzWdN6ZZ1AbVq1Srq6+udLkNExFHHjh1j/fr1097/yJEjc54bbypdXV3e48eP5zY0NOQ+//zz+RODJ5544onSPXv2lD/77LMNMzmeuvhERCQtvvKVr5QeOHAgf+IB3ccee6wcLjywO1NZ14ISEZE3euT5RzgeOX7FfQYGB/J8p31XT/eYa0rXDP3trX8749nMJ947ffp07sR7s6UWlIiIzNjlZjMHOHr0qL+0tDR+6bpQM6UWlIhIlvvkjZ+ccp8jR46MbNq06bV0nfNys5kDPPnkk6VPPvnkmbmeQy0oERGZsclmM4fkgIiJOfnmOrO5AkpERGZsstnM9+7dW/TXf/3XSzdu3Lh+48aN6yeCa7azmauLT0REZuXi2ct/9KMfFd177739995775FL97v33nv7+/r6Xp7p8dWCWgD6Rsb56rOnicUTTpciIouQZjOXy/ras6d57CcnCObn8M7rljpdjogsMprNXC7r+4dbAfjS/lNoAUqRxWOh/H1PJBIG+I0uIAVUljvZ0c/xtn42Vhdz+HwvB8/M6oFtEckyeXl5dHd3Z31IJRIJ09nZWQL8xr0rdfFlue8fbsUY+Pz9W3jn53/Fl/afom5VyOmyRGSeLVu2jPPnz9PZ2Tmt/dva2nzxeLx8nsuajQRwJBaLffDSNzIeUMaY7cCHrbV3TPLeI9baqZ84EyDZvP/+4VZuXBViVXkB77txBbt/0ci5yBDLQ3N6/EBEXC4nJ4fVq1dPe/8NGza8Yq2tm8eS0i7jXXzW2qcm226M2QbUZLicrPZaez8nOwZ4x+ZqAP7olpV4jOGrz552tjARkTRwxT0oY0wN0OR0Hdnm+4da8Ri4e2MlAFUlAd52TRXfeuEcA6Mxh6sTEZkbt9yDqrHW7jPGTPqmMWYHsANgxYoVmazLtay1/OCVVm6uCWFe/RJfO/xlTjFKv0lQtRx27307/9cfPOp0mSIis+Z4QBljtllr911pH2vtbmA3QF1dXXYPWUmTV1v6GOs5zqbir/K2Y30M53oIGh8rPflExns50vks8YTF65k89EVE3M7xgAIiqftPQaDGGLPFWvuiwzW5U3wcuk5A62Geff4pqD3Ok14Pdxev56O3P8rq0uQtvHd/+ToGPQP89Fg7d6a6/0REso0To/i2AXXGmO3W2qcmwijVjRfMdD1ZIz4O/3Mz9CUf2P5xdRUBG2DP7f/IhpW3v2HX5f4iTsQjfGn/KQWUiGQtJ0bx7bPWll46ms9au9taW6vW02X0NSf/vOkjHHzn93jN7+fqqvt+I5wAqgNhOn1Qf6qDI829ma9VRCQNXDGKT6ahryX537V38uXT5zHG8u4Nvz3prtVFyxnxeFiV18qXf3Uqg0WKiKSPAipbpAIqUbSUA80vYKyXm5dtmXTXqtI1ANxZ28u/H2qho38kY2WKiKSLAipb9J4H4FB/AcPekyzNX0vAF5h01+rwRgDWlHUTS1i+/tycV14WEck4BVS26GuB3GK+e7QTT+A8b175psvuWl1xHQADo83cflWY//3yvMyELyIyrxRQ2aKvGVu8lB+e+DXGxLm5+obL7locKKXAQstQG9evKOV8zzDDY/EMFisiMncKqGzR10xvTpg+TmAwXJdqJU3GGEOVyaFlLMqaikKshaaugczVKiKSBgqobNHXQuNoMTkFp1kTXEtJbskVd6/OKaY1PkxtuBCAkx0KKBHJLgqobBAbww508OueAL78s9RVbp3yI1WBMC0ew6qiOB4DjZ2DGShURCR9FFDZoL8Vg+VlAwnG2Lpk6oBaWrScfq+H8Z4TrAjl09ipFpSIZBcFVDZIPQN1Jm8UYFoBVRVaC0BL+2Fqw4U0qotPRLKMAiobpObf6wpEWVa4gvLA1Ks2V4evAaCl+zi1FYU0dQ0ST2gieBHJHgqobNDXTAIYz2/nxqrprdhcXXY1AC39Z1kTLmQslqC5Z3geixQRSS8FVDboa+FETiHWO8zm8OZpfSQUKMNvoXWwndqKAgBOdvbPZ5UiImmlgMoCtvc8z/mDAGwo2zCtz3iMhyqPn5ax6OtDzRs7NJJPRLKHAioLxKLNHMrJw4uP2mDttD9XnVNCa2KUYJ6P8kK/RvKJSFZRQGUB29vMyVwPSwtqyfHkTPtz1fkVtHg9MNBOTbhQD+uKSFZRQLldbAzfcCetueNsCk+ve29CVdEKun1eRrobWFNRqBaUiGQVBZTbDbTR7PMy5o1TV3nNjD5aHboKgNaOV6gNF9IzNE73wOh8VCkiknYKKLfra+HVXD8AG8pn2IJKrQvVGjlBbTg5kk9THolItsh4QBljthtjnr7oddAYsyW1/ZFM1+N6vec55s/Bg5e1wbUz+ujSklUAtPSdZU1FaiSfuvlEJEtkPKCstU9dsuk+oG5iuzFmR6ZrcrPRnvMczfVTlrMMv9c/o8+G88N4LbQMtVNdEiAvx6OBEiKSNXxOF2Ct3X3Ryxrg6cvtuxj1tp3mqD+XdSUz694D8Hl8LPEFaO1tw/Py16kpX6UWlIhkDdfcgzLG1AARa+2+Sd7bYYypN8bUd3Z2OlCdc871NNHn9XD9kk2z+nxV2TpOF4YY/97HuD93vwJKRLKGawIK2G6t/fBkb1hrd1tr66y1deFwONN1OapxtBWAW5dPb4qjS12/ZCtHGOWu1auIjD7OxsF/Y2Rcy7+LiPu5IqCMMduttY+mvt7idD1ucpo+PBY2lK+b1ef/9Lo/5XNv/Rzrq2/iSyUlHFy1j/qjP09zlSIi6efEKL5tQJ0xZvtFrx8xxhw0xhwEQpmuybXi4zTlxFmSKCDXmzurQ3g9Xm5ffjufv+ML/G3tRxnxeHjlzK/SXKiISPplfJBE6h5T6SWvpz/B3CIy2tPMsVw/td4laTle3Yot0ATNvefScjwRkfnkii4+mdzRUy8S8XqpLVqTluNVhdfiT1g6R9rTcjwRkfmkgHKx/ef2A3BN1dRLvE+HCZRSGY8TjUfTcjwRkfmkgHKpF9pe4Ct9+1gzGuO3N70tPQc1hoq4oddo+XcRcT8FlAsdbD/In+z7KMvHx3h752aCRcG0HbuCHPp941r+XURcTwHlMoc6D/HRfR+l0pPLF1vbea1se1qPX+kroN+b4LX2nrQeV0Qk3RRQLvP5lz5Pob+QPZ29nIyvp3Dp+rQef3leCGvgcNvZtB5XRCTdFFAu0zHUwea8Spb0nOXr4299fRbydFlWUAHA8S4FlIi4mwLKZbpHuglFmxnLDfHjxA2sCac3oKoKqwE4F1VAiYi7OT6buVwQS8SIjkYp6+njaOW7GO/1pb0FtaRoOQC9Q2fSelwRkXRTC8pFoqNRAELxGD/Ju5tgfg6hgpmtATWVvKJKQvE41nQQGRxL67FFRNJJAeUi3cPdAISCNbzQW8yacCHGmPSeJL+cqlgMT05US2+IiKspoFykeyQZUGVF1TR2Dqa9ew+AgjDVsThxX79W1xURV1NAuUhkOAJAft4SIoNj8xRQ5VTGYozlDHGyvT/9xxcRSRMFlIt0958HIEFyKHjtfARUXpCqeIKYJ8FrXZo0VkTcSwHlIpH+8+RYSyRWDpD2IeYAeDxUeQMANPacT//xRUTSRAHlIpHBdkLxOI0jhQRyvCwNBublPFU5JQB0Drdp+XcRcS0FlIt0D3cSiic40p9PTbgAjyfNI/hSqgLJFprxRWnqHJyXc4iIzJUCykUio72UxeO8FMmdnwESKaX5FeRa8OT0aqi5iLiWAspFuscHCFkPJ3uhdj7uP6WYgjCV8TgmJ6qh5iLiWhkPKGPMdmPM05Ns22aM2ZHpetzCWkskMUrQk7zvNJ8tKArKqRofIy+vlzPd6uITEXfKeEBZa5+6+LUxZntq+77U622ZrskNBscHGcOSbwqAeQ6o/DKqYnG8OT2ciQzN33lERObADV18NwBNqa+bgC0O1uKYiVkkvLYIr8ewqqxg/k5WkJzuaMz0czbSN3/nERGZAzcEVPCS12WX7mCM2WGMqTfG1Hd2dmamqgyLpObhGx8vZmUoH79vHv/X5JdTFYsDlshoJwOjsfk7l4jILLkhoKJA6Eo7WGt3W2vrrLV14XA4M1VlWKQv+dBsdKRkfmaQuFhBmKpYMpQ8OVHOdqubT0Tcxw0B9QIXWlE1wNOX33Xh6u49DUDzQMn83n+CVBdf8gFdkxPlrO5DiYgLOTGKbxtQd9HgiKeAmtT24MRgicWmu78ZgMjYEtbOd0AFSlkSTwaUJyfK2YhG8omI+2R8Rd1UAJVesu3R1JeLMpwAIkPtlMTjdBCa/xaUx0tuIESlJ5e2QLdaUCLiSm7o4hOSixWG4gk6bOm8PqT7uvxy1pFLTqCVM7oHJSIupIByichYH6UJKA2WUpCbgYZtQTnrYpZxbxtnItH5P5+IyAwpoFyiOzZIftw3/yP4JuSXsW50BLC0Dp8iFk9k5rwiItOkgHKJSGIMf8w/P2tATaYgzPr+aPJrfzOtvSOZOa+IyDQpoFxgPD5On7EQC8z/AIkJBeVUDUbI9xXhyWvVQAkRcR0FlAtEUtMc2Vgha5dkqouvHINlbdFqvHktGighIq6jgHKBSO9ZAMZiJRns4kvOKHVt8XI8ua2c6tacfCLiLgooF4j0JOfKtZ4KSgv8mTlpfnJV3fV55RhPjBORpik+ICKSWQooF+juPQNAYeHyzJ20IBlQ67zJWdPP9Ddk7twiItOggHKB7oEWACrKrsrcSQuSk+6uTnjwkEP32CmstZk7v4jIFBRQLtDe305uIkFV1drMnTSQnEDeN9RNOHcVsZzzRIfGM3d+EZEpKKBcoH2om2Dcsnrpksyd1OuDio1w+NusLqzBm9fCaS3/LiIuooBygch4P8Vxw9qKosye+K6/g55T3DTSifEO80r7mcyeX0TkChRQLtCbGCEQz2FJcW5mT1z7Ftj0brY2JieRP9zxambPLyJyBQooF+g1MfJNAGNM5k9+599xdcJgLDRGX8v8+UVELkMB5TCbSBD1QpGn2JkCiqsI3P5/s2p8nNGhF5ypQURkEgooh53rbCJmDMFAuXNF3LiDlTE/o55zztUgInIJBZTDfnniZwCsDWbwGahLeX3k5a2gxwvDI5rVXETcQQHlsJdb6/Fay5tW3ORoHcFABePG0HTmqKN1iIhMmPHSrcaY64Ca1J8oEAGarLUvp7OwxeLE0EnWjY2xcuV6R+uoKFkOHS9wuvlVNl69xdFaRERgmgFljFkFfApYDTSl/kQBA9QCdxpjaoBG4BFr7emZFGGM2Z46Xo21dvdMPpvNxhPjnKOL+0bG8BZXOVrL8oo10AHtXZqTT0TcYcqAMsZ8HAgBn7TW9k6xbwmwwxjTY6394nQKMMZsI9kCe9EYs80Ys8Va++J0PpvtjncfZ9wkuHosB7w5jtayvOpqOALRPg2UEBF3uGJApcLpKWvtqekcLBVgnzXGrDbG7LTWPjaNj9UDB40x7yHZgto3nXMtBC+0HQRgrSfkcCVQVrICgMHRDocrERFJuuIgCWvtZ6cbTpd87tQ0wwlrbRTYBXwH2DrZPsaYHcaYemNMfWdn50zLca1fna+nYtxSlsllNi4jlJcMyeF4j8OViIgkzXgUX+p+VNqkuvj2WWtrgWjqftQbWGt3W2vrrLV14XA4nad3jLWWo5HDXD8ySl7I+YDye/3kJwxjDJBIaNkNEXHebIaZlxpjPjjxwhjzbmPMW+dQw8X3nD5D8n7Xgne+/zwDsR5uHB2iaMkKp8sBoNj4GfeO0jkw6nQpIiIzDyhr7UvAmolQstb+K8lRfH88yxp2p7rwtgH3LZZRfC92JDP5+pFRfEHnW1AAQW8hg94EZzvUzScizptNF9+PAUtyYMN1qc2fAR6dTQHW2miqC2/fYgkngJc6XsKX8FM7Pg7F1U6XA0BZoJRur4eulianSxERmVUXXy2wKzViz6SGlu9J/ZFpeqnjJUqHi5P/A4qXOl0OAEsKlxDxehlon/G4GBGRtJtNQN0JfNIYU5zq7tsGPG+t/VR6S1u4ekd7aeptYsVwav2nImcf0p1QXlxN1ONhJHLW6VJERGZ1D6rJWvugtbYv9fpfgd45DpRYVF7ueBmAdSOW8UAYfH5nC0oJFa8gYQwj/VpZV0Scl5bJYq21ewD1C03TscgxAK4fHcJT4o77TwChgiUAxMZaHK5ERCSNs5nP5oHexeps31lyCbHGG8Vbsszpcl438bCujy4GRmMOVyMii90VA8oY8/HZPJg7MdXRrKta4M70n4FYOZV0Q4k7BkjARQHl7eNs95DD1YjIYjflVEfAHcaYz0wnqIwxxcaYvwfePd2pjhajM71nGB8spsAOumaIOUBpXmnyC98gZyODzhYjIovelLOZW2v3GGNWAx8xxlzPhaU2GoEgUJb6b21q26Pq7ru83tFeesd6KRxNjeBzyRBzgGBuEAMMeRO0trfDJneMLhSRxWla60GlAudTkOy+48KChb0kB0c0pYacyxTO9CVHyJWNpS69i1pQPo+PoC+fiLefWPsZ4DqnSxKRRWzGK+qmwuoU8NP0l7PwTQTUslgiucFFAQUQ8geJeLvI07NQIuKwGQcUQGqy2IkuvW9PPBMlUzvTdwasYWtOHMaAIpcFVH45EW8TS6PNTpciIovcbObi+wKwhuRy7/cBp+YwUeyic7r3DDZWyubCIcgvh5w8p0t6g9KCJUQ8XgLDrcTiCafLEZFFbDYtqKdTs0cAYIwJAp8yxvy+tfa7aatsgToROUV8tIyVOVHwu6v1BBDKKyPi81FJNy3REVaU5TtdkogsUnN+UDc1G/mnSI7mkyuw1tI8cI7EWDmhRJerRvBNCAVC9HkMYbo41a2h5iLinNkEVJMx5gVjzLuMMcUXbe9OV1ELVfdIN2N2iJC/mpyBVtcNkAAoy0v+npHvi3CyY8DhakRkMZtNQP0B8G3gfcDpVFh9i+SwcwA0cezkTkVPA7C5fDkM97gyoCYe1s3N6aOhTWNfRMQ5swmoRuA71tr7rLUhYAdQT3JV3W5jzAvAI+kscqF47uxrALylIrWqvYvm4ZswMd1Rv8fS3nbe4WpEZDGbzXIbe4DSiamPrLUvWWs/a62901pbBnwY0JrhkzjY2oC1Ht4aDiQ3uLAFNRFQEa+Hoa4zWGsdrkhEFqtZDZJIhdLpy7z3IvDJuRS1UJ2KnsaXKCM81pHc4MZBEq8HlJcV46do7xt1uCIRWazSttzGxWY67ZExZosxZrsxZvt81OMGsXiCnrEWKnPK4ZmHIbgCSpY7XdZvKPYX4zM+uv0BrjcnOdHe73RJIrJIzUtAzcJfWGufAkLGmJop985CR1qikNPFbQPHITYC73/KNSvpXswYQ2leKd2FYa7zNNKgkXwi4hDHA8oYswN4wRhTY63dba1tcrqm+fCfx4+AZ5zakSi875sQvtrpki4rlBeiN1DE1Z5znG7tcLocEVmkHA8oknP6lQERY8yu1MwUb2CM2WGMqTfG1Hd2dma8wHQoOPpZAFa+6WOw8haHq7myUF6IiM+HlwS0vOx0OSKySLkhoAAarbVR4CDJYetvkGpZ1Vlr68LhcMaLm6tYLE7O+FEAVl37foermVooEKLbjgNQ2nNII/lExBFuCKgXLvo6SHIxxAXlRGMD3TkxcvBQWVDpdDlTKs0tpWe0l/7AMtbHT2gkn4g4YlbLbaSTtfYpY8wnjDHbUq93O11TOiRsgl2Hd9Ez0sPZxmOcLwiwNFCBx7jhd4IrKwuUMRQbIrpkM9cNPUdDRz+VJe6adV1EFj7HAwrAWvto6st9jhaSRscjx/mXl/+FgpwCEqOj+D0e3rPqTqfLmpaJZ6FGlm9i7ekf8J9nGmFt9nWtikh2c/+v81nqZPQkAF+/50keOR3iu+0+/uuNH3e4qumZCKhP9/2aD1WGefL83/DL8790uCoRWWwUUPOkoacBv8fPQH8JV9PEaHiT0yVN2zXl13BL9S14/YUMGy/naeE/Tv2H02WJyCLjii6+hagh2kBNsIZXTpzi/zAR+mtucLqkaSsLlLHrjl0AnH/0Jh4MDtMzoukVRSSz1IKaJw09DawJrqGz4XkAilZvdbii2ekv20xlfJjOoYjTpYjIIqOAmge9o710DHVQG1yDp/2V5MbKa50tapa8K24gHI8RGdSMEiKSWQqoeTAxQCI3sZQ18UYG85dDIOhsUbNUvu5Wgok4/eO9TpciIouMAmoenOxJBlRXpJRN5jTepdc5W9AclC69mkDcxygxRmIjTpcjIouIAmoeNEQbKMwppPHUIKs87eStuN7pkmbNeDz4KAIgOhp1thgRWVQUUPOgoaeB2uAaBs++nNxQtdnReuYqPycIoJF8IpJRCqg0s9ZyMnqSAEupGU929VGZ3QFVHKgA4FSPBkqISOYooNKsY6iDvrE+jp3O56bAeWxxNRRm9zRB4ZJlALzWds7hSkRkMVFApdnECL7WrlJuCpzDVF3nbEFpsKJyLQDNnQtyLUkRcSkFVJq9FjkBwNbCEIX9p7L+/hNA9ZK1GGuJ9J13uhQRWUQ01VGaPdN0GO94Pl8b/++YnHxY93anS5ozX3A5JYkE/ePZuZqxiGQnBVQajccTnO44SF28h1x/DvzRj6HyGqfLmruiKoLxBCOxKNZajDFOVyQii4C6+NLo+X/7F0Z83azylmA+9LOFEU4AecUEExD3DNHRr9V1RSQzFFBpMjrUR/7Rf2DU42Hjb30cCiucLimtSjx+xr1jnGjvd7oUEVkk1MU3R+f6znEyepKmn3+NocI4AFeVb3S4qvQrzSlgOD7AifYBfkur64pIBiig5sBay0f2fYSz/WeTG0pLyPPlsbpktbOFzYOy3CADo/2caOtzuhQRWSRc1cVnjHnE6Rpm4kzfGc72n+Xd8aU8eb6dv13zaf793n8nPyff6dLSrjRQRtwYGjranS5FRBYJ1wSUMWYbUON0HTPxq5ZfAfBHLQdp99/Bvbdup7Kg0uGq5kdpwRIAuiMnsdY6XI2ILAauCChjTA2QddMU/Kr5V1TFfVSMG5b83qedLmdeBYuWApAbb6a9TyP5RGT+uSKggBpr7WUDyhizwxhTb4yp7+x0x8OiY/Exnm9+jjcP9vCDsg9wzdVXOV3SvCotWQlAia+Lhg6N5BOR+ed4QBljtllr911pH2vtbmttnbW2Lhx2xwiynx74EqPECI6s4Hce+H+cLmfelYaS8/Hl+yKcaB9wuBoRWQzcMIovkrr/FARqjDFbrLUvOlzTFfV1nuPgwX/CV5zD7dufoKwoz+mS5l1pMDkysdDfT4OehRKRDHC8BWWtfTHVggqRDClXGx8fo2XPezmYZ7iqcB0bV9c6XVJG5PsLybGQ6x+koUMtKBGZf44H1IRUN16tm1tP1lr+48sPUxo/xsncHO5a9zanS8oYYwyleLDeYU609RNPaCSfiMwv1wRUNvjK0we5vWUP/x7aAMCt1bc6XFFmlXpyGfWM0j8a49WWXqfLEZEFTgE1TT843EruL/6OQjPK8TUbCAfCXFW6sEfuXSqYU0Af44DlVye7nS5HRBY4NwyScKXTvadp6k2OfG/qHOBbP/kFnyp+jmeueicHeo7y5mVvXnTLTpT6SzjmaeX6sOHZxi4evH1x3H8TEWcooC7jI/s+QvNA84UN1fB/EobeegDesvwtDlXmnGCgjJ5eD+9fFuf/OxJhNBYn1+d1uiwRWaAUUJPoGu6ieaCZD2x8gGcPLWdpy4950LsXbv8LuPpt+L1+akqyalamtAgVLKHP66WubIiR8SJeOhvlppoyp8sSkQVKATWJ45HjAHS0r2ZZ4/P8k/8pzMrb4aY/B8/ivW0XLFoGQFVeFx5TxLMnuxRQIjJvFu+/tldwtPsoAH0HnuMf/V+AVbfBe59c1OEEUFq8AoDRofNcs7SEZxs1UEJE5o9aUBMSCTi6F8YGONz0Q0rG8/hn7x7s8pvw3P8t8C+8JTRmKlhQDkBPfzO3rClnzy+aGByNUZCrHyMRSb/F3SS42Gs/gKcegO99jJPR49w82s1Y9Y14//A74C9wujpXKM0tBSA61MGtteXEEpbnT0UcrkpEFioF1ISXvg5FVTyy6es05/jwrXqAwAd/CLmFTlfmGqV5yYDqGe5ma3UeRd4YBxpaHa5KRBYq9c0A9LdBw09ovOqD7D7aSP5KeOeWOxb9PadLBXODAPQMtRP47FJeyYHYQS9c/zQs2+pscSKy4OhfYIBD3wSb4GPHN7KsMtlltT603uGi3Mfv9VPgCxBddSts+xueW/lRfMQZOv4Tp0sTkQVIAWUt9qWv85p/E2epYtPqfpYWLqUkt8TpylypNK+MnrJVcNuf43/rJ2hILKX/5HNOlyUiC5AC6tzzmO4Gvjh4C5+8+2pO959gQ9kGp6tyrdK8UnpGegC4dlkJr5i1FHa+DFazm4tIei36gBp+/qsMkUtr9d383vUhzvafVffeFQRzg68HVI7XQ3/5dRTEeyHS5HBlIrLQLO5BEqMDmFe/yw8SN/M373kTJ6LHAFhfpoC6nNK8Ul7peoVvHPsGAK9Wx/nGeCHDv/4cgdU3XPZzud5c3l7zdgK+QKZKFZEst6gD6tV9/4uNdhiu+0PWVBTy1VeTM0ioBXV5a4Nr+V7j9/j75//+9W0/LAtB50+Tf66gIKeAe1bfM98lisgCsWgDqn9knJH6r9PsqeL3fvf3ATgWOcaS/CWUBTS/3OV8YNMHeNfad2FT95wS1nLos2+jIjfG0v/69KSfGYoNcde/3kXbYFsmSxWRLLdoA2rXv/2MnfYIrdf/N/w5ySUjjnUfU/feNFw6wnEseB1XR76F15ODmWTWjRJbQsAXoHO4M1MlisgC4HhAGWOCQE3qzw3W2k/O9ZiD44Mc6TqCZfKRZa+19dPasIcDebmwbjNnWg8QS8Q41XuKu1fdPdfTLzp5q27GF3mS5mO/Zunmt/7G+8YYwoEwnUMKKBGZPscDCrgPwFq72xhzgzFmh7V291wO+E8H/4lvvvbNK++0HH7CEnjuoTds3hzePJdTL0qrr3szvAhtr/5y0oACCOeH1YISkRlxPKAuCaMaYPIbGTNwpu8Ma4JreOimh37jvW+9cJZXXjzAwzlPwG/9Oay98/X38rx5egZqFpYvX0GzWYJprr/sPuFA+PVlTEREpsPxgJpgjKkBItbafXM9VttQG2uCa9i65I3zwx1p7uW7z7bz1YoWtg54oO5PIK94rqdb9IwxtBdfw7LegyTiCTze33y8LpwfpvN8J9ZajDEOVCki2cZND+put9Z+eLI3jDE7jDH1xpj6zs4rdxNZa2kbbGNJ/pI3bB+LJdj5nUMsyYebh38O639X4ZRG3hU3UkEPDSdfm/T9cCDMcGyYwfHBDFcmItnKFQFljNlurX009fWWS9+31u621tZZa+vC4fAVj9U31sdwbJjKgso3bP/nZxo43tbP4zd04hnthc3vTee3sOgtu+a3ATh7+OeTvh/OT/5/030oEZkux7v4jDHbgEeMMX+R2jS7UXyHvgntr9I23gtA5cmfQ/NJADr7Ryl8uZknlhZxbdMrUFQFNbfPvXh5XVnNVkbxc82xf8A+8W8Y3tiNF/bGAegc6mR1yWonShSRLON4QKXuOdXO6SDxcdj7UTCGtvwCCJdQ9dpPYCyGBYpicf6LF3J7vWAM3P4p8HjTUr+k+Pw0XvUheo/9DP9QnFCB/8J7iRjhc/WwrJqO4Q7nahSRrOJ4QKVF9CzYOLzzcdryvPDrh6n80xchv4LHfnycz/+skSc+cANvWVfhdKUL2to/eJi3/sN/EiKXvX90y4XBENZS8f9WA9A11OVghSKSTVxxD2rOJmbSDtXQNtSGz/goyyvj0LkoX/h5E+/ZukzhlAE5Xg8PvnkNh85F2X/yoiAyhoLSlQQwakGJyLQtvIAabKMiv4LxOOz8ziEqinJ56B16tilT3r11KZXFefzzMyffsN2Eagkn1IISkelbOAHlL4SCMG2DbVQWVPI/f9pAQ8cAf//uaykJ5Dhd4aKR6/Oy47dr+PWpCM+filx4I7Sa8rFROobUghKR6VkYAdXdCKEaMIbWwVb8hNj180bee8Ny3nzVlYelS/q978YVlBX4+dwzDRc2hmqoiI3TpRnNRWSaFkZARZogVEPCJmgfbOdgY4KqkgB/+XbNTO6EgN/LB3+rhl82dHHoXDS5MVRDeTxOh56DEpFpyv6AiscgegZCNZzv7SBmY4yOFLPnv9RRlKeuPaf84U0rKM7z8fmfpe5FhWqoiMcZToxpNgkRmZbsD6jec5CIES9dzc69vwDgw7duZUO1pjFyUlFeDg/cupqfHG3neFsfFC+lPJEcdq77UCIyHdkfUKkRfF857uHF5lMA3HHV1U5WJCkP3LqKAr+Xz/+sETxeKgLJ+4FdwxrJJyJTWzABtesVuOXq5OwQl87DJ84I5vv5w5tX8v3DLTR1DhAuXg6oBSUi05P1AXW64RWGbC5bNqzjmpWWXG8uwdyg02VJygdvq8Hv9fD4fzYSLl0DQJdW1hWRacjqgDp0LsqpE6/Q7qvmH997/evPQGm9IfcIF+XyvhtX8L9famYkbyV5iQQdvWecLktEskDWBlRH3wh//NV6Vnvaqa7ZQMDvpW2oTd17LvThN9eQ7/fymQNjhONxOvsUUCIytawNqG/XnyMyMMwK00luRbLrqG2wjcp8BZTbVJUEePJDN9EQCxOOx2npa3W6JBHJAlkbUN8/3Mqdy2J4EmMQqiGWiNE13KUWlEttWlrCI3/8DspjCc70d3KyY8DpkkTE5bIyoE6093O8rZ93rRxLbgjV0DnUScImFFAutmFZGeXefIa9Y7x39wFOtPc7XZKIuFhWBtT3D7XgMXBzaTS5IVRL21ByjjcFlLstyS9j1GMxnhHet/sAx1r7nC5JRFwqOwPqcCs31ZRRPHgWfHlQVEXrQPK+hu5BuVu4oAqAf3xfDTleD+/bc4Ajzb0OVyUibpR1ATU8Hqepa5Df3VwNkVNQuho8HrWgskQ4uAqAXNPKtz58EwV+H+/dfYD/deAMiYR1tjgRcZWsC6jeoXF8HsPdGytfn8UckiP4inKKKPQXOlyhXElFWXIaqs6uY6wsK+DbH7mZa5eV8Fd7j/DuLzyrLj8ReZ0rAsoYs90Ys80Ys2OqfaPD49y2tpzSgA96TkFoNZAMqCUFS+a9Vpmb8oprAejsaQRgaTDANz74Jv7HfZs50z3EOz63n8/8xzGGxmJOlikiLuB4QBljtgNYa/elXm+70v7j8QTvuLYa+lshNvKGFpS699yvqHw9eYkEnQPNr28zxvD7W5bxzH97M9u3LGPXL5q443/8gp8ea3ewUhFxmrHW2X5/Y8wjwLestS+mwmmLtfbRy+1fvCpgb/vrNYCFRAyKqiAnQMtAC+9a+y4+ffOnM1a7zM7bvryJiIGQnXxKKgvEdT9KJK2e/tCrB621dU7XMRM+pwsAgpe8Lrt0h1TX3w6AsuX5XJtbnnzDmwOVm8HjZXN4M9vXbp/nUiUdPrzqHTzX+usr7mOtZWA0xlg8kaGqRMRt3NKCetpauy/VgrrDWvvJy+1fV1dn6+vrM1egiMgCYIzJuhaU4/eggBe40IqqAZ52rhQREXELxwPKWvsUUJNqPQUnBkuIiMji5oZ7UFw0KELhJCIigAtaUCIiIpNRQImIiCspoERExJUUUCIi4koKKBERcSXHH9SdKWNMP/Ca03W4RDnQ5XQRLqFrcYGuxQW6Fhdcba0tcrqImXDFMPMZei3bnoaeL8aYel2LJF2LC3QtLtC1uMAYk3VT8KiLT0REXEkBJSIirpSNAbXb6QJcRNfiAl2LC3QtLtC1uCDrrkXWDZIQEZHFIRtbUCIisgi4OqCMMduNMdtSCxbO+P2FZJrXYlEsVXKla2GMCRpjtqT2ecSJ+jJpGj8X21J/Fv21uGi/RX8tjDE9xpinjTGfyHRtM+HagDLGbAeYWH4jtRzHtN9fSKbzvaaWLVnwpnEt7gPqJq7HQv7lZRp/R7YAW1LvbzHG1GS+ysyY7r8Hqe0L9jrAtK/Fe6y1d1y0koQruTaggBuAptTXTcCWGb6/kCym73UqV7wW1trd1tqJm8E1F+27EE11LV601j5qjAkCTdbaRXstAFIBvZCvwYTp/HsRzIZfWNwcUMFLXpfN8P2FJHjJ64X8vU4leMnrSa9F6i9fZIEvgBm85PXlfi7qgMb5LcVxwUteT3YtahZ4SE8IXvJ6smsRAiLGmF3zX87suTmgoiQv4mzfX0iiLJ7vdSpRpncttltrPzzPtTgtyjSuRSqkaye6fhaoKFe4FsaYbQv8l5WLRZni5yLV0xAFom7+uXBzQL3Ahd8EaoBLBwBM9f5Cspi+16lMeS2MMdsn+tZT92EWqiteC2PMIxfdg4uysH/JmernIpIaNLAdqFnkPxc7suX7d21ApW5y16Ru8AUvuuH39JXeX4imuhapr7cBdW7+bSgdproWqe2PGGMOGmMOsoD/UZ7Gz8UuoOmi97PuQc3pmsa/Fy+mtoX4zS6wBWUaPxffTr3eftH+rqQHdUVExJVc24ISEZHFTQElIiKupIASERFXUkCJiIgrKaBERMSVFFAiIuJKCigREXElBZSIiLiSAkpERFxJASWSBsaYGmNM40VTLi3o9ZdEMkEBJZIenwTuAF5Mrdhat0iWdhCZN5qLTyQNjDFBa200tThg3UKevFgkUxRQImkysYSBtfZFp2sRWQjUxSeSBqmlC5omwmmhL3sikgkKKJE5Si0KWAPsMcYEU/egos5WJZL9FFAic5AaqdeUWsG3CTgFNOoelMjc6R6UiIi4klpQIiLiSgooERFxJQWUiIi4kgJKRERcSQElIiKupIASERFXUkCJiIgrKaBERMSVFFAiIuJK/z+9KmIp6Dp4GQAAAABJRU5ErkJggg==
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAxPElEQVR4nO3deXhb133n//cBQIAENxAkKFILJVGSZdOyJUu069jOxEkVJ3aSRkkUJ3HyTOuOI9dp+kyfjupkpvn195uM50nsOJOmaca1nNjZ3NaxptVkbyI7raM4SkxLlixTCxft3Bdw3wCc3x8ALVmWxEUg7gX5eT2PHgEXF/d+DYH8+Jx77jnGWouIiIjbeJwuQERE5GIUUCIi4koKKBERcSUFlIiIuJLP6QJERGTmXn755XKfz/cNYB3Z3dhIAIdisdh9mzZt6jj/BQWUiEgW8vl836ioqLgmEon0ejyerB2OnUgkTGdnZ01bW9s3gD84/7VsTl0RkYVsXSQS6c/mcALweDw2Eon0kWwJvvE1B+oREZEr53F7ONXX1/vvvPPO6qn2S/13vCmPFFAiIjInampqxr/73e+enO37FVAiIjIn6uvr/UeOHAnM9v0aJCEikuX+cueBZcfaBoLpPOZVFYXDX9q6/vTl9nn00UfLbr755uG9e/cGt2/f3vXUU0+VfP/73y+5++67e5uamvz33HNP74MPPrjkxRdfbOjq6vL+zd/8TVltbe1wXV1dMBQKxbdv3951ueMroEREZMY+97nPLaqtrR2+7bbbhru6uryPPvpo2fbt27v++q//eslPf/rT5sn9iouL4wB79uwJhkKh+JYtWwYef/zxyPn7XIoCSkQky03V0pkLL7/8cv4999zTC3DVVVeNPf7445Ht27d3rVu3bvhi+2/ZsmXg0UcfDezatavwy1/+8pnpnEMBJSIiM7Zp06ahY8eOBWpqasaPHTsW2LRp09Dl9t+zZ0/wrrvu6q+pqRmf7jk0SEJERGbsoYceaq+rqwvu2rWrsK6uLvjQQw+179q1q/DQoUPBPXv2BCEZSocOHQrW19f7b7vttuEPf/jDq+68887qBx54YElXV5d3qnMYrQclIpJ9Dhw4cGL9+vWXHWTgJp/73OcW/fmf/3lXWVlZvL6+3v+1r30t8thjj52dfP3AgQNl69evX3H+e9TFJyIic662tnb4hz/8YVFJSUmst7fX9/GPf7x3qvcooEREZM5t2bJlYKbv0TUoERFxJQWUiIi4kgJKRERcSQElIiJp88ADDyyB5DRI52+fHHo+EwooERFJm6effjqybNmydatXrx6b3LZr167C+++/f/lMj6WAEhGRtPnOd77TdPr06UPnj9rbsmXLQHFxcWymx9IwcxGRbLfrT5fRUZ/W2cwprxlmy9cvO8ffAw88sORd73pXP0BjY2Ng+/btXXV1dUGAydklrqQEtaBERGTGHn300bLS0tLYZEspGo16ITkF0pYtWwa6u7t9u3btKrySc6gFJSKS7aZo6cyFffv25X/qU5/qhORs5nV1dcGnnnqqBODee+/tLS0tjTU2NgaAGd+gO0ktKBERmbGNGzcO7d27Nwhw7NixAMCaNWvG3ve+9/UDNDc35958880XXXpjuhRQIiIyY9u3b+9qamoKTM5mDnDbbbcNf+tb3yp56qmnSqqrq0dvu+22YYCnnnqq5NChQ/mTLazp0mzmIiJZyE2zme/Zsyf4s5/9rPBKBkVcbDZztaBEROSKPP300yXPP/980XTWeJoJDZIQEZErcv66TumkFpSIiLiSAkpERFxJASUiIq6UddegysrK7IoVK5wuQ0TEUY888gj19fXTnoB1bGwsdsMNNxyYy5rg3CzmTU1NgfOvTe3Zsyc4Oex8urIuoFasWEFdXZ3TZYiIOOrw4cNcc801097/0KFD43NYDpCctfyuu+7qr6mpGb/zzjurd+3aVbhly5aBXbt2Ff7VX/3V0tdee+3wTI6nLj4REUmLxsbGwE9+8pMigBUrVoylpjrSbOYiIgvVw797mCM9Ry67z+DQYK7vhG/tdI+5umT18P+49X/MeDbzydcOHDgQ/PjHP9473fNdjFpQIiIyY5eazRyS15ve8Y539M/0mtOF1IISEclyn7npM1Puc+jQodF169YdTdc5Lzab+eRrVzrt0SS1oEREZMYuNps5JFtWk+F0petBKaBERGTGLjab+a5duwo///nPL122bNm6oqKiDZP7znY2c3XxiYjIrEze51RWVhb/2c9+Vrhly5aB/v7+Vy7c79577+299957ZzxgQi2oeaB/dIJvv3iCWDzhdCkisgBpNnO5pO+8eIJHf36MUDCH929Y4nQ5IrLAaDZzuaQfHWwF4Jt7jqMFKEUWjvny855IJAzwpi4gRwLKGLPxEtsfzHQt2a6xY4AjbQNcu7iIg2f6ePnkFd0XJyJZIjc3l+7u7qwPqUQiYTo7O4uBQxe+lvEuPmPMZuBhYNNFtt+Y6Xqy3Y8OtmIMfP2ejbz/67/mm3uOU7si7HRZIjLHli5dypkzZ+js7JzW/m1tbb54PF42x2XNRgI4FIvF7rvwhYwHlLV2tzGmJ9PnnY+stfzoYCs3rQizoiyfj91UxY4XmjjdM8yycHDqA4hI1srJyWHlypXT3r+mpuZVa23tHJaUdq64BmWM2Wit3e10HdnmaPsAjR2DvHf9YgD+8JbleIzh2y+ecLYwEZE0cEVAAeqTmoUfHWjFY+Dd11YAUFmcx13XVfLMS6cZHJvxxMEiIq7i+DDz6bSejDHbgG0AVVVVGanL7ay1/PjVVt5SHca89k2+c/BJjjPGgElQsQx27HoPf/GRR5wuU0Rk1hwPKKDaGFN93uON1tp95+9grd0B7ACora3N7iErafJaSz/jvUdYV/Rt7jrcz0jAQ8j4WO4J0jvRx6HOF4knLF6PcbpUEZFZcWIU31ag1hiz1Vq701q7M7V9GxDKdD1ZJT4BXceg9SAv/m4nrDrCP3g9vLvoGj51+yOsLEnm/Iee3MCQZ5DnDrdzR6r7T0Qk2zgxim8nsPMi219vJclFxCfgq+uhP3nD9r8uriTP5vHE7V+hZvntb9h1mb+QY/EevrnnuAJKRLKWWwZJyFT6zyb//N6f8PL7f8BRv5+1lR95UzgBLM6L0OmDuuMdHDrbl/laRUTSQAGVLfpbkn+vuYMnT5zBGMuHat560V0XFy5j1ONhRW4rT/76eAaLFBFJHwVUtkgFVKJwCXvPvoSxXt6y9KIzRlFZshqAO1b18cMDLXQMjGasTBGRdFFAZYu+MwAcGMhnxNvA0vyryPPlXXTXxZFrAVhd2k0sYfneb05mrEwRkXRRQGWL/hYIFPHP9Z148s7wH6puuuSui8s3ADA4dpbbr4rwL6/MyUz4IiJzSgGVLfrPYouW8NNjv8WYBLcsuXRAFeWVkG+hZbiNG6pKONM7wsh4PIPFiohcOQVUtug/S19OhH6OYTBsSLWSLsYYQ6XJoWU8yuryAqyF5q7BzNUqIpIGCqhs0d9C01gROfknWBO6iiJ/0WV3X5xTRGt8hFWRAgAaOxRQIpJdFFDZIDaOHezgt715+IKnqK3YNOVbKvMitHgMKwrjeAw0dQ5loFARkfRRQGWDgVYMlv0GEoyzadHUAbWkcBkDXg8TvceoCgdp6lQLSkSyiwIqG6TugTqVl7yfaeOii9//dL7K8BoAWtoPsipSQJO6+EQkyyigskFq/r2uvD6WFSynLG/qVZsXR64DoKX7CKvKC2juGiKe0ETwIpI9FFDZoP8sCWAir42bKqe3YvPi0rUAtAycYnWkgPFYgrO9I3NYpIhIeimgskF/C0dzCrDeUdZH1k/rLeG8UvwWWofaWVWeD0Bj58BcVikiklYKqCxg+87wG38IgJrSmmm9x2M8VHr8tIxHXx9q3tShkXwikj0UUFkgFj3LgZxcvCaH6lD11G9IWZxTTGtijFCuj7ICv0byiUhWUUBlAdt3lqaAh6X5q8jx5Ez7fYuD5bR4PTDYTnWkQDfrikhWUUC5XWwc70gnLYEJ1pVNr3tvUmVhFd0+L6PdDawuL1ALSkSyiiMBZYzZeMHzbak/DztRj6sNtnHW52XCG6e28roZvXVx+CoAWjteZVWkgN7hCboHx+aiShGRtMt4QBljNgNPXPB8t7V2B1Cdei6T+luoD/iB6Q+QmFSZWheqtecYqyLJkXya8khEskXGA8pauxvoOW9TNTAZSs2p5zKp7wz1fj8evKwJrZnRW5cUrwCgpf8Uq8tTI/nUzSciWcLndAGpltOkjcAzTtXiRmO9Z6gP+CnLWUaOd/oDJAAiwQheCy3D7SwuziM3x6OBEiKSNVwzSCJ1XeoX1tp9TtfiJn1tJ6j3+1lZPLPuPQCfx8ciXx6tw214Xvke1WUaKCEi2cM1AQVsttY+crEXUgMo6owxdZ2dnZmuy1Gne5sZ8Hq4YdG6Wb2/svRqThSEif3gz7gnsEcBJSJZwxUBZYzZNhlOFxskYa3dYa2ttdbWRiKRzBfooMaxVgBuXTa9KY4utKF8I4cY410rV9A/+hjXDf6Q0Qkt/y4i7ufEKL6tQG3q78lAetgY02SM6c10PW53gn48Fq4pWzur93/6hk/z1bd/lTUVN/JYSTF1K3/OvvpfpblKEZH0c2IU305rbYm1dmfq+e7U81Wpv3dnuibXik/QnBNnUbyAgDcwq0P4PD7eUfUO/v5dT/D5lfcz4vFw8OSeNBcqIpJ+rujik4sb6z3L4YCfZb5FaTne7y2/EYCzfafScjwRkbnk+DBzubTXju+j1+ulunB1Wo5XEVmNP2HpHO9Iy/FEROaSWlAutud08lrR9ZVTL/E+HZ68MIvicXrjutQnIu6ngHKpva17+Xb/c6wZi/HWdXel56DGUB439JthLf8uIq6ngHKhl9pe4s+e+zTLJ8Z5T+d6QoWhtB27nBwGfONa/l1EXE8B5TKvdLzCnz73pyz25PJEaztHSrem9fgVvnz6vQmOtUfTelwRkXRTQLnM/37lf1PoL+SJzj4a4tdQsOSatB5/WW4Ya+Bg28m0HldEJN0UUC7TMdzB+twKyntP8d2J3399FvJ0WZpfDsDhLg01FxF3U0C5TPdoN+HoGcYDpfw8UcvqSHoDqrJgMQBnogooEXE33QflIrFEjOhYlNLefuorPsBEny/tLaiKwmUARIfVxSci7qYWlItEx6IAhOMxfp77bkLBHML5/rSeI7ewgnA8jqWTnqHxtB5bRCSdFFAu0j3SDUBpqJqX+opYHSnAGJPekwTLqIzF8OT0aukNEXE1BZSLdI8mAypcuJimzqG0d+8BkB+hMhYnnjOg1XVFxNUUUC4y2YIK5i6iZ2h8jgKqjIpYjPGcERrbB9J/fBGRNFFAuUjPwFkALMmh4KvmIqByQ1TGE8Q8cY52adJYEXEvBZSL9AycIcdaumNlAGkfYg6Ax0OlNw+A5t4z6T++iEiaKKBcpHuojXA8TtNoAXk5XpaE8ubkPJU5xQB0jLRp+XcRcS0FlIv0jHRRGo9zaCBIdSQfjyfNI/hSKvOSLTTji9LcOTQn5xARuVKOBJQxZuMFz7caYzYbYx50oh636B6LEo4n2N8TmJsBEinhvAh+C56cqIaai4hrZTygjDGbgSfOe74RwFq7G4heGF4LSc/EEKXWQ2MfrJqL608ppqCcyngckxPVUHMRca2MB1QqiHrO2/QRIJp63AxsznRNbmCtpScxRrEned1pLltQ5JdRMTFBbm4fJ7vVxSci7uSGa1Ah3hhYpQ7V4ajBiUHGsQRNPjDHARUspTIWw5vTy8me4bk7j4jIFXBDQAnQM5rMaJ8txOsxrCjNn7uT5ZdRGYszbgY41dM/d+cREbkCbgioKBBOPQ4B3RfuYIzZZoypM8bUdXZ2ZrC0zOlJzSIxPlHE8nAQv28O/2lS8/GBpWesi8Gx2NydS0RkltwQUM8A1anH1cDuC3ew1u6w1tZaa2sjkUhGi8uU7v7TAERHi+dmBonz5U8GVHIk36ludfOJiPs4MYpvK1Cb+htr7b7U9s1AdPL5QtPTl1yf6exgaG6vP8HrE8ZC8l6oU7oOJSIulPEFC621O4GdF2zbkek63KZ7IDntUM94OXfMdUDllbAongBSLagejeQTEfdxQxefAN3DHYTicToIz30LyuMlN6+ERZ4AgWC3WlAi4koKKJfoGekmHE/QYUvm9Cbd1wXLuJoAOXmtnNQ1KBFxIQWUS3SP9xNKQEmohPxABnpe88tYG4cJbxsne6Jzfz4RkRlSQLlET2yI/Lhv7kfwTQqWcs3oCJCgdeQEsdQ1KRERt1BAuUR3YpycmH9u1oC6mPwIawejycf+Flr7RjNzXhGRaVJAucBEfIIBYzGxvLkfIDEpv4ylgz3kefPx5LZooISIuI4CygV6RpOzSCRihaxZlKkuvjIMljVF1XgDLRooISKuo4Byge7UTbrjsaIMdvEl5+RdV7gUT24rx7sHMnNeEZFpUkC5QE9vc/KBp5ySfH9mThpMrqpbkxvBeCZo6GnOzHlFRKZJAeUCky2o/IKqzJ00PxlQV3uTs6afGGjI3LlFRKZBAeUC3YOtAJSXrsncSfOTk+5WWw8efHSPH8dam7nzi4hMQQHlAu0DbeQmElRWZjCg8pIrnOQM91DmX07Md5bo8ETmzi8iMgUFlAu0D/cQiltWLlmUuZN6fVB+Lbz6LCsLqvHktnBCy7+LiIsooFygd2KAwrhhTXlhZk/8rv8JPc383mgXHt8Qh9pPZ/b8IiKXoYBygb7EKMF4DouKApk98aq3w7oPsan5OQAOdryW2fOLiFyGAsoFoiZGkCDGmMyf/I7/ydqEwVho6jua+fOLiFyCAsphNpEg6oUCb5EzBRRVkn/7f6MqNsHY0EvO1CAichEKKIed6mwibgyhvFLnirhpG1UxP+PmpHM1iIhcQAHlsF8d/SUAa0vWOleE10cwUEWPF0ZGNau5iLiDAsph+9vq8FnLTVU3O1pHKC/CuMdw/OQRR+sQEZk046VbjTErgI1AGAgBzUDUWvv8bIswxmwFokC1tXbHbI+TjRqGG6kZG6eq6mpH6ygvXgYddZxsOUTN2g2O1iIiAjNoQRlj/tIY83PgYWAVYIC+1OM7jDE/N8Y8ZozZMJMCjDEbgWZr7W6gOfV8QRiPj3OabtaPjeMtqnS0lqXlqwFo62x0tA4RkUlTtqCMMSuB+4F/stZ+aYp9i4Ftxphaa+03ZlDHw8A7Sbagds/gfVmtvruemEmwdtwP3hxHa1leuRYOQbT/lKN1iIhMumwLKhVOv2+t/ay19pWpDmat7UuF2HPGmPumU4C1dh/JllMT0DOd98wXL7XtA+AqE3a4EigtXg7A0Fi7w5WIiCRdNqCstcdn2BKa8fuMMSGS158eB54wxlRfZJ9txpg6Y0xdZ2fnTMtxrd+cqaNy3BIqXOp0KZTklgAwEut1uBIRkaQZj+IzxqT7jtJtwBestY8AHwa2XriDtXaHtbbWWlsbiUTSfHpnWGup7z3IDWNj5IaXOV0OAW+AvIRh3AySSGjZDRFx3myGma86fyCEMWalMeYd6Sgmdf0pmo5jud3J/pMMxfq4aXSIwkXLnS4HgGLjZ9w7RufgmNOliIjMPKCstfuBG1PDzbHWHgdKjDFfmE0BqZbTNmPMVmPMtoUyzHx/x34AbhgbwxdyvosPIOTNZ8ib4FSHuvlExHmz6eJ7BmgCes/r7ttNsqtuVqy1j1hrdy6UcIJkQOUkAqyYiEHREqfLAaA0t4Rej4eulmanSxERmVUX3yagzlrbB5jU0PLNwBfTWtk8t79jP+HhouQ/QNFip8sBoLxwET1eL4Ptx50uRURkVgH1YVKtpVRIhYGSqe6RknN6Rns40X+CZaN+LAYKnb1Jd1JZ4WJ6vR5Ge3QvlIg4b8ZTHaWuQe0/7/lxY8zLxpgN07lXSuCVjlcAqBmxxPLKyPH5nS0oJVxURdwYxgY0q7mIOG/GAXUx1tr9qa4+mYajvUcBw4bxITxl7rj+BBDOXwRAbLzF4UpERNI4m3mqu0+m4WT/SXIpZZU3itclI/gAwnnJGS18tovBsZjD1YjIQjflVEfTnbIoHe9bKE71n4JYGRV0u2YEH0BJIDmbhM/Xz6nuYYerEZGFbsqpjkjOq/f307kZ1xhTZIz5S5Lz9814iqSFwFrLif4TjA8VErTDrhnBB1A6uaqvb4hTPUPOFiMiC96U16BSIfUnxphPGmM+C1hgH9Cd2qWU5LpQq0jeH/VI6j1yEdGxKAPjAxSM5iY3uKgFFQqEABj2Jmhtb4d17hhdKCIL07QHSVhrnyA5mWsxUEsylMLAcZLrOe2/zNsl5WR/coRcZCLVeC12T0D5PD5C3jx6vAMUtp8ENjhdkogsYLMZZt4HPDcHtSwIkwG1dCKR3OCiLj6AkkAxPd5uAroXSkQcNqtRfMaY+1Kr5943B7Obz2sn+0+C9bDJnxol55KbdCeF88ro8Xgw/WedLkVEFrjZzMX3RWA1yeXe7waOG2P+U7oLm69O9J3EToS5vmAY8iPgCzhd0huE8yvo8XrJHWkjFk84XY6ILGCzuVH3JWvt/5l8klpw8LPGmA9aa/85bZXNU8d6jhMfL2V5ThQC7rn+NCmcV0q3z0clXbRER6kqDTpdkogsUFd8o661Nmqt/SzJ0XxyGdZaWoZOkxgvIxzvdNUIvkmluaX0ewzldHG8W0PNRcQ5swmoZmPMS8aYt19w/an7ku8QADpHOpmwo4T9i/ENtLpugAScW/o939dDY8egw9WIyEI2m4D6CPB94AHgRCqs/hWoNsYUAhhjPpjGGueN5ugJAG4oWwpjfa4MqHBucrojv6+fhrZ+h6sRkYVsNgHVBDxrrb3bWhsmufTGbuAO4KQxpgF4OI01zht7Tx0B4B3lqd7QYvfMwzdpMqAGvAna2844XI2ILGSzWfL9CZJLvK9IPd9vrf2StfaOVGB9hOTNu3KBfa0N2ISX28tSy2u4sQWVmjC2x+tluOsk1lqHKxKRhWpWy21cbtYIa+0+Y8xnZnI8Y8xGoDr1/p2zqSkbHO87gS8RoWw0dY+RCwOqNDfZuuvxeqmaOE57/xgVxbkOVyUiC1Halts43yymPbo/FUzVqbCad2LxBNGJVpbkhOG5z0PkaiiucrqsNyn0F+I1XrpzctlgmjjWPuB0SSKyQM1JQM2EMWYryetaWGsfsdbuc7ikOXGopRd8Xbx18DXw+uGeZ8CblvUi08pjPJTkltBdGGGDp5EGjeQTEYc4HlDAjUCpMWajMeZBp4uZK88fOQieOKvGBuFjz0DJCqdLuqRwbphoXhFXe05zorXD6XJEZIFyQ0ABdE+2nFItqjcwxmwzxtQZY+o6OzszX10aBOu/DMCKW/4Clm5yuJrLC+eG6fH58JKAllecLkdEFig3BFQT0Jx63EyyRfUG1tod1tpaa21tJBLJaHHpEIvF8cUOA7D8uo86XM3Uwrlhem1yMttQ70GN5BMRR7ghoHaTGsGX+vslB2uZE8eaGujOiRHARyTP/QEbzg3TM97HQN4Srokfo71/zOmSRGQBcvwqvbW22RgTnezamy/DzOOJOH+7/29pG2rj1KljtOcHWRaswBjjdGlTCueGGZoYom/RBjYM/4aGjgENNReRjHM8oCDZhed0Del2pOcITx56kvK8chgbpDyeYEuN+7v34NxsEqPLrmP1iR/z7yebYI37W34iMr+4IqDmo4ZoAwA73vkEp/7mPmpyR1l07R86XNX0TAbU347WsyQcovn0Y9zSX8nyouUOVyYiC4kbrkHNSw29DQS8AQYHQ1zNccYj65wuadquLbuW6yPXc2S4jV2FBbzo2cdTh55yuiwRWWAUUHOkobeB6uJqXj3aRKXpIbTqTYMTXas8WM7Tdz3Nzz/8C57tLKRqzEPXSJfTZYnIAqOAmiMN0QbWlKyh89jvAChcWetwRbMzULqeRfEROod6nC5FRBYYBdQc6B3tpWuki1XFq/F0HExurLjO2aJmyVt1I2WJGN2DbU6XIiILjAJqDjRGGwEI2CWsiTczmF8FucUOVzU7ZVffSkk8Qf9En9OliMgCo4CaA8d6jwHQ2V3COnMc75INzhZ0BUqWrCUv4WWEcSYSE06XIyILiAJqDjT0NlDkL6LpeD9Vnk7yqrJ3BRHj8ZBjCwDoG1MrSkQyRwE1BxqjjawJrWH41CvJDZXrHa3nSgVzQgD0jGighIhkjgIqzay1NEYbCdglrJpI3qxLRXYHVFFeOQDHe7NzJnkRyU4KqDRrGWphaGKI104EuTnvDLZ4KeSXOl3WFYkULwXgSNsphysRkYVEAZVmDb3JVlNrZ4ibck9jKjc4W1AaVFWsAeBsR5PDlYjIQqKASrOjPcmAekthIQWDJ7L++hPA4vJkQHX3n3G4EhFZSDRZbJr92/GD+Cby+ebY/5u896nm/U6XdMX8JVUUxhMMjmv5dxHJHLWg0mginuBU1z5unujGHyyG+56DyFqny7pyhZWUJOKMxKNaXVdEMkYBlUZ7/+/fMezro8oXxnzyeShb43RJ6ZFbRCgBcc8wHQNaXVdEMkMBlSZjw33kHv4KMWO47m2fhWDY6ZLSqtj4iXnHONY+4HQpIrJAuOoalDHmQWvtI07XMRMNvQ0c6jpE82++z0Bqur01ZTXOFjUHSnLyGYkPcqx9kLdqdV0RyQDXBJQxZjOQPYsmkbwp99PPfZqWoZbkhsICInkRqournS1sDpQGihkcHeBYW7/TpYjIAuGagMpGzX3NtAy18IlYFf/x7G85ftdObtx4KzmeHKdLS7uSvFImxs/S2KGRfCKSGa64BmWM2Wit3e10HTO15+weAO5p+S2HgndyS+3t8zKcAEL5yemOunoaNZJPRDLCFQEFZOWIgl+f/TXL4j5KYl4q3vfXTpczp8KFyemOcuMttPdrJJ+IzD3HA2o6rSdjzDZjTJ0xpq6z0x0Tlg5PDFPX+lvePtjDj0rv5bq182RI+SWEipYDUOzrpKFDI/lEZO45HlBAtTFmqzFma+rxmxZPstbusNbWWmtrIxF3jCB7bu83mCBB4dhK3nnv/+d0OXOuJLwKgKC3h2Ptgw5XIyILgeMBZa3daa3dSbKbL+RwOdPS33GKulf+Dn/C8ra7v0NpYa7TJc25klByZGJBoJ8G3QslIhngeEBNSrWSVllr9zldy+VMjI/R+o2P8lKul2uKruea5VVOl5QRBYEifBYC/iEaOtSCEpG555qAygbWWn765EMEE0c57fdxZ817nC4pY4wxlODBekc41jZAPKGRfCIytxRQM/DtX9Rxe+s3+EHpNQDctuQ2hyvKrJAnwJhnjIGxGK+19DldjojMcwqoafrxwVZyX3iIfDPG4RVrWFqwlKrChdG9N6kkJ58BJgDLrxu7nS5HROY5zSRxCY29jRztPUrcxmnu7OOHL/yGPy55me+tuIPf9bzGH6z6A4wxTpeZUSX+Io6aVm6IGF5s6uKB21c5XZKIzGMKqEt44LkHaBtqO7dhEXyREhh8DY/xcMfyO5wrziGhvFJ6vR7uWRrnbw/1MBaLE/B5nS5LROYpBdRFdA530jbUxrbr7+dX+1ZQfeaH/IXnWXx3PoLv+rsJeAMEvAGny8y4kvxF9Hs81JYOMzpRyP5TUW6uLnW6LBGZp3QN6iLqu+sBONuyjKrmF/iCfYby6t8nvPGPKfIXLchwAigpXIo1hiW5XXgMvNjY5XRJIjKPKaAu4rXu1zAYhn/zKx7J2QHVt8Pd3wHPwv64SoqSg0JGh89y3ZJiXmzSQAkRmTvq4puUSED9v8DYAAeaf0rJeC5f8X0Tu/w2PB/9B8jJc7pCx4WCZQD0DpzhltVlPPFCM0NjMfID+hqJSPot7CbB+Y7+GHb+MfzwP9PQ38itY12MLXkL3o9/H/xBp6tzhXBuctL56HAHt64qI5aw/O54j8NVich8pYCatO+7UFjJF9Z9m06fD++q+wne92OF03lCgRAAPSPdbKoqxu/18GKTrkOJyNxQ3wxAfys0/oLGqz7JN440ElwGH9j4Tlhg9zlNpSS3BIDoUDt5XyijPsfLcF0QNv0MKtY5XJ2IzDdqQQEc+EewCf7syLUsWdSFx3i4Ony101W5jt/rJ9+XR++KW+D2/8qBpZ+gyA4wXP8zp0sTkXlIAWUtdv/3OBK4jtNUsGZZHyuLVhLMUdfexYRyw/SWrYTbPwvv/O80Jyrob/iN02WJyDykgDq1F9PTxBMDt/KZd6/leP9RakprnK7KtcK5YaKjUQCuX1rMq2YN+Z37wWp2cxFJrwUfUKO/+xZD5NK29F3ccV2QzpFOBdRlhAIhekaTI/dyvB76Sm+gMNYN0VMOVyYi883CHiQxNoCp38WPE7fw37fexJHelwG4tuxahwtzr5LcEl7tepWnDz8NwGtLEjwdK2B471cJrtj0hn0NhhxvDjmeHPJz8rl96e3keHOcKFtEstCCDqj6X3ybGjuKueETrC4v4OevJCeCXVuy1unSXGtNaA0/aPoBX/zdF1/f9pPSMHT8IvnnMr78ti9zx4qFN8muiMzOgg2ogdEJxl/+Hqc9S3j/e7cAyTn4NEDi8v5o3R/xgTUfwKauOSWs5eCX7qQ0YFn2n//1DfsmSBBLxOgb6+ODP/ggrUOtTpQsIlnKFQFljNmWerjKWvuZTJzzif/7HH9hD9Oy6UH8OcklI+q767m58uZMnD6rFQeK3/B8vHgDV/c+i88bwFxkSqhIXoRcby6dw52ZKlFE5gHHA8oYsxnYba1tNsY8a4zZbK3dfSXHHBwf5GDXQcbj40wkJhiPj7/+eCIxQXNXH81nfsDXQ8VMhBNMvPQlRmIjGiAxS4GVN5PT+4+cObyXpde//U2vG2OIBCN0jHQ4UJ2IZCvHAwqoTv3ZATSnHl+Rr+77Kv909J8uv1MZ1FGMr+mf8Xv85HhzWFKwhFuW3HKlp19wVm64HfZB22u/umhAQbIVpRaUiMyE4wFlrd1x3tONwDNXesyT/SdZHVrNQ7c+hM/jw+/14/f6yfHk8MQLJ9n/q938Y84X8W15HLPho1d6ugVv2bLlnDWLMGfqLrlPJBjhaM/RDFYlItnO8YCaZIzZCPzCWrvvSo/VNtzG6tDqNw0XP3S2j6de6OTpyAFyRgqg5n1Xeioh2YXXUXQdS/r2k0hYPJ43z2EYyYvwq+FfOVCdiGQrN92ou9la+8jFXjDGbDPG1Blj6jo7L99NZK2lbaiNRcFFb9g+Hkuw/dkDVAYT3DT8AtRsAX9+2opf6DzLbqSCbo41XLyVFAlGGI4NMzQxlOHKRCRbuSKgjDHbJsMpNWjiDay1O6y1tdba2kgkctlj9Y/3MxIboTK/8g3b/+75Bo60DfDYphbMxBBs+Fg6/xMWvKXXvw2AUwf//aKvR/KS/266DiUi0+V4F18qkB42xnwGCAMfntWBDvwTtL9G20QfABWNv4RT9WDjdPcPs/i1Fr5fkcu6hiMQqoIqDYZIp9LqTYzh5/rDj2Kf2oXBAAY8XvD4iHjjAHSOdLKieIWjtYpIdnA8oFJDykuu6CDxCdj1KTCGtmA+RIqpOLYbYmA9XryjCTZ7DeF4EPDBW/8LeFzReJw/fH6arvokfYd/iX84TjjfDzYBsTGI9VHedQiWLlYLSkSmzfGASovoKbBxeP9jtOV64bcPUfGnL0OwnEf/9Qhf/2UTT/3Rjbz96nKnK53X1nzkId7x5X8jTIBdf3gLZnLBx0SCsi8sBpItKBGR6ZgfzYie5uTf4WrahtvwGR+luaUcOB3l7/+9mQ9vWqpwyoAcr4cH3raaA6ej7Gk8byl4j4fC0HJyMWpBici0zb+AGmqjPFjORBy2P3uA8sIAn3uvZofIlA9tWkJFUS5/93zjG7ab8CoiCTSbhIhM2/wJKH8B5EdoG2qjIr+Crz7XQEPHIF/80PUU52mJh0wJ+Lxs+w/V/PZ4D7873nPuhfBKIhPjakGJyLTNj4DqboJwNRhD61ArARPm8X9v4qM3LuNtV11+WLqk38duqqI038/Xnm84tzFcTWRinK6hNucKE5GsMj8CqqcZwtUkbIL2oXbqGi2VxXn81XuucbqyBSnP7+W+t1bzq4YuDpyOJjeGq4nE43RokISITFP2B1Q8BtGTEK7mTF8HMRtjbLSQJ/5jLYW56tpzyidurqIo18fXf5m6FpUKqOH4mGaTEJFpyf6A6jsNiRjxkpVs3/UCAPffuomaxUUOF7awFebmcO+tK/l5fTtH2vqheCmRRHLYua5Dich0ZH9ApUbwfeuIh31njwPwzqu0ZLsb3HvrCvL9Xr7+yybweInklQG6F0pEpmfeBNTjr8Ita5Mr41bkVzhZkaSEgn4+8Zbl/OhgC82dg5QXLQPUghKR6cn6gDrR8CrDNsDGmqu5brkl4A0QCoScLktS7rutGr/Xw2P/1kRZyWoAOod1L5SITC2rA+rA6SjHj71Ku28xX/noDbQNtVGZX3luih1xXKQwwMduquJf9p9lPLCc3ESCzv5TTpclIlkgawOqo3+U//TtOlZ62llcXUOe30vbcBuL8hdN/WbJqPvfVk3Q7+ULvx1PDjXvO+l0SSKSBbI2oL5fd5qewRGqTCeB8mTXUdtQGxVBXX9ym8riPP7hkzfTECsnEo/T0t/idEkikgWyNqB+dLCVO5bG8CTGIVxNLBGja6RLAyRcat2SYr74x++hLJbg1EAXjR2DTpckIi6XlQF1rH2AI20DfGD5eHJDuJrO4U4SNqGAcrGaZWWUeoMMe8f46I69HGsfcLokEXGxrAyoHx1owWPgLSXR5IbwKtqGk3O8KaDcrSJYypjHYjyjfGzHXg639jtdkoi4VHYG1MFWbq4upWjoFPhyobCS1sFWAF2DcrlIfiUAX/lYNTleDx97Yi+HzvY5XJWIuFHWBdTIRJzmriHet34x9ByHkpXg8agFlSUioRUABEwrz9x/M/l+Hx/dsZfv7j1JImGdLU5EXMUVAWWM2WqM2WyMeXCqffuGJ/B5DO++tuL1WcwhOYKvMKeQAn/BnNcrs1dempyGqrPrMMtL8/n+n7yF65cW8//sOsSH/v5FdfmJyOscDyhjzEYAa+1uIDr5/FKiIxPctqaMkjwf9B6H8EogGVC6B8r9ysqvB6CztwmAJaE8nr7v9/hfd6/nZPcw7/3aHr7wk8MMj8ecLFNEXMDxgAI+AkRTj5uBzZfbeSKe4L3XL4aBVoiNvqEFpe499yssuyY5m8Tg2de3GWP44MalPP9f3sbWjUt5/IVm3vm/XuC5w+0OVioiTvM5XQAQAs5bG5zSy+0cCJzhyQN38uQBC0srofl7cPr/0DLYwgfKPjCnhcqVM/48ItawM1rP809ed9F9rrkK4gnLw7+Gh3+d4QJFxDXcEFBTMsZsA7YBlC4Lcn0guWwD3hyoWA8eL+sj69m6ZquDVcp03b/ivfym9beX3cday+BYjPF4IkNViYjbGGudHTlljHkY+IW1drcxZitQba195FL719bW2rq6uswVKCIyDxhjXrbW1jpdx0y44RrUM0B16nE1sNvBWkRExCUcDyhr7T4AY8xmIDr5XEREFjZXXIOy1u5wugYREXEXx1tQIiIiF6OAEhERV1JAiYiIKymgRETElRRQIiLiSo7fqDtTxpgB4KjTdbhEGdDldBEuoc/iHH0W5+izOGettbbQ6SJmwhXDzGfoaLbdDT1XjDF1+iyS9Fmco8/iHH0W5xhjsm4KHnXxiYiIKymgRETElbIxoDTrxDn6LM7RZ3GOPotz9Fmck3WfRdYNklioUjO9R4GNl5rt3RizUXMZykI1nZ+R1H4PXu51cQ9Xt6CMMVuNMZuNMQ/O5vX5whizEcBauxuITj6/YJ/NwBOZrs0J0/hebEv9eTjTtWXaND6Lzak/8/qzmM7PSGq/zcCNmazNCdP4Xjyc+ntbZiubGdcG1FRfuOl+IeeJj5D8P0OAZmDzhTukPoeeC7fPN9P4XmwGdqcmIK5OPZ+Xpvkz8s7U6xsX+s/IQjHN343bjDFNJD8r13JtQDH1F24hfSFDvDF8Sh2qww2m+nevPm9bM+fWGpuPLvtZWGv3WWs/k3paPc+7f0NM8TOS6gJfCOvNTed344ettavc/nm4+T6oEJf/wk31usxPIS7z737B0i0bSS6IOV+FmMbPQKqb5/5MFORyYacLyJAQU38vNhpjYIrrdU5zcwtKzoly7ocrBHQ7VkmWSHVr/GKetxqmJfUL6H5jTMjpWuZQlMv8jCyg1tO0WGsfSX0epW7uBndzQEW5/C/lqV6fT57hXFdVNbAbYJ7/wrmUKNP7d9/s5v8zTJMoU/xSPu/6QzPg6gviV2iqn5Hq1MCBranH8/l6XJTLfy8mPwdSr7m2G9zNATXVF+6ir89Hk62A1P/pRM9rFTw3uU/qC1d73hdvvpoyrI0x2ybDyc3/d5gGU30Wm3njLypXXxC/ElP9jFhrd1prd5L8PEKOFJk5U30vmjn3+3IV4NopkFx9H1RqCGQzyQu8O1LbXrbWbrrU6zL/Xe57kfoF9SzJPvgwyYvB8/Z/Xqb4LELA3SQ/i3daa3UdaoGY5u/OntTrru1pcHVAiYjIwuXmLj4REVnAFFAiIuJKCigREXElBZSIiLiSAkpERFxJASUiIq6kgBIREVdSQImIiCspoERExJUUUCJpkJqYtckY8+x5z0MOlyWS1RRQIumxGdgEPD65jLa1NupoRSJZTnPxiaRRqtUUttbO25nDRTJFASWSJpNdemo5iaSHuvhE0sAYUw3nwmnyuYjMns/pAkSyXWp11lqgxxizm+T1qCjzeIFAkUxQC0rkCpzXrbeD5Oqlx4Eb5/MiiSKZomtQIiLiSmpBiYiIKymgRETElRRQIiLiSgooERFxJQWUiIi4kgJKRERcSQElIiKupIASERFXUkCJiIgr/f/TusWw6asHCQAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -15019,8 +14754,8 @@ Wall time: 1.58 s
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 105 ms, sys: 51.2 ms, total: 156 ms
-Wall time: 157 ms
+<pre>CPU times: user 98.4 ms, sys: 66.8 ms, total: 165 ms
+Wall time: 165 ms
 </pre>
 </div>
 </div>
@@ -15057,8 +14792,8 @@ Wall time: 157 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 63.1 ms, sys: 14.6 ms, total: 77.8 ms
-Wall time: 77.8 ms
+<pre>CPU times: user 63.6 ms, sys: 48.2 ms, total: 112 ms
+Wall time: 112 ms
 </pre>
 </div>
 </div>
@@ -15099,7 +14834,7 @@ Wall time: 77.8 ms
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtGklEQVR4nO3de3Rc1X0v8O9vXhq937KxsS1Llgmyg8HIxDFOkxDz6g0pDS4kQFtIwZR0kTSrbkh6KTdtaYMd32alCXVtSEm5gZaE3Li3BtpiSNI6xmDZxsYYY71s/JCtt6znSDOz7x9zjjSSRprXmTnnzHw/a3lZmhkdbQ/CX//2/p29RSkFIiIiq3GYPQAiIqJIGFBERGRJDCgiIrIkBhQREVmSy+wBEBFR/A4ePFjlcrmeAbAS9i42ggCO+f3+B6699tqO8CcYUERENuRyuZ6ZP3/+lZWVlb0Oh8O27djBYFA6OzvrL1y48AyAz4U/Z+fUJSLKZisrKysv2TmcAMDhcKjKysp+hCrBqc+ZMB4iIkqew+7hpNP+HDPyiAFFREQpcfz4cc+tt95ak+jXM6CIiCgl6uvrx1599dXWRL+eTRJERDb3py8dWXTywkCekddcPr9w+DsbV52Z6zXbtm2rWLt27fD+/fvzNm/e3LVr167CrVu3zn/wwQe7WlpaPLfccsvA17/+9YX79u1r0l9fXl4eaGlp8dTW1o7df//9vXNdnwFFRERxe+yxx+bdcsstA+vXrx/u6upybtu2rWLz5s1djzzyyJLw4CkuLg4AwK5duwrLy8sD999/f++tt95a88QTT1yM9j0YUERENhet0kmFN954o+juu+/uBYDly5f7duzYUbl58+aulStXDkd6/fr164f//M//fH5dXZ3vM5/5zKVYvgcDioiI4rZq1arhkydP5tTX14+dPHky59prrx2a6/UdHR3Om2+++dJHPvIR3/r16yOG2HRskiAiorht3779XGNjY96uXbsKGxsb85544omLu3btKjx27Fje3r178wBg7969eceOHcs7fvy4BwB27NhR+ZWvfOXyW2+9tUZ/zVyE50EREdnPkSNHTq1atarL7HHE6uGHH164ffv2c7N9fuTIkYpVq1ZVh38Np/iIiCjl7rnnnt5nn322tK6uztfU1JRzzz33zNnBBzCgiIgoDdavXz+srz1xDYqIiGyNAUVERJbEgCIiIktiQBERkSUxoIiIKG67du0qXLduXV2k54qKiq5et25d3WOPPTZPf+zZZ58tne31s2FAERFR3G6//fYBfZ+96Z577rmWffv2NYXvtxdtY9hI2GZORGR3u/5oETqOG7qbOarqh3H7U1H3+NN3ktA3jgWA3t5e1/Hjxz319fVjyQyBFRQRESXk2LFjebfffvvA3Xff3fv888+X6o93d3c7q6qqAnffffeSZK7PCoqIyO5iqHRSYbadyzdv3twFAMXFxf5nn322NJHpPYAVFBERGWjbtm0VsWwEGwsGFBERxS18p/JXXnml6MiRI3ldXV3O++67rxcIde0Bk80R2k7n+frjseBu5kRENmS33cyjibSbOSsoIiKyJAYUERFZEgOKiIgsiQFFRESWxIAiIiJLst2NuhUVFaq6utrsYRARmWrr1q04fvx4zDs1+Hw+/zXXXHMklWMymu0Cqrq6Go2NjWYPg4jIVO+//z6uvPLKmF9/7NixpPbFm27Xrl2FW7dunb9v376m8Me7urqcJ06cyGlqasp5++2387Zv334OCN0X9fTTT1dMf/1cOMVHRERxm2038x/96Eel+/fvz9Nv0N22bVsFwN3MiYiy0pa3t+BEz4k5XzM4NOh1nXJdEes1l5UuG/6r6/8q7t3M9X34AODUqVM5N99886VYv+d0rKCIiCghs+1mDgDHjx/3lJaWBm6//faBRK/PCoqIyOYeve7RqK85duzY6MqVKz8w8vvOtps5ALzwwgulL7zwwulkrs8KioiIDPXss8+W6qfpJrOzOQOKiIjiNttu5rt27Sp8/PHHF65YseLKFStWXNnV1eUEsmQ384aGBsU2cyLKdgm0mQ+vXLny/RQOKSnczTxDXRodxz/tOwV/IGj2UIiIDMOAygDP7TuF//X/3sPL77abPRQiIsMwoDLA7qOhYPrh3jbYbcqWiBKXKf+/B4NBATBjCogBZXPNHQM4cWEAKxYU4ejZfhw8HffN2kRkQ16vF93d3bYPqWAwKJ2dncUAjk1/jvdB2dzuo+0QAZ66ezV+66lf44d729BQXWb2sIgoxS6//HKcPXsWnZ2dMb3+woULrkAgUJHiYSUiCOCY3+9/YPoTaQ8oEdkI4CGl1I0RntuilIp+xxkBCJX3u4+247rqMlRX5OOL1y3Gzv9qwZmeYSwqS/jWAyKyAbfbjaVLl8b8+vr6+neVUg0pHJLh0j7Fp5R6KdLjIrIBQE2ah2NrH1wcQHPHID67agEA4PfXLYFDBP+075S5AyMiMoAl1qBEpAZAq9njsJvdR9rhEOCWFfMBAJcV5+I3P3oZXjxwBoM+v8mjIyJKjiUCCkCNUmrWgBKRTSLSKCKNsc63ZjqlFF5+tx0fry1HZWHOxONfWr8UAz4/fnIg6ibERESWZnpAicgGpdSeuV6jlNqplGpQSjVUVlama2iW9t75S2jrGsJnr1ow5fGrF5Xg2iWl+NG+UwgE7d3dQ0TZzfSAAtAjIhu05okaEVlt9oDsYPfRdjgdgpu16b1wf7B+KT7sGcbr7180YWRERMZIe0BpzRANWiBBKXVIq6DKAJSkezx2FJreO4/rl1WgLN8z4/mb6udhYUkufri3zYTREREZw4wuvj1KqdLp3XzaNF6tUupQusdkN0fP9uNMzwg+e9VlEZ93OR24b1013mrrwbFz/WkeHRGRMawwxUdx2n30PNxOwc31M6f3dHeuWYQ8jxP/+GtWUURkTwwomwkGFV4+2o5P1FWiOM896+uKc924s2ER/u3IeXQMjKZxhERExmBA2czhM3043z866/ReuPvWVcMfVPjxm0mdukxEZAoGlM3sPnoeHpcDN9bPi/ra6op8fGp5JX7+zrk0jIyIyFgMKBsJBhVeebcdn1xeiULv7NN74a5ZXIqzvSMYGQukeHRERMZiQNlI4+leXLzki2l6T7esqgBKAa1dgykcGRGR8RhQNrL76Hl43Q5suDL69J6utrIAANDcwYAiInthQNlEaHrvAm74SBXyc2I/JaW6Ig8OAVo6h1I4OiIi4zGgbOJs7wi6Bn34RF18exHmuJxYXJaHlk5WUERkLwwom2juHAAA1FUVxP21tZUFaOEUHxHZDAPKJvQ1JH1NKR61VQVo7Rri7uZEZCsMKJto6RhCeb4HpRE2h41mWWUBxvxBnOsdScHIiIhSgwFlE82dg6hNYHoPAGqr8rVrDBg5JCKilGJA2YBSCs0dg1iWaEBp04ItHezkIyL7YEDZQNfgGPpHxrEsgfUnACjJ86CiwMNOPiKyFQaUDegNEolWUABQU1nAm3WJyFYYUDbQrFU+ia5BAaFwYwVFRHbCgLKBlo5B5HmcWFDsTfgatZUF6B0eR/egz8CRERGlDgPKBlo6B1FbWQARSfgatZX52rXYKEFE9pD2gBKRjSLyWtjnJSKyWnt8S7rHYwfJdPDp9K/nNB8R2UXaA0op9dK0h+4E0KA/LiKb0j0mKxv0+dHeP5p0QC0ozoXX7WCjBBHZRuzbYqeIUmpn2Kc1AF6b7bXZqCWJLY7CORyCmgo2ShCRfVhmDUpEagD0KKX2RHhuk4g0ikhjZ2enCaMzz2SLeX7S12InHxHZiWUCCsBGpdRDkZ5QSu1USjUopRoqK+M7bsLumjsH4XIIlpQnH1C1lQU42zuC0XEe/05E1meJgBKRjUqprdrHq80ej5W0dAxiSXke3M7k/1PVVuVDKTZKEJE9mNHFtwFAg4hsDPt8i4gcFJGDAMrSPSYra+5MvoNPN9nJx1ZzIrK+tDdJaGtMpdM+r033OOxgzB/E6e5h3LpyviHXqy7PDx3/zk4+IrIBS0zxUWSnu0OHDCbbwafzup1YxOPficgmGFAWZsQmsdPVctNYIrIJBpSFJXPM+2xqK/PRxuPficgGGFAW1tw5iAXFXuTnGLdUuKyqAD4e/05ENsCAsrCWJI55n83E6bpchyIii2NAWVQwqNDSMWTo+hPAgCIi+2BAWdT5/hGMjAcMD6jSfA/K8z1slCAiy2NAWdREB5+BDRK62kruyUdE1seAsqhUtJjraqvYak5E1seAsqiWzkGU5LlRlu8x/Nq1lfnoHR5Hz9CY4dcmIjIKA8qimjsGsSzJY95nU8vTdYnIBhhQFtXSaXwHn05f1+I0HxFZGQPKgnqGxtAzNJaygFpYEjr+nZvGEpGVMaAsaGKLoxQFlH78ezOn+IjIwhhQFpTKFnNdLY9/JyKLY0BZUHPHIHLdTiwsyU3Z96itzOfx70RkaQwoC2ruHERNZT4cDuM7+HTLqgqgFNDK03WJyKLSfqJuRgsGgAvvAiq5qsR94TBuuKwIOHfQmHGVVAP55VMeCt+Tr35BkTHfh4jIQAwoIzX+I/DK5qQv80MAOA3g6aQvFXLZKuCh/5ry0NKKfIiw1ZyIrCvtASUiGwE8pJS6cdpjfQBqlFI70z0mwwx1hn7/4otAgjfYnuoewl/823F8+VO1WFNdlvyY3toBdLw/42Gv24kFxbk43c0pPiKyprQHlFLqJRF5SP9cCycopfaIyCYR2aCU2pPucRnCPwo4c4Arbkn4Eu8cPodfBHPwzVW/AcwrTH5MLW/MOlW4pDwPp3uGk/8eREQpYIUmiTUAWrWPWwGsNnEsyfH7AJc3qUs0dwzC6RBUl+cbMyZ3LjAeOYQWl+XhDAOKiCzKCgFVMu3z8ukv0CqrRhFp7OzsTM+oEuEfBVw5SV2iuWMQS8ry4HEZ9J/GnQcExoCAf8ZTi8vz0DU4hkHfzOeIiMxmhYDqAzDnYotSaqdSqkEp1VBZWZmeUSXCiArK6GPe3dq9VP6RGU8tLssDAHzYzSqKiKzHCgF1AJNVVA2A18wbSpKSrKDGA0Gc6jJ4k1g9oMZnBtSSstA04oec5iMiC0p7QInIBgANYc0RLwGo0R4vsW2DBJB0BXW6exj+oEKdoQEVqpIirUNNVFA97OQjIusxo4tvD4DSaY9t1T60bzgBSVdQzR0DAAw+RXeOCqo4z43iXDcrKCKyJCtM8WUOvy/JgNJ2MTdyk9g5KihAazXnGhQRWRADykhJV1CDWFiSi/wcAwvbOSooAFhUlscKiogsiQFlJP9YUmtQhnfwAWEVVOSAWlKWh3O9I/AHgsZ+XyKiJDGgjJREBRUMKjR3DBp/BtREBTX7zbr+oEJ7/6ix35eIKEkMKCMl0cV3rm8Eo+NB4495jzLFt7hc7+TjNB8RWQsDykhJVFD68et181I1xTdbk0ToXig2ShCR1TCgjJREBdWSqmPeo1RQ84u8cDsFp3kvFBFZDAPKSElUUE0XB1Ge70FpvsfYMUWpoJwOwaJSbhpLRNbDgDKKUkAg8QoqJR18AOB0Aw7XrBUUEGo15xQfEVkNA8oofl/o9wQqKKVCHXyGbnEUzp03Z0AtKc/Dh93DUEql5vsTESWAAWUUv9amnUAF1TnoQ//IuPEdfLo5zoQCQq3mAz4/+obHU/P9iYgSwIAyShIVlL7FUWoDavYKSt80lqfrEpGVMKCMkkQFpXfw1VUZcMR7JO68OSsovdWc90IRkZUwoIwSGAv97kysgirIcWFeUXKn8c4qSgW1qCzUiv5hN1vNicg6GFBGmaig4g+Zpo5QB5+IGDwoTZQmiTyPC5WFOaygiMhSGFBGmViDin+KLyV78IWL0iQBhNah2GpORFbCgDJKghXUpdFxdAz4UtcgAUStoIDQruasoIjIShhQRkmwSaJ5okEi1QEVpYIqz8OFS6MYHQ+kbhxERHFgQBklwTbz5ospbjEHojZJAKEpPqWAs71zv46IKF3iPrpVRK4GUKP96gPQA6BVKfWOkQOznUQrqM5BeFwOLNLuRUoJdy4wNncFtUQ7duNMz3Bqw5KIKEYxBZSIVAP4BoClAFq1X30ABEAtgJtEpAZAC4AtSqlT8QxCRDZq16tRSu2M52stI9EKqmMQNRX5cDpS1MEHTE7xKQXM0im4uEw/doOt5kRkDVEDSkT+FEAZgEeVUv1RXlsMYJOI9CqlnollACKyAaEK7JCIbBCR1UqpQ7F8raUkWEE1dQxg1eUlxo8nnDsXgAqFqDvy+CoKPMjzOLmbBBFZxpxrUFo4vaSU+ma0cAIApVS/Uuo7AF4Xkc0xjqERwE9FZDVCFZT9wglIqIIaHQ/gbO9I6qfUohy5AQAigsVlPHaDiKxjzoBSSn1HKdUW70WVUm1KqW0xvrYPwA4APwVwbaTXiMgmEWkUkcbOzs54h5MeCVRQLZ2DUCrFDRJA1EMLdTx2g4isJO4uPm09yjDaFN8epVQtgD5tPWoKpdROpVSDUqqhsrLSyG9vnAQqqOZU78Gnm6igYrsXKhjksRtEZL5E2sxLReQB/RMRuUNEbkhiDOFrTt9GaL3Lfvw+wOEGHM6Yv6S5YxAOAaorUtjBB4RVUNE7+Xz+IDoHfakdDxFRDOIOKKXUYQDL9FBSSv0MoS6+P0hwDDu1KbwNAO60dRdfAh18S8rzkeOKPdQSEscUHwBO8xGRJSQyxfcfABSAg9o9UUCo8tmayACUUn3aFN4e24YTEFqDSiCgalO5B58uhiYJgMduEJG1JDLFVwtgh9bVJ1pr+dPar+zl98XVIDEeCKKtawh189IRULFVUAtLcuEQHrtBRNaQSEDdBOBRESnSpvs2AHhbKfUNY4dmM3FWUKe7h+EPqtTuYq6LsYLyuBy4rDiX90IRkSUksgbVqpR6WCl1Sfv8ZwD6k2yUsD//aFwVVMqPeQ8XYwUFhBolOMVHRFZgyGaxSqmnAcR9v1RGibNJoqUzFFC1aQmo2NrMAS2g2CRBRBZg2G7midzQm1HirKCaLg5gQbEXBTlx79cbvxjbzIFQJ1/30BgGff4UD4qIaG5RtzpK5MZcEVkax1ZHmSHOCqq5czA91RMwGZyxVFDaprGsoojIbFG3OgJwo4h8O5agEpEiEXkSwB2xbnWUMeKooIJBhZaOofQda+FwAK7ox74DoXOhAODDHnbyEZG5os4vKaWeFpGlAP5QRK7B5FEbLQBKAJRrv9dqj23Nyum+OCqoc30jGBkPpPfcpRgOLQRCJ+sCvFmXiMwX0wKIFjjfAELTd5g8sLAfoeaIVq3lPHsFYr8PqrkzTXvwhXPnxRRQxblulOS52clHRKaLe4VeC6s2AK8bPxwbi6OCOtE+AACoS3sFFVvoLC5jqzkRmS+hFjJts1h9Su8n+j1RWS2ONai32rpRW5mP0nxPigcVJsYpPiAUUO+ei3r8FxFRSiWyF98/AFiG0HHvdwJoS2Kj2Mzh9wHO6IHjDwRxoK0Ha2vK0zCoMPqx7zFYUp6Hc70j8AeCKR4UEdHsEqmgXtN2jwAAiEgJgG+IyOeVUv/XsJHZiVIxV1Dvnb+EobGACQGVC4zF1pm3uCwP/qDC+b7RiaYJIqJ0S/pGXW038m8g1M2XnYJ+QAVjCqj9rd0AgI/VpPnYK09+zFN8+q7mbdw0lohMlEhAtYrIARH5bREpCnu826hB2c7Ece/RmyT2t4bWn6oKY991whBxNEno7e/6foFERGYQpeI73lu7EbcbwBqEdjJvQejeqAP6zbkicoNS6g2DxwoAKF1Wqj71vz+ViksnLhgAuj4ACi8DckvnfGlTxyCKvG7MK4rv7KikXWoHxgaBirqYXt7cMYhCrwvzimYG6YryFXhi/RNGj5CIUkhEDiqlGsweRzwSWYNqQWgd6jsAoN28uwGhU3W/iVBYAaEAM5zH6UF1UXUqLp248RGg/T0gpwwoWjLry/pHxuEf7cLiyhJcVpSbxgECGBkAhvqAGN+7i93dCI4B1UVTZ26b+5rxaturDCgiSrlE7oN6WkSuEREopU5pN+geBqAH1moATxo8zgmLChfhu5/+bqoun5juFmDfPwPX3wWsumvWl+34VQveOHcCf3ffZ9I/xbfnW0DTU8AfxvbePdb/Lv71nfP42y/dBBGZeHz7O9vx90f+HoFgAE5Hio+qJ6KsllCThFLqsFLq1CzPHQLwaDKDsp0Y16D2t3ajxoz1JyDUZh4YAwKx7VK+fF4hBkb9uHjJN+Vxr9YI4gv4In0ZEZFhDDtuI1y82x6JyGoR2SgiG1MxnpSbCKjZg8cfCKLxVG/628t1+pEb/tg6+fRGiZMXB6Y8rgfUSIzXISJKVEoCKgHfVEq9BKBMRGrMHkzc/GOh3+eooI63X8KAz29+QMXYar58XmifwKZpnXxeZyigRgOjxo2NiCiCNJyWNzcR2QTggIjUKKV2mj2ehMRQQen3P61dmub7n3QTp+rG1mpeUZCDsnwPmqZVULmuUNCN+hlQRJRaVqigahG6ybdHRHZoO1NMISKbRKRRRBo7OzvTPsCo/Np6zBwV1P7WntD6U4S27bSIs4ICQtN8MyooLYQZUESUalYIKABoUUr1ATgIYNP0J5VSO5VSDUqphsrKyrQPLqooFZS+/97Hlpq42UacFRQALJ9XgJMXBxB+rxzXoIgoXawQUAfCPi5B6DBEe4lSQU2uP5k0vQckVEFF6uTjGhQRpYvpAaU1R5SIyAbtc/utQ0VpM59YfzKrQQIIq6Dim+IDgKaOyXUofQ2KFRQRpZrpTRIAoJTaqn24x9SBJGqigoo8xfdWaw9qKvIjbhuUNhMVVDxTfKFOvpMXB/GJutDUKpskiChdTK+gMsIcFVQgqPB2Ww8+Zmb1BCQ0xVee70FpnntKJx/XoIgoXRhQRpijgjp+3gLrT0BCTRIigrp5hVM6+djFR0TpwoAygn8UEAfgmDljaon1JyChCgqY2cmX69Sm+NgkQUQpxoAygn6abtimqrr9rd3mrz8BCVVQAFBXFerk6xgIVYkuhwtOcbKCIqKUY0AZwe+bff3pVE/6T8+NxOkOVXhxVlB186buySci8Lq8XIMiopRjQBkh4Iu4/vR++yUMjJq4/9507rwEpvgmO/l0XqeXU3xElHIMKCPMUkHp60+m7iARLo5j33WzdfJxio+IUo0BZQR9DWqa/a3dWFqRj/nFJq8/6dy5cVdQkTr5cl25DCgiSjkGlBEiVFCBoMJbbT3mt5eHc+fFXUEBETr5XLkYCXANiohSiwFlhAgV1J73L2Jg1I/1yyy0uW0CFRQws5PP6/JiJIHrEBHFgwFlBL8PcHomPg0GFf72P0+ipiIfN6+YZ+LApkmgSQKY2cnHJgkiSgcGlBGmVVAvv9uODy4O4Ksb6uByWugtTniKb2onH5skiCgdLPS3p42FrUH5A0F8d89JXDGvELddtcDkgU2T4BSf3snXrO1qziYJIkoHBpQRwiqof33nPFo7h/C1G+vgcMzcWcJUCVZQeiffRAXFKT4iSgMGlBH8oRt1xwNBfO/1JqxYUISbV8w3e1QzJVhBAVM7+biTBBGlAwPKCP5RwJWDnx08iw97hvEnNy2HRNiXz3TuXGAs/goKmDxdt2PAN7EGFX4UPBGR0RhQRvCPwe/04O9eb8LVi0rw6SuqzB5RZPoUXwLBop+ue/LiAHJduVBQGAuOGT1CIqIJDCgj+EfxfscYzvePYvNNV1izegK0IzfU5PlVcQjv5PM6eSYUEaUeAypZwQAQHMe+04O4bmkZrl9mkX33IknwyA0AqCjIQVm+B00XB3iqLhGlhaUCSkS2mD2GuGnVSI/PgT+50aJrT7oEDy3ULasqQFPHIHJdoeswoIgolSwTUCKyAUCN2eOI19DwEADg8soSfMwqx2rMZqKCSq6Tj1N8RJQOM88oN4GI1ABoNXscifjJ/mbcD+CT9YvMHkp0egX1wu9E3H09mj8ZHsO9QR86XvYC+cDoT38fCDqTH1fpUuCuHwMOy/x7iYgswBIBBaBGKbVntukxEdkEYBMALF68OJ3jmtPhD3vx470f4H4XsLjKQruWz2bxWuCquxJagwKAoHcMbf098OZ4AZzGSNFlgLMwuTH1nAI+eBnw9QO5pcldi4gyiukBJSIblFJ75nqNUmongJ0A0NDQYImbb870DOPB5xpxZYEDGAXg8kT9GtPlVwCf35nwl6tBHx5+Yg8eqs4Bzn4No+u/Ciy+IbkxHX4e+NcvA6MMKCKaygpzKj0iskFENgKoEZHVZg8omv6RcXzpRwcw5g/ib26rCz2YwJSZ3eidfOd6/AAMWoPyFod+H+1P/lpElFFMDyil1CGtgioDUGLycKIaDwTxR88fwqnuIez43QYsKtTewghHvmeiuqoCfNitBZQR+/F5i0K/j15K/lpElFFMDyidUmqnUqpWKXXI7LHMRimFx35+DHubu/Dtz1+Fj9eWh7Y5ArKiggJCN+y2XQztIGFImzkrKCKahWUCyg7+4VeteLHxDL5ywzJsvPby0IP6rgxZElAN1aUYGA01s3CKj4hSiQEVo5ePtmPLv5/Ab129AF+7cfnkEwE9oLJjiu/jteWACvXWGDLFl6NN8fk4xUdEUzGgYnD4w1587SfvoGFJKbbccdXU3SKyrIKqKvSirqoIDuXBSII3/E6hBxQrKCKahgEVRfegD19+/hDmF3mx8/ca4HVPuzF1Yg0qOyooALh+WQUCQTeGEryfagqnC/AUMqCIaAYG1BwCQYU/fvEddA+NYfu9q1GWH+FepyxrkgCAdbXlUEE3zvUbNC3nLWIXHxHNwICaw/ffaMJ/N3XhLz+3AisWFEd+kT+71qAAhPYcDLrRfsmogCoGRvuMuRYRZQwG1Cz+62Qnvvd6Ez6/eiHuWjPHPntZWEEV57rhdXnROTRozAW9xWySIKIZGFARtPeP4I9ffAd1VQV44vaVcx+hoVdQThtsdWSgYm8+Lo0OY8jnT/5iOUVcgyKiGRhQ0+g7RfjGA9h+77XI80TZrtA/GqqerHwOVApU5BcAjjG83daT/MW8xQwoIpqBATXNk6+ewKEP+7Bl41WorSyI/gV+H+DMnvUnXVVBIcQxjn0tXclfzFvMJgkimoEBFebVd9vxw71tuG9dNT571YLYvsg/mlUNErp8dy68ngB+3dyd/MW82hSfssRG9URkEQwozZmeYfzpS0dx9aIS/NlvXhn7F/p9WdUgoct15cLl9ON4+yX0DI0ldzFvMaACwNiQMYMjoozAgEJoE9g/+/m7AIAf3H0NPK443ha/LysrqFxXLpSMAwDebEmyiuJ2R0QUAQMKwM8OncN/N3Xh0VuuwOWlefF9cZZWUF6XF+PBUeR7nMmvQ3HDWCKKIOsDqnPAh7/afRwNS0pxz8eWxH+BLF2D8jq98Cs/1tQUY1+yFRQDiogiyPqA+ot/ew8jYwE8ecdVcDgSaBXP4goKANYsLUBb1xDO9yWxcexEQHGKj4gmZXVA7Tl+EbuPtuORG5ZhWVUMLeWRZGkFlevKBQBcvTgfAJKrolhBEVEEUe5CtaALR4Fvz7H1UIwUFNb6AnjPC+S97QTeTvBG27FB4IrfTHo8dqNXUJeXuVCW78G+5q7JQxzjvpgWUD4GFBFNsl9A5ZUD19yb9GX2tXThRPsAblu1APmFSVZA9bcnPR678TpDAeULjuLjteX4dUsXlFJzbws1G54JRUQRmB5QIlICoEb7tUYp9eicX1C0ELjl20l9zwOnenDPL9/El65fiqrb6pO6VrbSK6hR/yiur63Ay0fb0do1FNvuG9O5vaHdOBhQRBTGCmtQdwJoUEq9BAAisimV32x0PIBHf3YUl5fmYvPNy6N/AUWkr0GN+kexrrYcALCvOYl2c253RETTmB5QSqmdSqmd2qc1AFpT+f2e+kUzWjuH8De//dHoG8HSrPQpvtHAKJaU52FhSW5y2x55uaM5EU1lekDpRKQGQI9Sak+qvsexc/3Y/ssWfP6ahfiN5ZWp+jZZQZ/iG/GPQESwrrYcb7Z2IxhMcD897mhORNNYJqAAbFRKPRTpCRHZJCKNItLY2dmZ0MXH/EFs/ukRlOZ78DjXnZKmT/GN+EP3P61bVo7+kXEcb09wmo6HFhLRNJYIKBHZqJTaqn28evrz2jRgg1KqobIyscrnB2804cSFAXz7tz+KkrzsOlwwFcKbJABgXW0FAODXia5D8dBCIprG9IASkQ0AtojIQRE5CKDM6O/x7tl+PPXLFtyx+nJsqJ9n9OWzUniTBADMK/LiysuK8PPD56ASOTaDU3xENI3pAaWU2qOUqlVKXav9MnQNyucPYPNPj6CigFN7RsrRDmkcCUxucfTA+qU4cWEAr7/fEf8FvUXs4iOiKUwPqFT7u9eb8MHFATz5+atQnOs2ezgZw+Vwwe1wT1RQAPC5qxdgUVkuvv+L5virKG8x4B8J7W1IRIQMD6gjZ/rwD79qxe9cezk+/ZEqs4eTcbwu75SAcjsdePiTy3DkTB/2xrsW5S0J/c4qiog0GRtQo+Ohqb2qwhw89llO7aVCrjMXo4HRKY/dce1CzC/y4gdvNMd3MR5aSETTZGxAfe/1JjR1DOLJOzi1lypel3eizVyX43Ji02/U4K22Hrzd1hPHxfQdzfuMGyAR2VpGBtThD3ux41ct+MKaRfgkb8hNmelTfLovXrcY5fkefP+NpjguxjOhiGiqjAuoi5dG8eXnD+Gy4lz8z/9xpdnDyWizBVSux4kHPlGD/27qwpEzfTFejDuaE9FUGRVQQz4/vvSjA7g0Mo6nf68BhV5O7aVSrit3xhSf7t61i1HkdeGpX8S4FsVDC4lomowJKH8giEf++TBOXBjAD+5ZjfoFRWYPKeNFapLQFXrduP/6pfjP4xdx4kIM03YThxZyio+IQjIioJRS+Mvdx/HGiQ5863Mr8Okr2FKeDrNN8enuv74a+R4nnvpFS/SLeQoAcbCCIqIJGRFQP9zbhufePI0HP7EUv7t2idnDyRqRuvjCleR5cO/Hl2D30fNo7Ryc+2Ii3I+PiKawfUD9x3sX8NevvI9bVszHN29lU0Q6eZ3eWaf4dA+sr4HH6cD2X8ZQRfHQQiIKY+uAOnKmD1/9l8O46vISfPeuq+FwiNlDyiq5rtw5p/gAoLIwB1+8bjF+fvgc2rqG5r4gDy0kojC2DaiOS6P4g39qREVBDp75vQbkepxmDynreF1e+AI+BFVwztc99Mka5HmcuPeZt/Bh9/AcFyxhQBHRBNsG1E8az6Br0Idnfr8BlYU5Zg8nK00/E2o2lxXn4oUH12JozI+7dr45eyWVU8QuPiKaYNuA2n20HQ1LSvGR+WwnN4vXqQVUlHUoAFi5sBgvPLAWPn8Qd+14E80dEZomeCYUEYWxZUCdvDiAExcGcNuqBWYPJatNP7QwmvoFRfiXTWsRVMAXdu7HyYsDU1/AgCKiMLYMqN1HzsMhwK0fnW/2ULJavAEFAMvnFeJfNq2FQ4Av7tyP99vDpvS8RYBvAAjOvaZFRNnBngF1tB1ra8pRVeg1eyhZTV+DmuteqEiWVRXgxYc+DrfTgS8+vR/HzmlVk7cYgOI6FBEBsGFAjYwH0No1xOk9C0g0oABgaUU+XnxoLfI9Lnxh5378n/2nEeSZUEQUxmX2AOLVPzwOr0NwywpO75lNn+J75I1H4HYktjGvLFFw+fx48j2F7zn8yFu8EHjlC4DDdj+apnE73Pjy1V/GHcvvMHsoRIayxN8CIrIRQB+AGqXUzrle2zcyjo11FSjN96RlbDS7+rJ6PPDRBzAwNhD9xVG0dg7hzOlmfFIdwEn3GtRUL4OLN17HpKm3Cd9681voHu3Ggx99ECJ83ygzmB5QWjhBKbVHRDaJyAal1J7ZXj8eCOKzV3F6zwrcTje+uvqrhl1voPUACp/bgIfbl+BXZ9fg8dvqrbHxrwjg9IR+t6Dx4Dge//Xj+P7h76NntAdfX/N1OMR2s/dEM5geUADWAHhR+7gVwGoAswaUALhpxbw0DIvSrbA0FEbbPd8DfN8DXjJ5QGH8cGIYuRiWXPhhvV1LHgbgLnXi+fefx7+/+2N4lNkjIkqeFQKqZNrn5dNfICKbAGwCgNKFS1HEgwgzU8li4LeeAgY74A8qHDrdi4sDsbewp4oohRw1gpzAMLzBYTgQMHtIEd3mVyge7McJd/xNK0RWZIWA6gNQNtcLtHWpnQDQ0NDAfxtmKhHgmnsBhH4wrzN3NLa0xuwBkGU985A1p6jnYoWJ6gOYrKJqALxm3lCIiMgqTA8opdRLAGpEZAOAkrkaJIiIKHtYYYoPSqmt2ocMJyIiAmCBCoqIiCgSBhQREVkSA4qIiCyJAUVERJbEgCIiIksSpex136uIDAD4wOxxWEQFgC6zB2ERfC8m8b2YxPdi0hVKqUKzBxEPS7SZx+kDpVSD2YOwAhFp5HsRwvdiEt+LSXwvJolIo9ljiBen+IiIyJIYUEREZEl2DKg5DzTMMnwvJvG9mMT3YhLfi0m2ey9s1yRBRETZwY4VFBERZQFLB5SIbBSRDdqBhXE/n0lifC+y4qiSud4LESkRkdXaa7aYMb50iuHnYoP2K+vfi7DXZf17ISK9IvKaiHw93WOLh2UDSkQ2AoB+/IZ2HEfMz2eSWP6s2rElGS+G9+JOAA36+5HJ/3iJ4f+R1QBWa8+vFpGa9I8yPWL9+0B7PGPfByDm9+J3lFI3hp0kYUmWDSiEDgdt1T5uBbA6zuczSTb9WaOZ871QSu3UTmAGQn8RtSJzRXsvDimltopICYBWpVTWvhcAoAV0Jr8Hulj+viixwz9YrBxQJdM+L4/z+UxSMu3zTP6zRlMy7fOI74X2P19Phh+AWTLt89l+LhoAtKR2KKYrmfZ5pPeiJsNDWlcy7fNI70UZgB4R2ZH64STOygHVh9CbmOjzmaQP2fNnjaYPsb0XG5VSD6V4LGbrQwzvhRbStfrUT4bqwxzvhYhsyPB/rITrQ5SfC22moQ9An5V/LqwcUAcw+S+BGgDTGwCiPZ9JsunPGk3U90JENupz69o6TKaa870QkS1ha3B9yOx/5ET7uejRmgY2AqjJ8p+LTXb581s2oLRF7hptga8kbMHvtbmez0TR3gvt4w0AGqz8ryEjRHsvtMe3iMhBETmIDP5LOYafix0AWsOet92NmrGK4e+LQ9pjZZg5BZZRYvi5+In2+caw11sSb9QlIiJLsmwFRURE2Y0BRURElsSAIiIiS2JAERGRJTGgiIjIkhhQRERkSQwoIiKyJAYUERFZEgOKiIgsiQFFZAARqRGRlrAtlzL6/CWidGBAERnjUQA3AjikndjakCVHOxClDPfiIzKAiJQopfq0wwEbMnnzYqJ0YUARGUQ/wkApdcjssRBlAk7xERlAO7qgVQ+nTD/2hCgdGFBESdIOBawB8LSIlGhrUH3mjorI/hhQREnQOvVatRN8WwG0AWjhGhRR8rgGRURElsQKioiILIkBRURElsSAIiIiS2JAERGRJTGgiIjIkhhQRERkSQwoIiKyJAYUERFZEgOKiIgs6f8DwEg2VkudIlEAAAAASUVORK5CYII=
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtvUlEQVR4nO3de3xcZZ0/8M8zt8wl92TS0muatEXSSiFNsUJdlQ0I/ES7UkCB3VUX24V9+VNfW8FdefFz3e5Ku3VdF1m2BbeK4grWn9mfRVQK6m4tRUJLSymlzaX3tLmnuc0kM/P8/phzkkkymeuZOefMfN6vl69c5syZxyHJp9/nfM/zCCkliIiIjMai9wCIiIiiYUAREZEhMaCIiMiQGFBERGRINr0HQEREyXvjjTeqbDbb0wBWwtzFRgjA0UAgcP/q1as7Ix9gQBERmZDNZnt67ty5V3m93j6LxWLaduxQKCS6urrqLl68+DSAj0U+ZubUJSLKZyu9Xu9lM4cTAFgsFun1egcQrgSnPqbDeIiIKH0Wo4fTsWPHHLfeemtNvOOU/x8z8ogBRUREGVFXVzf2gx/84HSqz2dAERFRRhw7dsxx/PjxglSfzyYJIiKT+/LuwwtPXBx0a3nO5XOLRv5pw6qzsY7Zvn175dq1a0cOHDjg3rx5c/euXbvKnn/++bK77rqrr7W11XHPPff0PfTQQ/P3799/sru72/ov//IvlQ0NDSPNzc3u0tLS4ObNm7tjnZ8BRURESXvkkUfmNDQ0jKxbt26ku7vbun379srNmzd3P/roo/NffPHFNvW4kpKSIADs27fPXVpaGly/fv3gjh07vJHHzIYBRURkcvEqnUx44403PPfcc08fACxfvty/Y8cO7+bNm7tXrlw5Eu349evXD27fvr2gqamp6Jvf/Oa5RF6DAUVERElbvXr18IkTJwrq6urGTpw4UbB69erhWMfv27fPfdttt12uq6sbS/Q12CRBRERJ27Jly6Xm5mZ3U1NTUXNzs3vLli2Xmpqaio4ePeret2+fGwiH0tGjR93Hjh1zrFu3buTOO++svfXWW2seeOCB+d3d3dZ4ryG4HxQRkfkcPnz41KpVq2I2GRjJI488MueLX/xid2VlZfDYsWOOxx9/3Pvkk0+eVx8/fPhw5apVq6ojn8MpPiIiyriGhoaRn//858VlZWWBvr4+27333tsX7zkMKCIiyrj169cPJvscXoMiIiJDYkAREZEhMaCIiChpTU1NRddff/2yaI898MAD84HwShOR31e7+xLFgCIioqStX79+UF0lYrpnn33Wu3DhwpVLly71q99ramoq2rRp0+JkXoMBRUREmnrmmWdaz549ezSyMUIJtEAy52EXHxERpUy9UfeWW24ZXLdu3QgANDc3u9WPW7ZsuZTquRlQRERm1/RXC9F5TNPVzFFVN4L1T8Rc4+/MmTMF69evH1y+fLn/8ccf96oBpYbSr371q+KmpqaiVFrMAU7xERFRiqJN2e3atats165dZQBQUVERaGlp4X5QRER5K06lkynRmiSWLVvmf8973uMHgLa2NueDDz7Yler5WUEREVHSIheG/dGPflR2+PBhd3d3t3XdunUj3/ve98p27dpVVlNT41On/Xbt2lV29OhRj1pdJYKLxRIRmZDZFouNJ9pisaygiIjIkBhQRERkSAwoIiIyJAYUEREZEgOKiIgMiQFFRERJi7Wa+fbt2yu3b99eqa5qrkp2NXPT3ahbWVkpq6ur9R4GEZGutm3bhmPHjiW8Orjf7w9ce+21h7V6/fXr1w/u2LHDO/37TU1NRbfddtvlurq6sVtvvbVGXeqoqamp6Ktf/eqCt99++51EX8N0AVVdXY3m5ma9h0FEpKt33nkHV111VcLHHz16dCyDw5nQ0tJS0NLSUlBXV9ddXV3tV5Y6Gly/fv3gtm3buJo5ERFlx/TVzDdv3jxx8/Dhw4fd9957b1+q52ZAERGZ3NY/bMXx3uMxjxkaHnLaTtmuTPScS8uWjvz9DX+f0mrmQPh604033ng58nvJYpMEERGlJNYGhL/85S+L0tkLCmAFRURkeg9f93DcY44ePepbuXLlu1q+7mxbvm/fvr1SDSfuB0VERFk122rmTU1NRV//+tcXLFy4cGVxcfE16vF5sZp5Q0ODZBcfEeW7FLr4RlauXJlwi3e2cTVzIiIyDQZUDrjsG8f3959CIBjSeyhERJphQOWAZ/afwv/5f2/jhbc69B4KEZFmGFA5YM+RcDB9d187zHZNkYhSlyu/76FQSACYMQWkS0AJIepn+f5D2R6L2bV0DuL4xUGsmFeMI+cG8MbplG/aJiITcTqd6OnpMX1IhUIh0dXVVQLg6PTHsn4flBCiEcBWAKujfH9NtsdjdnuOdEAI4Il76vHxJ36P7+5rR0N1ud7DIqIMW7BgAc6dO4eurq6Ejr948aItGAxWZnhYqQgBOBoIBO6f/kDWA0pKuVcI0Zvt181FUkrsOdKB66rLUV3pwaeuW4Sd/92Ks70jWFie1Kr2RGQydrsdS5YsSfj4urq6t6SUDRkckuYMcQ1KCFEvpdyr9zjM5t1Lg2jpHMJHV80DAPz59YthEQLf339K34EREWnAEAEFgHNSKdhzuAMWAdyyYi4A4IoSF2577xV47vWzGPIntao9EZHh6B5QiVRPQoiNQohmIURzovOtuU5KiRfe6sD7ayvgLSqY+P5n1y3BoD+A51+PuQgxEZHh6R5QAGqEEBuEEBuUz2d0+Ekpd0opG6SUDV7vjA0c89LbFy6jvXsYH7163pTvX7OwFKsXl+F7+08hGDJ3dw8R5besB5QSRA3KR0gpd0spdyM8zVea7fGY1Z4jHbBaBD6iTO9F+ot1S3CmdwQvv5PWSvdERLrKekApgVSmhFLk93dKKWullAezPSazCU/vXcANSytR7nHMePzmujmYX+rCd/e16zA6IiJtGGGKj5J05NwAzvaO4qNXXxH1cZvVgk9fX43X2ntx9PxAlkdHRKQNBpQJ7TlyAXarwEfqZk7vqe5asxBuhxX/8XtWUURkTgwokwmFJF440oEPLPOixG2f9bgSlx13NSzEzw9fQOegL4sjJCLSBgPKZA6d7ceFAd+s03uRPn19NQIhiR++ejoLIyMi0hYDymT2HLkAh82Cm+rmxD22utKDDy334mdvns/CyIiItMWAMpFQSOIXb3Xgg8u9KHLOPr0X6dpFZTjXN4rRsWCGR0dEpC0GlIk0n+7Dpcv+hKb3VEurCiEl0NY9lMGRERFpjwFlInuOXIDTbkHjVfGn91S13kIAQEsnA4qIzIUBZRLh6b2LuPE9VfAUJL5LSnWlGxYBtHYNZ3B0RETaY0CZxLm+UXQP+fGBZcmtRVhgs2JRuRutXaygiMhcGFAm0dI1CABYVlWY9HNrvYVo5RQfEZkMA8ok1GtI6jWlZNRWFaKte5irmxORqTCgTKK1cxgVHgfKoiwOG89SbyHGAiGc7xvNwMiIiDKDAWUSLV1DqE1heg8Aaqs8yjkGtRwSEVFGMaBMQEqJls4hLE01oJRpwdZOdvIRkXkwoEyge2gMA6PjWJrC9ScAKHU7UFnoYCcfEZkKA8oE1AaJVCsoAKjxFvJmXSIyFQaUCbQolU+q16CAcLixgiIiM9EloIQQ9dO+3qj8b6se4zG61s4huB1WzCtxpnyOWm8h+kbG0TPk13BkRESZk/WAEkI0Anhq2td7pZQ7AdQoX1OE1q4h1HoLIYRI+Ry1Xo9yLjZKEJE5ZD2gpJR7AfRGfKsGgBpKbcrXFCGdDj6V+nxO8xGRWSS+6miGKJWTqh7Ac3qNxYiG/AF0DPjSDqh5JS447RY2ShCRaRimSUK5LvWSlPKg3mMxktY0ljiKZLEI1FSyUYKIzMMwAQWgUUq5LdoDSgNFsxCiuaurK9vj0tVki7kn7XOxk4+IzMQQASWE2KiGU7QmCSnlTillg5SywetNbrsJs2vpGoLNIrC4Iv2AqvUW4lzfKHzj3P6diIxPjy6+DQAalI9qIG0VQrQKIfqyPR6ja+0cwuIKN+zW9P9T1VZ5ICUbJYjIHLLeJCGl3A1gd8TXewGUZXscZtHSNZTSHlDRTHbyDWPFvBJNzklElCmGmOKj6MYCIZzuGUm7g09VXeEJb//OTj4iMgEGlIGd7glvMphuB5/KabdiIbd/JyKTYEAZmBaLxE5Xy0VjicgkGFAGls4277Op9XrQzu3ficgEGFAG1tI1hHklTngKtOtlWVpVCD+3fyciE2BAGVhrGtu8z2Zid11ehyIig2NAGVQoJNHaOazp9SeAAUVE5sGAMqgLA6MYHQ9qHlBlHgcqPA42ShCR4TGgDGqig0/DBglVrZdr8hGR8TGgDCoTLeaq2iq2mhOR8TGgDKq1awilbjvKPQ7Nz13r9aBvZBy9w2Oan5uISCsMKINq6RzC0jS3eZ9NLXfXJSITYEAZVGuX9h18KvW6Fqf5iMjIGFAG1Ds8ht7hsYwF1PzS8PbvXDSWiIyMAWVAE0scZSig1O3fWzjFR0QGxoAyoEy2mKtquf07ERkcA8qAWjqH4LJbMb/UlbHXqPV6uP07ERkaA8qAWrqGUOP1wGLRvoNPtbSqEFICbV3DGXsNIqJ0ZH3LdwAQQtRLKQ9GfL0BQD+AeinlNj3GpIlQELj4FiDTq0rsFw/hxiuKgfNvaDOu0mrAUzHlW5Fr8tXNK9bmdYiINJT1gBJCNALYCmC18nU9AEgp9wohaqaHl6k0/wfwi81pn+a7AHAawFNpnyrsilXApv+e8q0llR4IwVZzIjKurAeUEkS9Ed+6G8BLyudtABoBmDOghrvCHz/1HJDiDbaneobxdz8/hgc/VIs11eXpj+m1HUDnOzO+7bRbMa/EhdM9nOIjImPSZYpvmlIAkYFVMctxxhfwAdYC4MpbUj7Fm4fO4zehAvzNqj8C5hSlP6bWV2adKlxc4cbp3pH0X4OIKAPYJKGlgB+wOdM6RUvnEKwWgeoKjzZjsruA8eghtKjcjbMMKCIyKCMEVD8AdS6rFEDP9AOEEBuFEM1CiOaurq4sDi1JAR9gK0jrFC2dQ1hc7obDptF/GrsbCI4BwcCMhxZVuNE9NIYh/8zHiIj0ZoSAeg5AjfJ5DYC90w+QUu6UUjZIKRu8Xm9WB5cULSoorbd5tyv3UgVGZzy0qNwNADjTwyqKiIwn6wGltJQ3KB+hduwp3X39pu3gA9KuoMaDIZzq1niRWDWgxmcG1OLy8DTiGU7zEZEB6dHFtxvA7mnf25ntcWREmhXU6Z4RBEISyzQNqHCVFO061EQF1ctOPiIyHiNM8eWONCuols5BABrvohujgipx21HisrOCIiJDYkBpKeBPM6CUVcy1XCQ2RgUFKK3mvAZFRAbEgNJS2hXUEOaXuuAp0HDmNUYFBQALy92soIjIkBhQWgqMpXUNSvMOPiCigooeUIvL3TjfN4pAMKTt6xIRpYkBpaU0KqhQSKKlc0j7PaAmKqjZb9YNhCQ6Bnzavi4RUZoYUFpKo4vvfP8ofOMh7bd5jzPFt6hC7eTjNB8RGQsDSktpVFDq9uvL5mRqim+2JonwvVBslCAio2FAaSmNCqo1U9u8x6mg5hY7YbcKnOa9UERkMAwoLaVRQZ28NIQKjwNlHoe2Y4pTQVktAgvLuGgsERkPA0orUgLB1CuojHTwAYDVDlhss1ZQQLjVnFN8RGQ0DCitBPzhjylUUFKGO/g0XeIokt0dM6AWV7hxpmcEUsrMvD4RUQoYUFoJKG3aKVRQXUN+DIyOa9/Bp4qxJxQQbjUf9AfQPzKemdcnIkoBA0oraVRQ6hJHmQ2o2SsoddFY7q5LREbCgNJKGhWU2sG3rEqDLd6jsbtjVlBqqznvhSIiI2FAaSU4Fv5oTa2CKiywYU5xervxzipOBbWwPNyKfqaHreZEZBwMKK1MVFDJh8zJznAHnxBC40Ep4jRJuB02eIsKWEERkaEwoLQycQ0q+Sm+jKzBFylOkwQQvg7FVnMiMhIGlFZSrKAu+8bROejPXIMEELeCAsKrmrOCIiIjYUBpJcUmiZaJBolMB1ScCqrCjYuXffCNBzM3DiKiJDCgtJJim3nLpQy3mANxmySA8BSflMC5vtjHERFlS9JbtwohqgHUAygHUAqgDUC/lPKVVAchhNgAoB9AjZRyZ6rn0VWqFVTXEBw2CxYq9yJlhN0FjMWuoBYr226c7R3JbFgSESUo4QpKCPFlIcSvAWwFUAtAABhQPr9ZCPFrIcSTQohrkhmAEKIeQJuUci+ANuVr80m1guocQk2lB1ZLhjr4gMkpvhhLGS0qV7fdYKs5ERlD3ApKCLEEwCYAP5ZS/lOcY0sAbBRCNEgpn05iHFsB3IRwBbU3iecZR4oV1MnOQaxaUKr9eCLZXQBkOETt0cdXWeiA22HlahJEZBgxKyglnP5YSvkVKeWb8U4mpRxQQuxlIcT9iQxASnkQ4cqpFUBvIs8xpBQqKN94EOf6RjM/pRZnyw0AEEJgUTm33SAi44gZUFLK9iQroaSfJ4QoRfj60w4ATwkhaqIcs1EI0SyEaO7q6kp2ONmRQgXV2jUEKTPcIAHE3bRQxW03iMhIku7iE0IUazyGjQC+IaXcBuBOABumHyCl3CmlbJBSNni9Xo1fXiMpVFAtmV6DTzVRQSV2L1QoxG03iEh/qbSZ10Y2QgghlgghbtRiMMr1p34tzpV1AT9gsQMWa8JPaekcgkUA1ZUZ7OADIiqo+J18/kAIXUP+zI6HiCgBSQeUlPIQgDVKuzmklO0AyoQQ30hlAErltFEIsUEIsdG8beb+lDr4Fld4UGBLPNRSksQUHwBO8xGRIaQyxfccgFYAfRHTfXsRnqpLiZRym5Ryt2nDCQhfg0ohoGozuQafKoEmCYDbbhCRsaQyxbcaQLOUcgCAUFrLGwE8punIzCbgT6pBYjwYQnv3MJbNyUZAJVZBzS91wSK47QYRGUMqAXUnlGpJCalyAGXx7pHKeUlWUKd7RhAIycyuYq5KsIJy2Cy4osTFe6GIyBCSXupIuQZ1KOLrdiHEG0KIaxK5VypnBXxJVVAZ3+Y9UoIVFBBulOAUHxEZgSaLxSqh1a7FuUwrySaJ1q5wQNVmJaASazMHlIBikwQRGYBmq5kr0335K8kK6uSlQcwrcaKwIOkiNnkJtpkD4U6+nuExDPkDGR4UEVFscZc6SnTJIi2eZ2pJVlAtXUPZqZ6AyeBMpIJSFo1lFUVEeou71BHC6+r9eyI34wohioUQX0Z4/b6kl0gytSQqqFBIorVzOHvbWlgsgC3+tu9AeF8oADjTy04+ItJX3PklJaT+UgjxOSHEVwBIAAcB9CiHVCC8L1QtwvdHbVOek1+SqKDO949idDyY3X2XEti0EAjvrAvwZl0i0l/CF0CklE8hvJhrCYAGhEOpHOHmiDalUSJ/BRO/D6qlK0tr8EWyuxMKqBKXHaVuOzv5iEh3qbSZDwB4OQNjMbckKqjjHYMAgGVZr6ASC51F5Ww1JyL9pdTFJ4S4X9k99/4MrG5uTklcg3qtvQe1Xg/KPI4MDypCglN8AAOKiIwhlbX4HgOwFOHt3u8C0C6E+AutB2Y6AT9gjR84gWAIr7f3Ym1NRRYGFUHd9j0BiyvcON83ikAwlOFBERHNLpWbcF6XUv5U/ULZcPArQohPSCn/r2YjMxMpE66g3r5wGcNjQR0CygWMJdaZt6jcjUBI4kK/b6Jpgogo29K+UVdK2S+l/ArC3Xz5KRQAZCihgDrQFm5+fF9NeaZHNZXDk/AUn7qqeTsXjSUiHaUSUG1CiNeFEB+edv2pZ9Zn5LqJ7d7jN0kcaAtff6oqSnzVCU0k0SShtr+r6wUSEelBSJnc9t7KNageAGsQ3majFUAvgJcA7JBSDmZyuq9saZn80Dc/lIlTpy4UBLrfBYquAFxlMQ892TmEYqcdc4qT2zsqbZc7gLEhoHJZQoe3dA6hyGnDnOKZQbqiYgW2rNui9QiJKIOEEG9IKRv0HkcyUrkG1QrgJXV7DSHEtQgH1c0A/lYIoVZSGQkoh9WB6uLqTJw6deOjQMfbQEE5ULx41sMGRscR8HVjkbcUVxS7sjhAAKODwHA/kOB7d6mnB6ExoLp46sxtS38LXmx/kQFFRBmXyn1QTwkhrhVCQEp5KmL7DTWw6pHBzQsXFi3Etz78rUydPjU9rcD+/wRuuBtYdfesh+34XSteOX8c//rpP87+FN/erwEnnwD+MrH37pGBt/Bfb17AP3/2ZgghJr7/5JtP4t8O/xuCoSCslgxvVU9EeS2lpbRjrRohpTwohHg4mfMpoVajPH93KmPSVYLXoA609aBGj+tPQLjNPDgGBAOANf5/9uVzijDoC+DSZT/mlkyO16k0gviDfrgt7PAjoszRbLuNSCkse7RJCaYaJazMZSKgZg+eQDCE5lN92W8vV6lbbgQS6+RTGyVOXBqc8n01oEYTPA8RUaoyElDJEEJsQPi6FqSU26SUB3UeUvICY+GPMSqoYx2XMegP6B9QCbaaL58TXifw5LROPqc1HFC+oE+7sRERRaF7QCHcDVghhKgXQjyk92BSkkAFpd7/tHZJlu9/Uk3sqptYq3llYQHKPQ6cnFZBuWzhoPMFGFBElFlGCCgA6FErJ6WimkIIsVEI0SyEaO7q6sr+6OIJ+MMfY1RQB9p6w9eforRtZ0WSFRQQnuabUUEpIcyAIqJMM0JAtQJoUz5vQ7iimkJKuVNK2SClbPB6vVkdXELiVFDq+nvvW6LjYhtJVlAAsHxOIU5cGkTkvXK8BkVE2WKEgNoLpYNP+fi6jmNJTZwKavL6k07Te0BKFVRkJ5+K16CIKFt0DygpZRuAfnVqLxfbzCeuP+nVIAFEVFDJTfEBwMnOyetQ6jUoVlBElGkp3QelNSnlTr3HkJaJCir6FN9rbb2oqfREXTYoayYqqGSm+MKdfCcuDeEDy8JTq2ySIKJs0b2CygkxKqhgSOIP7b14n57VE5DSFF+Fx4Eyt31KJx+vQRFRtjCgtBCjgjp2wQDXn4CUmiSEEFg2p2hKJx+7+IgoWxhQWgj4AGEBLDNnTA1x/QlIqYICZnbyuazKFB+bJIgowxhQWlB3041YVFV1oK1H/+tPQEoVFAAsqwp38nUOhqtEm8UGq7CygiKijGNAaSHgn/3606ne7O+eG43VHq7wkqygls2ZuiafEAJOm5PXoIgo4xhQWgj6o15/eqfjMgZ9Oq6/N53dncIU32Qnn8ppdXKKj4gyjgGlhVkqKPX6k64rSERKYtt31WydfJziI6JMY0BpQb0GNc2Bth4sqfRM2U9JV3ZX0hVUtE4+l83FgCKijGNAaSFKBRUMSbzW3qt/e3kkuzvpCgqI0slnc2E0yGtQRJRZDCgtRKmg9r5zCYO+ANYtNdDitilUUMDMTj6nzYnRFM5DRJQMBpQWAn7A6pj4MhSS+Odfn0BNpQcfWTFHx4FNk0KTBDCzk49NEkSUDQwoLUyroF54qwPvXhrEFxqXwWY10Fuc8hTf1E4+NkkQUTYY6K+niUVcgwoEQ/jW3hO4ck4Rbr96ns4DmybFKT61k69FWdWcTRJElA0MKC1EVFD/9eYFtHUN40s3LYPFMnNlCV2lWEGpnXwTFRSn+IgoCxhQWgiEb9QdD4bw7ZdPYsW8YnxkxVy9RzVTihUUMLWTjytJEFE2MKC0EPABtgL89I1zONM7gr++eTlElHX5dGd3AWPJV1DA5O66nYP+iWtQkVvBExFpjQGlhcAYAlYH/vXlk7hmYSk+fGWV3iOKTp3iSyFY1N11T1wahMvmgoTEWGhM6xESEU0wVEAJIR7SewwpCfjwTucYLgz4sPnmK41ZPQHKlhtycv+qJER28jmt3BOKiDLPMAElhGgEsEbvcSQtFARC49h/egjXLSnHDUsNsu5eNCluuQEAlYUFKPc4cPLSIHfVJaKsMExAmZZSjfT6Lfjrmwx67UmV4qaFqqVVhTjZOQSXLXweBhQRZZIhAkoIUS+l3Kv3OFIxPDIMAFjgLcX7jLKtxmwmKqj0Ovk4xUdE2TBzj3J9GGhF1eQ8f6AFnwHwwbqFeg8lPrWC+tGdUVdfj+evR8ZwX8iPzhecgAfw/eTPgZA1/XGVLQHu/iFgMcS/l4jIIHQPqESqJyHERgAbAWDRokVZGVciDp3pww/3vYvP2IBFVSbI2EVrgavvTukaFACEnGNoH+iFs8AJ4DRGi68ArEXpjan3FPDuC4B/AHCVpXcuIsopugcUgBohRE3E5/VSyoORB0gpdwLYCQANDQ2GuPnmbO8IPvdMM64qtAA+ADZH3OfozlMJfGJnyk+XQ348sGUvNlUXAOe+BN+6LwCLbkxvTIeeBf7rQcDHgCKiqXSfU5FS7pZS7kZ4mq9U5+EkZGB0HJ/93usYC4Twj7cvC38zhSkzs1E7+c73BgBodA3KWRL+6BtI/1xElFN0DyiVlHKnlLJ2evVkNOPBEP7q2YM41TOMHX/agIVFylsYZcv3XLSsqhBnepSA0mI9Pmdx+KPvcvrnIqKcYpiAMgMpJR752VHsa+nGNz5xNd5fWxFe5gjIiwoKCN+w234pvIKEJm3mrKCIaBYMqCT8++/a8FzzWfzvG5diw+oF4W+qqzLkSUA1VJdh0Be+14tTfESUSQyoBL1wpANbf3kcH79mHr500/LJB4JqQOXHFN/7aysAGe6t0WSKr0CZ4vNzio+IpmJAJeDQmT586fk30bC4DFvvuHrqahF5VkFVFTmxrKoYFunAaIo3/E6hBhQrKCKahgEVR8+QHw8+exBzi53Y+WcNcNqn3Zg6cQ0qPyooALhhaSWCITuGU7yfagqrDXAUMaCIaAYGVAzBkMQXn3sTPcNjePK+epR7otzrlGdNEgBwfW0FZMiO8wMaTcs5i9nFR0QzMKBiePyVk/ifk934+sdWYMW8kugHBfLrGhSA8JqDITs6LmsVUCWAr1+bcxFRzmBAzeK/T3Th2y+fxCfq5+PuNTHW2cvDCqrEZYfT5kTX8JA2J3SWsEmCiGZgQEXRMTCKLz73JpZVFWLL+pWxt9BQKyirCZY60lCJ04PLvhEM+wPpn6ygmNegiGgGBtQ06koR/vEgnrxvNdyOOMsVBnzh6snI+0BlQKWnELCM4Q/tvemfzFnCgCKiGRhQ0zz24nEcPNOPrRuuRq23MP4TAn7Amj/Xn1RVhUUQlnHsb+1O/2TOEjZJENEMDKgIL77Vge/ua8enr6/GR6+el9iTAr68apBQeewuOB1B/L6lJ/2TOZUpPmmIheqJyCAYUIqzvSP48u4juGZhKf72tqsSf2LAn1cNEiqXzQWbNYBjHZfROzyW3smcJYAMAmPD2gyOiHICAwrhRWD/9mdvAQC+c8+1cNiSeFsC/rysoFw2F6QYBwC82ppmFcXljogoCgYUgJ8ePI//OdmNh2+5EgvK3Mk9OU8rKKfNifGQDx6HNf3rUFwwloiiyPuA6hr04+/3HEPD4jLc+77FyZ8gT69BOa1OBGQAa2pKsD/dCooBRURR5H1A/d3P38boWBCP3XE1LJYUWsXzuIICgDVLCtHePYwL/WksHDsRUJziI6JJeR1Qe49dwp4jHfj8jUuxtCqBlvJo8rSCctlcAIBrFnkAIL0qihUUEUUR5y5UA7p4BPhGjKWHEiQhsdYfxNtOwP0HK/CHFG+0HRsCrrwt7fGYjVpBLSi3odzjwP6W7slNHJM+mRJQfgYUEU0yREAJITYqn9ZKKR+OebC7Arj2vrRfc39rN453DOL2VfPgKUqzAqpbn/Z4zMZpDQeUP+TD+2sr8PvWbkgpYy8LNRvuCUVEUegeUEKIRgB7pZRtQoifCCEapZR7Z31C8Xzglm+k9Zqvn+rFvb99FZ+9YQmqbq9L61z5Sq2gfAEfbqitxAtHOtDWPZzY6hvT2Z3h1TgYUEQUwQjXoGoANCqftylfZ4xvPIiHf3oEC8pc2PyR5fGfQFGp16B8AR+ur60AAOxvSaPdnMsdEdE0ugeUlHKnlHKn8mU9gOZMvt4Tv2lBW9cw/vFP3ht/IVialTrF5wv6sLjCjfmlrvSWPXJyRXMimkr3gFIJIeoBvCSlPJip1zh6fgBP/rYVn7h2Pv5ouTdTL5MX1Cm+0cAohBC4vrYCr7b1IBRKcT09rmhORNMYJqAANEopt0V7QAixUQjRLIRo7urqSunkY4EQNv/kMMo8DjzK605pU6f4RgPh+5+uX1qBgdFxHOtIcZqOmxYS0TSGCCghxEY1nJSmiSmUacAGKWWD15ta5fOdV07i+MVBfONP3otSd35tLpgJkU0SAHB9bSUA4PepXofipoVENI3uAaUE0lYhRKsQoi8Tr/HWuQE88dtW3FG/AI11czLxEnknskkCAOYUO3HVFcX42aHzkKlsm8EpPiKaRveAklLulVKWSSlrlY+zt5inwB8IYvNPDqOykFN7WipQNmkcDU4ucXT/uiU4fnEQL7/TmfwJncXs4iOiKXQPqEz715dP4t1Lg3jsE1ejxGXXezg5w2axwW6xT1RQAPCxa+ZhYbkLj/+mJfkqylkCBEbDaxsSESHHA+rw2X78++/acOfqBfjwe6r0Hk7OcdqcUwLKbrXggQ8uxeGz/diX7LUoZ2n4I6soIlLkbED5xsNTe1VFBXjko5zaywSX1QVf0Dfle3esno+5xU5855WW5E7GTQuJaJqcDahvv3wSJzuH8NgdnNrLFKfNOdFmriqwWbHxj2rwWnsv/tDem8TJ1BXN+7UbIBGZWk4G1KEzfdjxu1Z8cs1CfJA35GbM9Ck+1aeuW4QKjwOPv3IyiZNxTygimirnAurSZR8efPYgrihx4av/6yq9h5PTZgsol8OK+z9Qg/852Y3DZ/sTPBlXNCeiqXIqoIb9AXz2e6/j8ug4nvqzBhQ5ObWXSS6ba8YUn+q+tYtQ7LThid8keC2KmxYS0TQ5E1CBYAif/89DOH5xEN+5tx5184r1HlLOi9YkoSpy2vGZG5bg18cu4fjFBKbtJjYt5BQfEYXlREBJKfH1PcfwyvFOfO1jK/DhK9lSng2zTfGpPnNDNTwOK574TWv8kzkKAWFhBUVEE3IioL67rx3PvHoan/vAEvzp2sV6DydvROvii1TqduC+9y/GniMX0NY1FPtkQnA9PiKawvQB9au3L+IffvEOblkxF39zK5sisslpdc46xae6f10NHFYLnvxtAlUUNy0kogimDqjDZ/vxhR8fwtULSvGtu6+BxSL0HlJecdlcMaf4AMBbVIBPXbcIPzt0Hu3dw7FPyE0LiSiCaQOq87IPf/H9ZlQWFuDpP2uAy2HVe0h5x2lzwh/0IyRDMY/b9MEauB1W3Pf0azjTMxLjhKUMKCKaYNqAer75LLqH/Hj6zxvgLSrQezh5afqeULO5osSFH31uLYbHArh756uzV1IFxeziI6IJpg2oPUc60LC4DO+Zy3ZyvTitSkDFuQ4FACvnl+BH96+FPxDC3TteRUtnlKYJ7glFRBFMGVAnLg3i+MVB3L5qnt5DyWvTNy2Mp25eMX68cS1CEvjkzgM4cWlw6gEMKCKKYMqA2nP4AiwCuPW9c/UeSl5LNqAAYPmcIvx441pYBPCpnQfwTkfElJ6zGPAPAqHY17SIKD+YM6COdGBtTQWqipx6DyWvqdegYt0LFc3SqkI8t+n9sFst+NRTB3D0vFI1OUsASF6HIiIAJgyo0fEg2rqHOb1nAKkGFAAsqfTguU1r4XHY8MmdB/CDA6cR4p5QRBTBpvcAAEAIsQFAP4B6KeW2WMcOjIzDaRG4ZQWn9/SmTvF9/pXPw25JbWFesVjC5g/gsbclvm0JwL1oPvCLTwIWQ/xomoLdYseD1zyIO5bfofdQiDSl+18BIUQ9AEgp9wohaoQQ9VLKg7Md3z86jg3LKlHmcWRvkBRVXXkd7n/v/RgcG4x/cBxtXcM4e7oFH5Sv44R9DWqql8LGG68TcrLvJL726tfQ4+vB5977OQjB941yg+4BBeBuAC8pn7cBaAQwa0CNB0P46NWc3jMCu9WOL9R/QbPzDba9jqJnGvFAx2L87twaPHp7nTEW/hUCsDrCHw1oPDSOR3//KB4/9Dh6fb14aM1DsAjTzd4TzWCEgCoFELk3eEWsgwWAm1fMyeR4SCdFZeEwetLxbcD/bWC3zgOKEIAVI3BhRLgQgPFWLXkAgL3MimffeRa/fOuHcEi9R0SUPiMEVFxCiI0ANgJA2fwlKOZGhLmpdBHw8SeAoU4EQhIHT/fh0mDiLeyZIqREgRxFQXAEztAILAjqPaSobg9IlAwN4Lg9+aYVIiMyQkD1AyhXPi8F0DP9ACnlTgA7AaChoYH/NsxVQgDX3gcg/IN5nb6jMaU1eg+ADOvpTcacoo7FCBPVzwGoUT6vAbBXx7EQEZFB6B5QaseeEKIRQH+sDj4iIsofRpjiU6fwiIiIJuheQREREUXDgCIiIkNiQBERkSExoIiIyJAYUEREZEhCSnPd9yqEGATwrt7jMIhKAN16D8Ig+F5M4nsxie/FpCullEV6DyIZhmgzT9K7UsoGvQdhBEKIZr4XYXwvJvG9mMT3YpIQolnvMSSLU3xERGRIDCgiIjIkMwYUV52YxPdiEt+LSXwvJvG9mGS698J0TRL5SgixAeGV3+ullNtmOSbmbsREuSyR3xHluIdiPU7GYegKSgixQQjRKIR4KJXHc4UQoh4ApJR7AfSrX087phHAU9kemx4S+LnYqPxva7bHlm0JvBeNyv9y+r1I5HdEOa4RebArSQI/F1uVjxuzO7LkGDag4v3AJfoDmSPuRvhfhgDQBqBx+gHK+9A7/fu5JoGfi0YAe5UFiGuUr3NSgr8jNymP1+f770i+SPBv40YhRCvC75VhGTagEP8HLp9+IEsxNXwqdBqHEcT7714T8b02TO41lotivhdSyoNSyoeVL2tyfPq3FHF+R5Qp8HzYby6Rv413Silrjf5+GPk+qFLE/oGL9zjlplLE+O8+beuWeoQ3xMxVpUjgd0CZ5tmUjQEZXHn8Q3JCKeL/XNQLIYA41+v0ZuQKiib1Y/KXqxRAj24jMQllWuOlHK8aEqL8AdokhCjVeywZ1I8YvyN5VD0lREq5TXk/Kow8DW7kgOpH7D/K8R7PJc9hcqqqBsBeAMjxPziz6Udi/90bjfwvQ430I84f5YjrD20ADH1BPE3xfkdqlMaBDcrnuXw9rh+xfy7U9wHKY4adBjdyQMX7gYv6eC5SqwDlXzr9EVXBy+oxyg9cQ8QPXq6KG9ZCiI1qOBn5X4caiPdeNGLqHypDXxBPR7zfESnlbinlboTfj1JdBpk98X4u2jD597IWgGGXQDL0fVBKC2Qbwhd4dyrfe0NKuXq2xyn3xfq5UP5A/QThOfhyhC8G5+w/XuK8F6UA7kL4vbhJSsnrUHkiwb+dvcrjhp1pMHRAERFR/jLyFB8REeUxBhQRERkSA4qIiAyJAUVERIbEgCIiIkNiQBERkSExoIiIyJAYUEREZEgMKCIiMiQGFJEGlIVZW4UQP4n4ulTnYRGZGgOKSBuNAFYD2KFuoy2l7Nd1REQmx7X4iDSkVE3lUsqcXTmcKFsYUEQaUaf0WDkRaYNTfEQaEELUAJPhpH5NRKmz6T0AIrNTdmdtANArhNiL8PWofuTwBoFE2cAKiigNEdN6OxHevbQdwJpc3iSRKFt4DYqIiAyJFRQRERkSA4qIiAyJAUVERIbEgCIiIkNiQBERkSExoIiIyJAYUEREZEgMKCIiMiQGFBERGdL/B7aShBrHsYmyAAAAAElFTkSuQmCC
 "
 >
 </div>
@@ -15186,8 +14921,8 @@ Wall time: 77.8 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 2.56 s, sys: 2.76 ms, total: 2.57 s
-Wall time: 2.57 s
+<pre>CPU times: user 2.31 s, sys: 0 ns, total: 2.31 s
+Wall time: 2.31 s
 </pre>
 </div>
 </div>
@@ -15222,7 +14957,7 @@ Wall time: 2.57 s
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/Users/echarles/software/vro/qp/qp/spline_pdf.py:49: RuntimeWarning: invalid value encountered in true_divide
+<pre>/afs/slac.stanford.edu/u/ek/echarles/vol2/vro/software/qp/qp/spline_pdf.py:49: RuntimeWarning: invalid value encountered in true_divide
   return (yvals.T / integrals).T
 </pre>
 </div>
@@ -15264,7 +14999,7 @@ Wall time: 2.57 s
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAasAAAEnCAYAAAAXY2zOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABGn0lEQVR4nO3deXyU1bnA8d+ZJftKVkiAJCxhkzUsAooLolgXqogCttaq2GpdbuvaWm+ttlbUXuu1LmAv2rqLFrcqCioIiBCQnQQkJBAgIQnZ95k59493AgFCMklmMjPJ8+0nnzAz77zz8Jry5D3nOc9RWmuEEEIIX2bydgBCCCFEWyRZCSGE8HmSrIQQQvg8SVZCCCF8nsXbAQghhOi4TZs2xVsslpeBEfj/DYgD2GGz2W4eN27c0eYvSLISQgg/ZrFYXk5MTBwaFxdXajKZ/Lq82+FwqKKiomEFBQUvA1c0f83fs7AQQvR0I+Li4ir8PVEBmEwmHRcXV45xl3jya16IRwghhPuYukOiauL8u5yWmyRZCSGE8Khdu3YFzJw5M60z55BkJYQQwqOGDRvW8Omnn+Z05hxSYCGEEN3EvUu39t1TUBniznMOTgyveXL2qIOtHfPUU0/FTpo0qWb9+vUh99xzT/GyZcvCFy5cmHjLLbcU79u3L+CSSy6pvO+++5LWrVu3t+n4mJgY+759+wIGDBjQcOONN5a2FYckKyGEEB320EMPJVxyySWVU6dOrSkuLjY/9dRTsffcc0/xHXfc0b95EoqMjLQDLFu2LDwmJsZ+4403ls6cOTPtscceK3TlcyRZCSFEN9HWHZAnfPnllxHz5s0rBRg8eHD9Sy+9FHfPPfcUjxgxoqal46dOnVrz+9//PnHQoEH1F154YYWrnyPJSgghRIeNGjWqZs+ePYHDhg1r2LNnT+C4ceOqWzv+6NGj5osvvrhiyJAh9VOnTm0xobVECiyEEEJ02AsvvHAoMzMzZNmyZeGZmZkhjz32WOGyZcvCd+zYEbJmzZoQgDVr1oTs2LEjZNeuXQEAL730Utydd96ZPHPmzLSmY9qiZD8rIYTwX1u3bs0dNWpUsbfjcNUvf/nLpBdeeOHQmR4DbN26NXbUqFEpzZ+TYUAhhBBdZv78+aVLliyJHjRoUP3evXsD58+f32YlIEiyEkII0YWmTp1a0zRXJXNWQgghuhVJVkIIIXyeJCshhBA+T5KVEEIInyfJSgghhFtFRESMnjx58qCHHnoooem5JUuWRE+ePHlQR88p1YBCCCHc6p///Oe+WbNmVTZ/7sYbbyxdvHhxbEfPKclKCCG6i2W39+XoLrd2XSd+WA2z/n7GnoNr1qwJKS4uNpeWllqio6Nts2bNqiwtLbXs2rUrYNiwYQ3uCkOGAYUQQnTY66+/Hg3GndPgwYPrAUpKSszx8fH2efPm9XfX58idlRBCdBet3AF5yqOPPlrwk5/8pP8dd9zR/80338wBGu65555igMjISNuSJUuiXdmvqi2SrIQQQnTYRx99FPHpp5/mFBcXm5955pnY9evXh0yaNKmmPd0pXCHJSgghRIdt2LAhBGDQoEH18+bNK42Pj7dnZWUFLlmy5PjwIBibLu7YsSO0o3da0nVdCCH8mL91XXdFS13XpcBCCCGEz5NkJYQQwudJshJCCOHzJFkJIYTweZKshBBC+Dy/Ll2PjY3VKSkp3g5DCCG8ZuHChezatatdnSLq6+ttY8aM2eqpmDzBr5NVSkoKmZmZ3g5DCCG8Zvfu3QwdOrRd79mxY4fbevadqri42JyVlRW4d+/ewA0bNoS88MILh8Dour548eLYdevW7e3IeWUYUAghhNu88sor0evXrw9pWvj71FNPxcKJxcEd5dd3VkIIIU54YsMTZB3LavO4quqqIEuuJd2Vcw6MHljz6JRHXe663tQXECA3Nzfw4osvrnAp+DbInZUQQogOa6nrOsCuXbsCoqOj7afua9VRcmclhBDdxP0T7nfpuB07dtSNGDEi2x2f2VLXdYA33ngj+o033shzx2eA3FkJIYTohKau699///3uzz77LByMYorHHnusEIxhQnd8jiQrIYQQHbZhw4aQJUuWRGdlZQXOmzevdNmyZeEPP/xw0vDhw4cOHz58aHFxsRlO7rrekc+RYUAhhBAd1lSa3mTYsGENs2bN2nHqcbNmzaqsqKjY0tHPkTurbmZvYSUfbzvs7TCEEMKt5M6qm3nko12s3VfMkMRwBsaHezscIYRwC7mz6kYOl9Wydl8xWsPzX+/zdjhCiC7SnTbRdTgcCnCc+rwkq27k398fQmuYMSyBD7Yc5uCxGm+HJITwsKCgIEpKSrpFwnI4HKqoqCgSOG3Oy6vDgEqp2cCtWuuLWnjtCa21a4sGBFpr3tucz/iUaP545Qi+zv6KF1ft408/PsvboQkhPCg5OZn8/HyKiopcfk9BQYHFbrfHejCsjnIAO2w2282nvuDVZKW1XqqUuvXU55VS04E0L4Tkt7YcLCOnqJoF56SRGBnE7Ixk3s3M544LBpEYGeTt8IQQHmK1WklNTW3Xe4YNG7Zda53hoZA8wueGAZVSaUCOt+PwN+9tzifQYuLSkb0B+OW0Adi1ZvE3cimFEP7P55IVkKa1PuO/sEqpBUqpTKVUZntue7uzepudj7Ye4eLhiUQEWQHo2yuEK0f14Y3vDlBSVd/GGYQQwrf5VLJSSk3XWq9o7Rit9SKtdYbWOiMuLq6rQvNpK3cfpby2kavHJZ/0/G3nD6DOZuf/1u73UmRCCOEePpWsgGNKqenOwos0pdRYbwfkD97blE9CRCBTB548XzowPpyZIxL557o8ymsbvRSdEEJ0nleTlbOQIsOZnNBab3beWfUCorwZm78oqqzn6z1FzBqThNmkTnv9tvMGUllv41/f5nZ9cEII4SZeTVZa6xVa62it9dJTnl+ktR6gtd7srdj8xQdbDmF3aGaPTW7x9RFJkVwwJJ5/rNlPdb2ti6MTQgj38LVhQNFO720+xMjkSAYlnLm10u3nD6S0ppE3NxzowsiEEMJ9JFn5sV2HK9h9pIKrz3BX1WRc/2jOToth0eoc6hrtXRSdEEK4jyQrP/be5nysZsUVo/q0eewdFwzkaGU9Szfld0FkQgjhXpKs/FSj3cEHWw5xwZB4okMD2jz+7AExpMWF8lXW0S6ITggh3EuSlZ9avaeI4qqGNocAmyilGN4nkuzCSg9HJoQQ7ifJyk8t3ZRPr9AAzkuPd/k9QxLDyS+tpUqqAoUQfkaSlR8qq2lg5e6jXDGqDwEW1/8TDnZWDO6RuyshhJ+RZOWHvt1XQoPdweUuFFY0l96UrAokWQkh/Itsa++HsgoqUQqG9Y5o/cC6Ctj8KjTWgclMssnC8IBQsgtTuiROIYRwF0lWfii7oJKUmFCCA8xnPqh4L7w1D4r3HH/KBLxjDuHpvD8Cwz0epxBCuIskKz+UXVh5fEiv5QM+g/dvAbMVbvgI+k0Ghw0qj1D10pXcV/xbyE6G9JldF7QQQnSCzFn5mdoGO7kl1QxOPEOy2vxPePM6iE6BBV9D6rlgtoA1CHql8vmEJWQ7ktFvzYetb3dl6EII0WGSrPzMD0er0NooQz/Nsf3w6f1Ggvr5cojqd9ohKf36Ma/hd1TEZ8AHt0HJvi6IWgghOkeSlZ/JKqgAIP3UZKU1fHQXKDPMeh4CQlp8f3piONUE81n6Y2CywtePezpkIYToNElWfia7oJIAi4mUmNCTX9j8T9i/Ci56BCLP3NUiLiyQ6BArW8qCYNIvYPu7ULDdw1ELIUTnSLLyM9mFlQyKDzt5o8WKw/D5Q9B/Koy7sdX3K6UYnBBOdkElTLkLgiJh5aMejloIITpHkpWfyS6oPH0I8D/3gr0RrngWTG3/J01PDGdPYRU6KAqm3A17l0Petx6JVwgh3MHb29rPVkp90exxlFJqrPP5J7wZmy8qrW7gaGX9ycUVh7dA1sdw7m8gZoBL50lPDKeq3sbh8jqY+AsIS4QVfzDmvYQQwgd5e1v7pac8NQfIaHpeKbWg66PyXVnONknpic06V6x7FgLCYYLrl6ppjVZ2QYVRiDHtXji4HnK+dme4QgjhNj41DKi1XqS1XuR8mAbkeDMeX5PdVAnYtCC4NBd2/hsybjTmnlw06HiyqjKeGPMTCIqCLa+7MVohhHAfn0pWTZRSacAxrfWKFl5boJTKVEplFhUVeSE678kurCIy2EpCRKDxxLd/N0rVJ/2yXeeJDLbSOzLoRPd1SyCMuAp2fwz10uRWCOF7fDJZAbO11re29ILz7itDa50RFxfX1XF5VXZBBemJ4SiloLoENv8LRl4LEe3rvg7GvFV28+7rI68DWy3s+tCNEQshhHv4XLJSSs3WWi90/nmst+PxFVpr9hRWnSiu2PiykVwm39Gh86UnhPPD0SpsdofxRN8JEJ0K295yU8RCCOE+3q4GnA5kKKVmN3v8hFJqk1JqE9DLm/H5kqYdfgcnhENDDWx4CQZfAvFDOnS+wQnhNNgd5JbUGE8oBaOug/3fQHm+GyMXQojO83Y14AqtdXRT9Z/z8QCt9Tjn12lzVj1V05DdkMRw2LUMako6fFcFJ9o1nbRr8Mg5gIZt73QiUiGEcD+fGwYULct2JpXBieGw9U1jyK7/lA6fb2B8GCbFyfNWvdKg7yTY9rasuRJC+BRJVn4iu6CSpKhgIuoKjKG6UXONobsOCrKaSYkJPTlZAYy6Foqy4MiWzgUshBBuJMnKTxxvs7T9HUA7h+w6Z3BC+MnDgADDfwzmANnrSgjhUyRZ+YEGm4N9RVUMjg+DrW8ZO//2Su30eQcnhpNbUk1do/3Ek8HRMOACyP5EhgKFED5DkpUf2F9cjc2hmRR0AIr3GFV7bpCeEI5DGxs6nmTQDCg7AMV73fI5QgjRWZKs/EDThosjj30K5kAYPsst522qCDxt3mrQRcb3vcvd8jlCCNFZkqz8QHZBJcEmO9E5H8KQH7WrD2BrUmJCCDCbTp+3iuoHcUNh7+du+RwhhOgsSVZ+ILugkmuislA1JUYVoJtYzCYGxIcdL4s/yeAZxh5XdRVu+zwhhOgoSVZ+ILuwkivN6yAk1ih+cKP0hLDThwHBmLdyNMq2IUIInyDJysdV1ds4WlrBWTXfwdDLwGxx6/nTEyM4Ul5HeW3jyS/0nQiBkTIUKITwCZKsfFx2QSWTTTsIsNfAkMvcfv70xDAA9p46FGi2woDzYe8XUsIuhPA6SVY+LrugkhmmTBzWMEg91+3nH9y0EWNL81aDZkBVARRsd/vnCiFEe0iy8nF7C8qYYd6MGjzD2CTRzZKiggkNMLc8bzVwujMIKWEXQniXJCsfZz+wgVhVjhryI4+cXynF4FM3YmwSngB9xhhDgUII4UWSrHyY1poBJV9jUxZjSM5DhiQaPQJ1S3NTAy+C/I1QW+axzxdCiLZIsvJhRRV1THNsoKDXRAiK8NjnDE4Ip7SmkaKq+tNfTJsG2gEHvvXY5wshRFskWfmwg3s2k2IqpH7gJR79nPSEM7RdAkjKMFo85a7xaAxCCNEab29rP1sp9UULz01XSi3wVly+Qu/+GIdWRI+d5dHPGRhvlK/nFFWf/qI1CJLHQ+43Ho1BCCFa4+1t7Zc2f6yUmu18foXz8XRvxOUrEg+vYLsaTK+Efh79nLjwQEIDzOwvbiFZAaRMNcrXZd5KCOElvjYMOB7Icf45BxjrxVi8q+IIyXV7yIro+Nb1rlJKkRoXSk5ryUo74MB6j8cihBAt8bVkFXXK45hTD1BKLVBKZSqlMouKiromKi9w/LASgPLk87rk81Jjw9hfXNXyi8njnfNWMhQohPAOX0tWZUCv1g7QWi/SWmdorTPi4uK6JiovqNm1nKM6iqjUMV3yeamxoeSX1lJvs5/+4vF5KymyEEJ4h68lq42cuLtKA3rmalSHnYC8Vayyj2RIb8+VrDeXFhuK1nCgpKblA1KmQsE2mbcSQniFt6sBpwMZzQorlgJpzuejmgotepxDmwloLGe1HsWg+PAu+cjU2FCA1ossZN5KCOEl7t1vop2cySj6lOcWOv/YMxMVwA8rcGDiYNQEggPMXfKRKW0lq+bzVumeXfclhBCn8rVhQAHwwwp2mwbRu3dSl31kZLCV2LCAMycrmbcSQniRJCtfU3MMfWgTnzeMID2xa4YAm6TEtFK+DjJvJYTwGklWvmbflyg0q+yjGJLYNcUVTVJjQ898ZwUybyWE8BpJVr7mh5XUWyPZptMY0sV3VqlxoRRV1lNZ19jyAckZYLLAQUlWQoiuJcnKl2gN+1ayN2w8gVYr/XqFdOnHpzmLLHKLz1C+bg2G3qPg4IYujEoIISRZ+ZbCHVBVyBo9isEJYZhMqks/PjXW2dD2TJ0sAPpOhEObwH6Guy8hhPAASVa+ZN9XACyrGNzlxRUA/WNCUKqV8nWAvhPAVmcUWgghRBeRZOVL9q/C1msQWTXhXV5cARBkNdMnMrj1ZJU8wfguQ4FCiC4kycpX2Bogbx1HYycBdHlxRZO0uDYqAiOTILIvHPyu64ISQvR4kqx8xaFMaKxhZ+BoAK8MA8KJ8nWt9ZkP6jtB7qyEEF1KkpWv2L8aUKxuHEJsWCAxYYFeCSM1NpTKOhsl1Q1nPqjvRKg4BOX5XReYEKJHk2TlK3JWQe9RbCny3hAguNDQFow7K5ChQCFEl5Fk5QsaqiF/I47UaewprPRqskpzlq/vL2olWSWMAGuIDAUKIbqMJCtfcOBbcDRSGDORepvDa/NVAEnRwVjNqvUegWYrJI2TtktCiC4jycoX5KwCk5WtpqEAXilbb2I2KfrHhJJT1MrCYDDmrQq2G3eFQgjhYZKsfMH+VdB3AruKbZgUDEoI82o4qbGh5Ja0kYT6TgRth0ObuyYoIUSPJsnK22qOwZFtkDqN7IIKUmJDCbJ2zYaLZ5IWG0puSQ12Ryvl68kZxncpshBCdAGfS1ZKqdlKqelKqQXejqVL5K4BNKRNI7vAu8UVTVJjQ2mwOThcVnvmg0J6QWy6FFkIIbqETyUrpdR0IMe53X2OUmqst2PyuP2rwBpKTdxI8o7VkJ7gvfmqJm1ucd8kOcNYzNzaAmIhhHADn0pWQCbwrjNJpWmtu/+ESO4a6H82e4ob0Np7nSuaS3M1WSWNg5oSKM31fFBCiB7Np5KV1roMeAl4FxjX0jFKqQVKqUylVGZRUVFXhud+VUVQlAUpU8kuqAC8uyC4SVx4IKEBZtfurMDYMkQIITzIp5KVcxhwhdZ6AFCmlJp96jFa60Va6wytdUZcXFzXB+lOeWuN7/2nklVQSbDV3OUbLrZEKUVqXGjra60A4oeDJViSlRDC43wqWQFjmw39PQ708mYwHpe7Bqyh0Gc02QWVDE4M7/INF88kNTaM/a1twghgtkCf0ZCf2SUxCSF6Ll9LVoucw3zTgTla60XeDsij8tZCv4lok4WsgkqGJHh/CLBJamwo+aW11NvsrR+YNA6ObDW2OBFCCA+xtPcNSqnRQJrzqww4hlHBt6WzwTjnrLp3gmpSXQJHd8FZsymqqudYdYNPFFc0SYsNRWs4UFLDoNaSaNI4sD8HR3dCnzFdF6AQokdx6c5KKZWilHpRKbUcuBUYAJQDyvnnXyilPldKvaCUSvFYtN1Js/mq7IJKwDeKK5q41H0dThRZyFCgEMKD2ryzUkrdizF3dL/WuryNYyOBBUqpUq31y26KsXvKXWN0Lu8zhuxvjX2hfOnOyuW1VpF9ITTeWWRxi+cDE0L0SK0mK2eiWqq13u/KyZzJ7EmlVKpS6h6t9VPuCLJbyltr7AtlCSCroJK4cO9tuNiSyGArsWEBbScrpYy7K7mzEkJ4UKvDgFrrJ11NVKe8b78kqlbUHIPCHZAyFcBn2iydKjXWhfJ1gKSxULIXaks9H5QQokdqdzWgzEm5Qd4643v/qdgdmj2FlaT7UCVgk9TY0LbvrACSnPNWh7/3bEBCiB6rI6Xr0Uqpm5seKKWuVkpd4MaYur/cNcZi2qSx5JZUU29zMKS393sCnio1Noyiynoq6xpbPzBpLKAgXxYHCyE8o93JSmv9PTCwKUFprd8DZiilbnJ3cN1W3hroOx4sgT5ZCdikqSIwt7im9QODIiF2sNHUVgghPKAjw4DLAQ1scq65AqPbxEI3xtV91ZZCwQ7ob8xXZRVUYlIwMN67Gy62JC3OSFY5bXWygBNFFtKBXQjhAR0ZBhwAvOSs/FPOcvXFzi/RlgPfARpSpgCw41A5aXFhXt9wsSX9eoWglAvl6+DswF4MZQc8H5gQosfpSLKaAdyvlIpwDglOBzZorR9wb2jdVN5aMAdA0jgabA7W55QweUCMt6NqUZDVTFJUsIvJyrn12OHuv6uLEKLrdWTOKkdr/UutdYXz8XtAuRRZuChvnXEXYg1m84FSahrsnDPId7vHu1wRGD8czIHSgV0I4RFuaWSrtV4MtHs9Vo9TXwVHtkD/yQB8s7cIi0kxKc13m8unxYayv6ga3dZclCUAEs+CQ1K+LoRwP7d1Xe/I4uEeJ38jOGzNklUxY/tFEx5k9XJgZzYgPozKehsFFXVtH5w0zlhr5WijU7sQQrRTq8lKKXVvRxYBN7Vb6nBU3VXeOlAm6DuRY9UNbD9UzjmDYr0dVauGOtd/7T5S0fbBSWOhsRqK93g4KiFET9NmuyXgIqXU464kLaVUhFLqL8DV0m6pBXnroPcoCAxn7Q/FaA3nDPbd+So40Vx395HKtg9OGmd8l3krIYSbtdl1XWu9WCmVirENyBggB2Mfq31AFBDj/D7A+dxCGRJsga3eGAacYHQm/2ZvEZHBVs5KivRyYK2LCLKSHB3s2p1VrwEQGAGHNsOY6z0fnBCix3Bp80Vn8nkAjCE+Tmy+WI5RWJHjLGMXZ3JoM9jrof9ktNZ8s7eYqQNjMfvINvatGdo7wrVkZTIZGzDKnZUQws3avVOwM3HtB1a6PxxQSo3FSIRorZd64jO8ommzxX5ns6+oiiPldT4/X9VkaGI4K3cXUtdob3vxctJYWPccNNaBNahrAhRCdHsdqgZUSt3snMe6WSnl7g6sDzqTVC+lVJqbz+09eesgfhiE9GL1nmIApvpLsuodgUPDnkIX560cjcYWKEII4SYd6Q34IjAQY0v7OcB+dzWxVUotADYqpdK01ou01jnuOK/X2W1w8LuT1lelxYWSHB3i5cBc076KwKYiC+lkIYRwn47cWX2htX7A+TUDo7BikFLqKjfEMwCjYOOYUuolpVTUqQcopRYopTKVUplFRUVu+MguULAVGqqg/2TqbXbW5xzjnIH+cVcFRo/AkACzaxWBEX0gLFHmrYQQbtXpRcFa6zJnX0B3Nbjbp7UuAzYBC1r4vEVa6wytdUZcnG+XfR/XtNliv8lsyiulttHOuT5est6cyaRITwxnlyt3VuBcHCx3VkII92l3gQWQo5TaCPwZWNnUIxAocUM8G4Gm3kNRGCXy/i/vW+iVBhG9+WZdFlazYlKa+5rXaq0pry+nqLaI4tpiyhvKabA30GBvwOawEWgOJMgSRJA5iKigKOJD4okLjiPAHODyZwztHcHHWw+jtUapNioYk8ZA9idQV27sdSWEEJ3UkWR1LfAOMBf4h1JqH8baq41NByilLtBaf9neE2utlyql7lNKTXc+XtSB+HyLwwEH1kH6jwBjvmpsv2hCAzty6aHR0ciukl1sObqFvaV72Ve2j33l+6i11bb7XDFBMaRFpZEWmcbAqIGMiB1BenQ6VvPp7Z+G9o7gje8OcLi8jqSo4NZP3DRvdfh7SDuv3XEJIcSpOvIv5j6MeasnAZwLhadj7Bb8IEbiAhjfkYC01k2bOK7oyPt9TlGWseFi/8mUVNWz41AF916c3q5THKo6xIq8Faw9tJYtRVuOJ6bY4FgGRA3gqkFXkRSWRFxwHLHBsUQFRhFoDsRqtmIxWWi0N1Jrr6XWVktpXSlFNUUcrTnKoapD5JTn8EnOJ1Q1GhssBpoDGRYzjHEJ45jcZzKj40djNVkZ2tTJ4nBF28mqzxhn4JskWQkh3KIj66wWK6XGKKXQWuc6FwN/DzQlr7HAX9wcp/9qWl/VfzJrfjBK1l1ZX1VcW8wHP3zA8tzl7D62G4CBUQO5csCVZCRmMC5hHLHB7inS0FpTUF3AtuJtbC3aytairSzZsYSXt79MiCWESb0ncU7SBWCykVVQwfRhCa2fMDja6GYhFYFCCDfp0FhUa90qtNablVL3dzykbiZvHYT3gegUvlm5jagQK8P7tDyPo7VmY8FG3tnzDisPrMTmsDEydiS/HvdrpvebTt+Ivh4JUSlF77De9A7rzcUpFwNQ2VDJhiMbWHt4LavyV/HlwS8JH2zm3fwRDNg/nwv6XUCgOfDMJ00aB7lrPBKvEKLn6djESRuk9ZKT1kaySpmKxpivmtJCiyWtNavyV/Hi1hfZWbKTiIAI5g6Zy+zBs0mL9M666PCAcC7sfyEX9r8Qh3awrWgb9336GoW277hv9X2EB4QzM2UmVw++mmExw04/QdI42P4OVBw2ytmFEKITPJKshFPpfqgqgP6T2Xu0isKKes5tNgSotWZ1/mqe2/IcWceySApL4r/P/m8uS7uMIIvvtCoyKROj40czs08Iz345jVd+2YtP8z7ig30f8M6edxgVN4q5Q+Yyo/+ME8UZzRcHS7ISQnSSJCtPalpf1X8Kq7ONBcxTnVvY55TlsHDjQtYeXku/8H48NuUxLk27FKvJdzdiHNo7Aq1NRKrh/OWcKVROrOSDHz7gzaw3eeCbB3gq8ymuH3o9c9LnEJ54FpgsRpHF0Mu8HboQws9JsvKkvHUQEgNx6Xzz8UYGxIUSHap5YsMTvJn1JiGWEO4ffz/XDrnWp5NUk2HN2i6N7htFeEA41w+7nnlD57Hu8Dpe3fkqz2x+hpe3v8yc9Dn8JGEYsdLJQgjhBpKsPClvLfQ7mzqbg+/2l3Dh6Equ+vAqDlcdZvbg2fxqzK/oFdSr7fP4iOToYEIDzKf1CDQpE1OTpjI1aSo7S3ayZMcSXtn5Cm8GwXVVBfysppheIf7TXkoI4Xs63W5JnEHFYSjNhf6TWb33ELrXv1ld9ShmZWbJJUt4+OyH/SpRgdF2aUgbe1sNjxnOU9Oe4oMrP+DCqKG8EhrIJe/P5NnNz1LZ4EJvQSGEaIEkK09xzlflxKTy4He3EBC9nusGz2PpFUsZlzDOy8F13NDe4WQdqURr3epxKZEpPH72H1h26AjTwtNYvH0xl75/Ka/teo1Ge2MXRSuE6C4kWXlK3jo+i+zFNd/9gTpHOfNSHuV3Zz9IsKWN7g8+bmjvCCrrbeSXutDeKXYQaSqYJ639eOuyt0jvlc4TG5/gimVXsDJvZZsJTwghmkiy8gC7w84TR77i3l5h2OsSSar+Lfede4W3w3KLIYnt2NvKZIY+o+HQJobHDGfxRYt5cfqLBFmCuPvru7nl81vYU7rHswELIboFSVZuVtNYw10rfslrATYuJI2yfTfzh0snn7YQ2F8NSQxHKVzb2wqMbe4LtoOtHqUUU5Km8O7l7/K7ib8jqzSLaz66hse/e1zms4QQrZJk5UaF1YX87LOf8c2R9fyu+BhFOdOZPrQPk/1oo8W2hAZa6N8rhKyCduxtZW84aZt7i8nCdUOu45Mff8I1g6/hzaw3uWLZFXyS84kMDQohWiTJyk1yynOY/5/55FXk8b8RY7mq2samxv48eOkQb4fmdkPbqAg8SSvb3EcGRvLQpId487I3SQxJ5IFvHuCWL27hQMUBN0YrhOgOJFm5QfaxbG787EYaHY28OvNVJuZnscE2kOsmDWBAXJi3w3O7IYkR5B2robre1vbBEUkQltDqNvfDY4bz2qWv8dDEh9hZvJOrPryKl7e/TKNDqgaFEAZJVp20o3gHP1/+cywmC69c8gpDguKxlmTxvWk4d104yNvhecTQ3uFoDVkFLswzKQVJGZC/sdXDzCYz1w65lmVXLmNq0lT+tvlvzP14LrtKdrkpaiGEP5Nk1Qlbjm7h5s9vJjwgnFcveZXUyFS2f/sZJjQpY2cQHer6tvH+ZGjvdlQEAiRnQMkPUHOszUMTQhN45vxneOa8ZzhWd4x5n8zj2c3P0mBv6EzIQgg/57PJSin1hLdjaE3WsSxuW3EbMUExvHLJKySHJ2OzO9jz3WfUE8CMGZd6O0SPSY4OJjzQ4nqRRbJz0+h29Am8sP+F/PvKf/OjtB+xePtirv34WnaW7OxAtEKI7sAnk5VSajrgnY2cXLC/fD+3fnEroQGhLJ6xmMTQRADezjzI4LqtVMWNJjAoxMtReo5SiiG9w10vX+8zBpSpzaHAU0UGRvKnqX/i7xf+nYr6CuZ/Mp/ntzwvc1lC9EA+l6yUUmlAjrfjOJPDVYe55fNbAFh80WL6hBl7NR0qq2XR8u8ZbjpAr2HnezPELjG0dwRZRypwOFwoNQ8Mg/jh7U5WTc5NPpf3r3yfmakzeWHrC1z/n+vJKfPZHxEhhAf4XLIC0rTWZ/yXSCm1QCmVqZTKLCoq6sq4KK8v59YvbqXGVsOiixaREpkCQFFlPde//B3DHbsx4UClTO3SuLxhaO8IqhvsHCytce0NyRmQvwkcjg59XmRgJI+f8zh/Pe+vHK46zJyP5/DG7jdkXZYQPYRPJSul1HSt9YrWjtFaL9JaZ2itM+Li4roqNBrtjdz91d0cqjrE/17wv6T3SgegvKaRn/7fBgrK63h4xDEwB5yYo+nGhiSGA+3oZJE8HurLoWRvpz73ov4X8e8r/82ExAk8vuFxfrnylxTVdO0vLUKIrudTyQo4ppSarpSaDaQppcZ6OyAwtp//w7d/ILMwk0enPHq8a3p1vY0bX9nAvqNVvPSTcSSWbjIWwVr9u1mtK9KPt11qZ5FFB4cCm4sNjuXvF/6dhyY+xKaCTVz14VV8eeDLTp9XCOG7fCpZaa03O++segFRXg7nuEXbFvHhvg+5bfRt/CjtRwDUNdq59V+b2HKwjGfnjubc/kFweAv0n+LdYLtISICF1JhQdh4ud+0NMQMhKNItyQqMIo9rh1zL25e/Te/Q3tz11V08tv4x6mx1bjm/EMK3+FSyauIc6hugtT69R08XW3lgJc9teY7L0y7nFyN/AYDN7uDON79nzQ/FLJw9iktG9IYD60HbIfUcL0fcdSam9WJ9zjEa7S7MQ5lMxuLgg+5JVk3SItN47dLXuGHYDbyd/TZzP5nL3tLODTUKIXyPTyYrX7G/fD+/W/M7RsSM4A+T/4BSCodDc9/SbXy+q5BHrhjO7HHJzoNXGfNVfSd6N+guNG1wPFX1NjJzS117Q/J4OLoL6t3bYT3AHMA94+/hxekvUlpXytxP5vJO9jtSfCFENyLJ6gxqGmv4r6/+iwBTAH89768EmI1uFH/8eBfvf3+Ie2YM5obJKSfesH+1kah6wHxVkykDY7CYFF/vOeraG5LHA7rFprZuiSdpCkuvWEpGQgaPrn+U36z6DRUNLs6pCSF8miSrFmit+f3a37O/Yj8Lpy2kd1hvAP75bS6vrMvlpqmp3H7+wBNvqDkGR7ZBSs8ZAgQID7KSkRLNqmwXq/GSnR3Y3TRv1ZLY4Fien/48vx73a7468BXXfHgN24q2eezzhBBdQ5JVC97IeoPP8z7nzjF3Mqn3JABW7ynikY92MX1oPL+9dChKNdtMMW8toCH1XO8E7EXnpceTVVDJkXIXtrkPjobYwZCf6dGYTMrEjSNu5NWZr6KU4oZPb+DVna/i0B1b4yWE8D5JVqfIOpbF05lPMy15Gj8f8XMAfjhaxe1vbGZQfBjPXDfm9F1/938D1pATezf1IOenxwO04+5qvHFn1QXzSSPjRvLO5e9wXt/zeCrzKe748g7K6so8/rlCCPeTZNVMra2W+1bfR1RgFI9OeRSlFKXVDdz06kYCLSZeviGDsEDL6W/cvxr6nQ2W7tllvTWDE8LoHRnE1y4nqwyoKYZjXdMuKSIggr+e91d+O/G3fHv4W2Z/NJstR7d0yWcLIdxHklUzCzcuJLc8lz+f82eig6JpsDn4xWubOFJWx0s/GUdydAvNaauOQtHuHlWy3pxSivPS41j7Q7FrJez9zja+H1jv2cCaUUoxd8hcXrv0NawmKzd+diOv7HhFhgWF8COSrJxW5K1g6Z6l3DjiRib1nmQUWSzbwXf7j7Fw9kjG9e/V8hv3rza+98D5qibTBsdTWW9jU54LJeyx6RAUBQfWeTyuUw2LGcY7l7/D+f3O5+lNT3Pnl3dSXu/iomYhhFdJsgKKa4t55NtHGB4znF+N+RUA/1izn7czD/Kr8wcya0zSmd+8fzUERkLiqC6K1vccL2F3ZSjQZDLurrrwzqq58IBwnp72NA9OeJC1h9dyzUdSLSiEP+jxyUprzWPrH6OmsYY/T/0zVpOVVXuK+NN/djNzRCK/vmhw6yfI/QZSpoC5hbmsHqKphP3rbBfXW/WbZOwcXOXi8W6mlGLe0Hn8a+a/MCkTN3x2A//a9S9ZRCyED+vxyeqz3M9YeWAlt4+5nbSoNIqr6vnNO1sYHB/O03NGYTq18q+5soNGoUAPHgJs0lTCXlDuQm++/pON7166u2oyInYEb1/2NuckncPCjQv5r6//SxYRC+GjenSyKq4t5s/f/ZmRsSO5YdgNaK154L3tVNTa+Nvc0YQEtHG31DRf1cMWA7fkvHRju5ZVrnSz6D0aLEFw4FvPBuWCyMBI/nb+37gn4x5WHVzFnI/msLNkp7fDEkKcoscmq+bDf49OeRSzycxbGw+yYnch912SzpDEiLZPsu9LCI2H+GGeD9jHpSeEkxgRxFdZLsxbWQKMprY+kKzAGBa8YfgNLLlkCTaHjZ/85ye8nfW2DAsK4UN6bLJaeWDlScN/OUVV/PGjXUwdGMvPp6S2fQKHA3K+ggHnG0UDPVy7S9j7n220qKqv8nxwLhodP5p3L3+XCb0n8Nh3j3H/6vupbqz2dlhCCHposqpurObxDY+THp3OT4f9lEa7g/96ewsBFhNPXdPGPFWTgm1QUwIDLvR8wH7ivPQ410vY+00ytlTxYJ/AjogOiub5C5/nrrF3sTxvOdd9fB3Zx7K9HZYQPV6PTFbPff8cRTVFPHz2w1hMFv535V625pfz+FVnkRgZ5NpJ9q00vg8433OB+pkpA2NdL2FPngDK5DNDgc2ZlImbz7qZf8z4B9WN1cz/z3ze2/OeDAsK4UU9LlntLtnNG1lvcM3gaxgZN5JNecd47qsfmD0umUvP6u36ifZ9BYlnQVi854L1M+0qYQ+KMK6fDyarJhmJGbx7+buMjR/LH779Aw+ueZCaxhpvhyVEj+RTyUopFaWUGquUmq2UesLd57c77Pzx2z8SFRjFXePuorKukbvf3kJSdDD/fXk7iiTqq4yy6wEXuDtEv9euEvZ+Zxsd2O2Nng+sg2KCY3jxohe5Y8wdfLr/U679+FoZFhTCC3wqWQFzgAyt9VIApdQCd5586Z6l7CjZwX3j7yMiIIJHPtrFodJa/mfOaMKDrK6fKHcNOBolWbWgXSXs/c6Gxhqj0MKHmZSJBSMX8PKMl6lurGbeJ/NkJ2IhuphPJSut9SKt9SLnwzTAba25y+vLeW7Lc4xPHM+lqZfy0dbDLN2Uz23nDSQj5Qx9/85k30qwBJ9oyiqOa1cJe9P1y1vj2aDcZHzieN69/F3GJ47n0fWPcu/qe6lsqPR2WEL0CD6VrJoopdKAY1rrFS28tkAplamUyiwqcnFbCuDFrS9S0VDB/ePv5+CxWn77/nbG9ovirumD2h/gvi8hZSpYAtv/3m6uXSXs4QkQNwRyVnVNcG4QExzD89Of5+6xd7MibwXXfHQN24u2ezssIbo9n0xWwGyt9a0tveC8+8rQWmfExcW5dLKcshzezHqTqwddTWrEIO5463uUgr9dNwaruZ2XoDTP6Gs3UErWz6SphD0z14US9rTzIG8d2Oo9Hpe7mJSJm866iVcueQWtNT/99Kcs2bFEthwRwoN8LlkppWZrrRc6/zy2s+fTWrNw40JCLCH8asyvePrzbLYeLOOJq0fSt1cL+1O1Zd+XxneZrzqjKQNjCQu08Oq63LYPTjsPbLVwcIOnw3K70fGjj2858tdNf+W2FbdRXFvs7bCE6JZ8KlkppaYDTyilNimlNgHtnEw63TeHvmHt4bXcOupWtuXZeGl1DvMn9mNme8rUm9u3EiKSIbaNbuw9WHiQlVvOSeOznQVsOVjW+sEpU0GZjW4gfigyMJKnpz3N7yf9nszCTK7+8GpW56/2dlhCdDs+lay01iu01gO01uOcX6fNWbWHzWHjyY1PkhKRwvSkq/jNO1tJTwjn95d1sJefrd5YXzVoOigXulz0YDedk0pMaABPLs9q/cDAcEgeDzlfd0lcnqCUYk76HN6+7G1ig2O5feXt/GXDX6izuVC+L4RwiU8lK3db9sMycityuXPM3dz77k6qG2w8N28MQVZzx06Y+w00VEH6pe4NtBsKC7Rw+/kDWftDCWv2tjE0lnYeHP4eal2Y4/JhA6IG8MaP3mD+0Pm8vvt15n4yV9ZkCeEm3TZZ1dpqeX7L84yKG0V2Tj/W7SvhkSuGMyghvOMnzf4UrCGyf5WL5k/qR1JUME8uz2p9TVLaeaAdsP+bLovNUwLNgTww4QFenP4iZfVlzP1kLq/seEWKL4TopG6brF7f/TpFtUVc2ucm/mfFXi4f1Yc5GX07fkKtjWQ14AKwBrsv0G4s0GLm7umD2JpfzvKdBWc+MDkDAsL8eijwVFOSpvD+Fe9zbvK5PL3paW5afhP5lfneDksIv9Utk1V5fTn/t/3/mBA/lWc+sZMUFcyffjwC1Zl5poJtUHEI0me6L9Ae4KqxyQyMD+PJ5dnYzrTuymw1Ci26UbICo4P7/5z3Pzw65VF2H9vN1R9ezdI9S6XzhRAd0C2T1cvbX6aqsYpdu6bQYHew+KcZRLSnnVJLsj8FFAy62C0x9hRmk+KeGensK6rm/e8PnfnAtPPg2D4oO9BlsXUFpRSzBs7i/SveZ0TsCB759hFuW3kbBdWt3GkKIU7T7ZJVQXUBr+9+g8C6CVSUx/LqjRNIT+zEPFWT7P9A3wkQ5tpCZHHCxcMTGNU3ime+2ENdo73lg9KcW610s7urJn3C+rB4xmIemPAAmwo38eMPfsz7e9+XuywhXNTtktXz3y+i0W6n4sgF/ONn4xnVN6rzJy0/BEe2yhBgBymluP/idA6X1/H6d2e4c4pLh7BEY2lAN2VSJuYPnc97l7/HkF5D+O91/82tX9wqc1lCuKBbJauc0oP8+4f3sZWP58XrpjMpLcY9J97zmfFdStY7bPLAWKYOjOXvX/1AVb3t9AOUMlpY7Vvp01uGuEPfiL784+J/8LuJv2Nr0Vau+vAqXt35KjZHC9dFCAF0o2RVb7Pz82VPoIGHpvyK84e4cVPE7E+hV5p0reikey9O51h1Ay9/c4Zm+kMug7pyYz1bN2dSJq4bch0fzPqAiYkTeSrzKeZ9Mo+dxTu9HZoQPqlbJCub3cGC17+gWK0ho9clzM8Y5b6T11fC/lXGXZV0reiUUX2jmDkikcWrc9iWX3b6AQPOB2so7P6oy2PzlsTQRJ694FmemvYUR2uOMveTuTy2/jHK68u9HZoQPqVbJKvnv97H+tJ3sSjFXy68270nz/oE7A0w9HL3nreH+t2PhhIdGsB1i9bzdfYpGzRag2HQRbD7Y3CcoRCjG1JKcXHKxXz44w+ZO2Qu7+55lyuWXcEHP3wgi4mFcPL7ZOVwaN7Y9D0BUZu4Jn02iaGJ7v2A7e9CVD/oO9G95+2hkqNDeP+Xk0mJCeXmVzNZuumU4oKhl0P1Ucjf6J0AvSgiIIIHJz7IWz96i+SwZB5a+xDX/+d6thZt9XZoQnid3yerb3NKKA1Yjtlk4uazbnbvyauKjOq0EbNlCNCN4iOCePvWSUxM68U9727l71/9cKKEe9AMMAf0qKHAUw2NGcq/Lv0Xf5r6JwqqC7j+P9fzwDcPcLjqsLdDE8Jr/D5ZvZ65nYCoTcwaMIuE0AT3nnzXMtB2OOsa955XEB5kZcnPJnDl6D48uTybhz/Yid2hISjCaGm1+0OjxVUPZVImrhhwBR//+GNuOesWvsj9gsv+fRlPbXxK5rNEj2TxdgCd4dCarwuWYo52cNPIG93/AdvfhfjhkNDBLUVEqwIsJv5nzmgSIoJYtDqHosp6nrluNEFDLzeWCxRsg95uLJbpalpD8V7IWwul+43uHGUHoK4C0EbzXmWGkBhjsXlovFF1GpduVJ5G9iXEGsKdY+9kTvocnvv+Of6565+8v/d9fjbiZ8wfOp9Qa6i3/5ZCdAnlzyvoU4cO16H3BjG5z7ksuuR/3Hvy0lz42yi48L/hnF+799ziNP9Ys59HP97FiKQIHpvRm9FvTYCp/wUX/t7bobWPw2GsFdu+1KgirTxiPG8OhMhkY/4zKBJMZlAmY01ZTQlUF0FV4cnbpARGQtIYSBpn7PnVdyJ76ot5dvOzrMpfRVRgFDcMv4F5Q+YRYu3Arteix1JKbdJaZ3g7jvbw62QVntJbpzwSy9LLl5LeK929J//maVj5R7hrG0T3d++5RYuW7yzg4Q92UFhRz/LoJ0kLrsJ6Z6a3w3JNbSl8/zpsfNm4iwruBWnTIHWasaVMdCqYXBh1rzkGRdlQlGXcWeZnQuFOYzgaBQnDof8Utsf25/nS71lT8B2RgZHMGzKPuUPmEh0U7fG/qvB/kqzcQCk1GygD0rTWi1o7NjglTF+48Bo+nrPE/YE8fzYERsBNy91/bnFGNQ02XlyVQ9U3z/OwaQmvjHyN2T+aSVigj45YO+yQ+X/w5aPGguZ+Z8P4m2HoFWAJcM9nNNQYm1PmrYO8NXBwAzTWAIptvYfwcmQYX9UXEmQO5MeDrmLekHmkRKa457NFl9NaU2urpaKhgvL6cioaKqhqqKKq0fiqbqymprGGWlvt8a96ez11tjoaHA3U2+tptDfSYG/Apm3YHDYaHY3YHXYc2oFN2/h23reSrDrDmajQWi9VSi0Aclrb2j44NVh/tPJrpqe5uay8cCe8MBkufQom3OLecwuXHDlyiJhFo3m38RyeCb6Ne2ekc/YAN7XPcpOAI5uI/vpBAoq2U5c8hbKpD9MYP9LzH2xvIKBwC0H5awnMX0dAQSb7lY0lkRF8EhaGTcGEoL5c3u9KRqddhdnX5rW0A9VYg6mhEtVQhbLVYGqsQTXWgr0BZa93fjWCw4ZyNIK2o7Q27jBb+jdLmUApNMo5xGpGm8ygLGiTBUxm4/vxx03frWiz83mz5eTjleX4cK1W5hNDt8qEViZAGV+q+femeJx/bhZrta2a4roijtUVc6y+hJK6YsoaSimtP0Z5QxnlDeVUNJZT3lhBo6P1lmMmTASZgwgyBxBoCiTQFECgKYAAUwBWkwWrsmA1WbEoMxaTBbMyYVZmzMqECRN/uvivkqw6Qyn1BPC21nqzUmo6MFZrvfBMx0enhOrS3Gr3B/LZg7BhEfwmG0Jj3X9+4Zplt2Pf8R4/jXqVtfm+0zdP4eAO8zLutrzHUaJ4rPF6PnZMwvjHq+tZsXGWymGSaTeDrbvZH3mEjyOsHLVYiLfZmFYJAytiqW5I5oiO4bCOoUD3opQwynQYlYTgaEdhsAkHIdQRQj3hqoZwaglXNURSTaSqJoIaIlU1kVQRpaqOP9/0Whi1mJTv/LvjDhooNZk4ZLGQb7VwyGLhiMXMIYuFAouZQouFqhaGgYMdDmLsdmLsDqLtdqIdDqLsDiIddiIdDiLtDsIdxleYQxPqcBCmNYFad+qnTT1S4XfJytfGVqJOeXzar9LOO64FAEOSrMYQSYAbJ5frK+H712DYLElU3jbhFsxbXuO1cftYddFsiirrvR0R1sYKJnz/IH2OriIv6TI2n/V7pllCmebtwBgLQCOQrDV31eRxoOgjNtRk8l5UEY7oMkbWH+XiqmoWVNeQaD/RIUSjsJuDsJsCsZsDcZia9n5TgMbksGHSjZgcjZjtdZgdDW1GYzcF0GCNpCEgkkZLOA3WOBqsERRaw8m3htNoCaPREobNEorNHGx8ftOXKQCHKQCHyYJDWdEmCw7lvMNBOe9qTlBo0Nr53YHSDpS2Y9J2lPPL5LChsKMcNuP5438nG0rbjh9rcjQ63+M46XmlHWiHnVJHFUd1OYWOCgp1FUWOSgp1FUd1NXWc/AtVGAHEqhBiVQgDVAgxBNNLBRNtCiaKEKJUMIEmK013aNp5h6add2m62V1brfOrSIFu+sWi6RgUKE78uemqnLY2tPnjX7T539DX+OKd1Rda6xXOO6uLtNb3n+n4jD5mnfnZWzDSjeugvlsEn94LN680tlsX3vXydKN44faNrhUoeNLR3fDmXCg/CJf8xZib8oPF4kdrjvLRvo/4bP9nZJVmATAyrB/TwlI5NzCBdIcJ1VgDtjrjy9548lCbOcDYzdlsNVpiWUONXxADQo153cAIY31cUCQERUFwlHGcH9JaU1xbTG5FLgcqDpBXkUdeRR4HKg9wsPIg9fYTvzBZTVaSw5PpF96P5PBkksOSSQ5PJiksiaSwJJ+u0JQCi05q75xVRt9gnfn4pXD9e+4JwOGAv483/k93y5fuOafonG3vwPu3wPXvG1uIeEveOnjzOrAEwZx/QT//bL+VV5HH57mfs+LACnaV7AIgPjieSX0mkZGQwfjE8SSFJaH8IAl3lNaakroSDlYeNBJRxQEOVB44/ucaW83xY60mK33D+9Ivoh/9w/vTL6Kf8RXej4SQBMwmsxf/Jh0nycoNlFL3AZtpY74KICM9SWfOq4FfZ0G4G7pX7F0Br18NVy2GkXM6fz7RebZ6+OswY5fmuW96J4asT2DpzyGyL/zkfWOtVDdQXFvMmkNr+Cb/GzYWbKS03ljjFR8Sz8jYkYyIHcGI2BGkR6cTFRTl3WDbqdZWy5GqIxyqOnT862DlQQ5WHiS/Mv+khGRWZpLCkoyEFNGffuH9SIlIoX9kfxJDEv02IbVGklUXyxg9QmfOOggX/xnOvr3zJ3ztaijYDnfvcF/Zsei8lY8a697u2tr1a942vQof3w19xsK8dyDUtyoS3cWhHeSU5bChYANbirawo3gHBysPHn89LjiOQdGDSI1MNe40nENfCSEJXTrcpbWmoqGCktoSimqLKKot4mjNUQqrCymsKeRI9REKqgs4VnfspPcFmgNJCkuib3hf+ob3JTk8+Xhi6h3WG+vxebqeQZJVF8vIyNCZC8LAYYNfrOncyYr3wnMZcN5v4bwzTpMJbyjPh2dGwrgb4DI3dyppzdpn4Yvfw8CLYM6rxhxND1JWV8bOkp3sLd3L3rK97C3dS25FLrW22pOOCw8IJyEkgeigaKIDo4kOiibMGkaoNZQQawjBlmCsJqtRSm2yoFBo5//s2k6jvZFGRyP19npqbbXUNNZQY6uhqqGKioYKKhsqKasvo7SulNL60hZ3VA63hpMQmkBCSAK9w3rTJ7QPiaGJ9A3vS1JYEjHBMZiU37dCdRt/TFa+Vg3YfiOvg8/uh8Jdnevh991LxkRyhgd6DIrOiUw2ihk2LoZxP/N8v0Ct4as/weonYfhV8OOXeuSddlRQFFOSpjAlacrx55rP9+RX5lNYU0hhdSFHa45SVl/G3rK9lNaVUtVQhU13fLlBsCWY8IBwIgIiiAiIoE9YH0bEjjieDOOC44gNjiU2JJaEkATpkdgD+H+yGnE1LP8tbHsLLvpjx85Rsg82vQKjroOweLeGJ9zk/N/CjvfgP/fCz5d7rgrP4YDlD8J3L8LYn8JlzxiLQQVgbBQZGxxLbHAsY+LHtHpsg72B6sZqam21x7sonHpXZDFZjt91Wc1WQiwhBFmC5C5InMb/k1VYHAycDlvfhvMe7FjJ7GcPGFVeF/hZ09SeJDgKpv8BPvwVbHvb+MXC3WwN8MFtRrf9SbfDxX/yi9J0XxVgDiDAHEA00q9QdF73+PVl8q+gqsCYY2iv7M9g7+fGPJU7KgqF54yeb3Qg//z3zm023Ki+Et6YYySqCx+WRCWEj+keySr1XBj+Y1jzV2NrD1c11hl3VbGDYcKtHgtPuInJBJc+aWyn8dWf3XfeqqPwyo9g/2q48nk45zeSqITwMd0jWQHM+JOxkd1nv3X9Pd8+Z2zncMlfeuQEul9KGgfjb4LvXjC6nXfWwQ3w0jQo2mOs4xozv/PnFEK4XfdJVpFJMO1eyP4E9n7R9vGHtxhrd4Zc5t3OCKL9LvkLDLoYPv61UXTREVobrbWWXGr8onLTchh8sXvjFEK4TfdJVmBMiscMhE/vM4b4zuTw9/DPK4ztxGc+0XXxCfcwW+GaV4y9o95f4NovJ81VHIalNxo9IAdOhwVfe74cXgjRKd0rWVkCYOZCOJYD/zfD2HH1VIc2wT+vNLYM/9knxhoe4X8CQmDeW8bOuW9fD18/AfVVrb+nocY47n/HGS2ULnwYrnsDgqVaTQhf5/8dLDJb2PZ898fw0Z3QUG2svRp2JRTsgCNbjIrB4Cj42cfdpsdbj1ZdbLRD2v0RhMbDtPtg6OUQEgtmi3GHnbcWflgJO/8NlYeNn4fpj0CvVG9HL4RX+GMHi+6ZrAAqC+GD2+GHU4aIeo+Ca1+HqL6eD1B0nYMb4YuH4cC6E88F94LGWrDVgjkQUqbCufdA/8nei1MIHyDJqou1mqzAmETf8Z5Rmtx7JCSMMO6qRPekNeSugeJsqCqC6qPGYu8BF0D/Ke7dpFMIP+aPycr/O1i0Rik4a7a3oxBdRSlIPcf4EkJ0K92rwEIIIUS3JMlKCCGEz/OpYUClVBSQ5vwar7WWjaWEEEL43J3VHCBDa70UQCm1wMvxCCGE8AE+dWeltV7U7GEa0M7WBEIIIbojX7uzAkAplQYc01qv8HYsQgghvK/L76yUUrOBXqc8nXNKYpqttW5xzw7n0OACgH79pAOFEEL0BD63KFgpNbvZnNVYrfXmMx3b5qJgIYQQp/HHRcE+layUUtOBl4Ay51P3tzYUqJSqBFroVtsjxQLF3g7CR8i1OEGuxQlyLU5I11qHezuI9vCpZNVeSqlMf/vtwFPkWpwg1+IEuRYnyLU4wR+vhU8WWAghhBDNSbISQgjh8/w9WS1q+5AeQ67FCXItTpBrcYJcixP87lr49ZyVEEKInsHf76yEEEL0AH6TrJRSs5VS08/UL7Ct17sLF69Dj2hT1dq1UEpFKaXGOo95whvxdSUXfi6mO796/LVodlyPvxZKqVKl1BdKqfu6Orb28otk5ex6QdOaK+d6LJdf7y5c+Xs2Laju7ly4Fj2mKbIL//8YC4x1vj7W2c6sW3L13wLn8932OoDL1+IarfVFWuuFXRpcB/hFsgLGAznOP+cAY9v5enfRU/6ermj1WmitFzVrjJzW7NjuqK1rsVlrvdC5BU+O1rrHXgs43nu0O1+DJq78exHlL7+8+EuyijrlcUw7X+8uok553F3/nq6IOuVxi9eihzRFjjrl8Zl+LjKAfZ4NxeuiTnnc0rVI6+YJu0nUKY9buha9gGNKqZc8H07n+EuyKuP05rfteb27KKNn/D1dUYZr1+KMTZG7kTJcuBbOhD2gaXiomyqjlWuhlJrezX9xaa6MNn4unCMQZUCZr/9c+Euy2siJ3xJa2ueqrde7i57y93RFm9fC2RR5ofPP3XnItNVroZR6otmcXRnd+xeetn4ujjkLDmYDaT3852KBP/39/SJZOSfJ05wThFHNJgy/aO317qat6+D883Qgw9d/S+qstq6F8/knlFKblFKb6Mb/QLvwc/ESkNPsdb9bEOoqF/6t2Ox8rhenD5N1Ky78XLzjfDy72fE+SxYFCyGE8Hl+cWclhBCiZ5NkJYQQwudJshJCCOHzJFkJIYTweZKshBBC+DxJVkIIIXyeJCshhBA+T5KVEEIInyfJSgghhM+TZCWEmyml0pRS+5q1furWe0gJ0RUkWQnhfvcDFwGbnbvRZvSQLSmE8BjpDSiEmymlorTWZc7NDjO6a2NlIbqSJCshPKBp6wWt9WZvxyJEdyDDgEK4mXPLhZymRNXdt2sRoitIshLCjZybHKYBi5VSUc45qzLvRiWE/5NkJYSbOCv+cpy7E+cA+4F9MmclROfJnJUQQgifJ3dWQgghfJ4kKyGEED5PkpUQQgifJ8lKCCGEz5NkJYQQwudJshJCCOHzJFkJIYTweZKshBBC+DxJVkIIIXze/wMgy1LOtMB1RQAAAABJRU5ErkJggg==
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAasAAAEnCAYAAAAXY2zOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABHHElEQVR4nO3deXyU1dXA8d+dmew7WSEBkrCETdawKCguiEJdqAIK2FqrYtW2+rau1dpaba0U+1prrYJ90borWhStoqCCgAsB2UmABAIBAtn3bWbu+8czA2FLJslkluR8/eQzycwzzxyHJCf33vOcq7TWCCGEEL7M5O0AhBBCiNZIshJCCOHzJFkJIYTweZKshBBC+DyLtwMQQgjRfhs3bkywWCwvAsPw/wGIHdhutVpvGTNmzLHmD0iyEkIIP2axWF5MSkoaHB8fX2Yymfy6vNtut6uioqIhhYWFLwJXNX/M37OwEEJ0d8Pi4+Mr/T1RAZhMJh0fH1+BMUo8+TEvxCOEEMJ9TL6eqHbu3Bk4bdq0dFeOdfy/nJabJFkJIYToVEOGDGl85ZVX8jtyDklWQgghOtXOnTsDs7OzgzpyDimwEEKILuLepVt67y6sCnXnOQcmRdT+ZeaIgy0ds3DhwrgJEybUfvPNN6H33HNP8ZIlS2LefvvtmNmzZ5fl5uYGzp07t+y+++5LXr9+/Z7i4mLz008/HZeZmVmblZUVGh0dbbvnnnuKW4tDkpUQQoh2e/jhhxMzMzNrJ02aVFtcXGxeuHBh3D333FP8yCOPJH/88cd5zuOioqJsAGvXrg2Njo62zZgxo+qFF16Ib35MSyRZCSFEF9HaCKgzbNy4MWzu3LllAAMHDmx44YUX4u+5557iYcOG1Z7p+BkzZlQtXLgwaNmyZRFPPfVUgauvI8lKCCFEu40ZM6Zm9+7dQUOGDGncvXt30JgxY2paOn7t2rWh06dPrxwyZEhjW15HCiyEEEK02+OPP340KysrdNmyZRFZWVmhjz/++NFly5ZFbN++PXTt2rWhYCSo7du3h+7cuTNw0qRJtbNmzeo3bdq09Ntvvz25uLjY7MrrKNnPSggh/NeWLVv2jxgxotUCBV/x8MMPJ959993FcXFxtp07dwb+/e9/j//nP/95qPkxW7ZsiRsxYkRq8/tkGlAIIYTHZGZm1i5fvjwyJibGWlZWZpk3b16ZK8+TZCWEEMJjZsyYUdWe58malRBCCJ8nyUoIIYTPk2QlhBDCrW6//fZkMDpbNL/fWR3YHpKshBBCuNVrr70W37t372H9+/dvcN63bNmyiNtuu61ve88pyUoIIYRb/fvf/849ePDg9ubFFDNmzKiKioqytvecUg0ohBCi3dauXRva/MLeGTNmVGVlZYUCOC8SdsfrSLISQoiuYtmdvTm2061d10kYUsuMf5y15+Brr70Wc9lll1XOmDGjaufOnYFgdLUAWLFiReSyZcsi2luu3pxMAwohhGi3xx57rHDFihWRQ4cOHVxaWmpZsmRJzJIlS2IAYmNjrXv37u3QPlZOMrISQoiuooURUGdZvnx5pKNd0qGHH3448fLLL68aNGhQA0BeXl7wHXfcUeSO15FkJYQQot1yc3MDnSOpuXPnlg0ZMqRx4cKFcbGxsbb09PT6SZMm1QIsWbIkZvv27WFLliyJuemmm1xqsdScNLIVQgg/5m+NbF1xpka2smYlhBDC50myEkII4fMkWQkhhPB5kqyEEEL4PElWQgghfJ6UrgshhHArZ7f13NzcoOZb1q9duzbUWcreVn6drOLi4nRqaqq3wxBCCK9ZsGABO3fubFM384aGBuuoUaO2dEY8y5Yti5g+fXrlkCFDGqdNm5bubLe0bNmyiIceeihlx44du9pzXr9OVqmpqWRlZXk7DCGE8Jpdu3YxePDgNj1n+/btjZ0UDnv37g3au3dv0JAhQ4pTU1MbHO2WqmbMmFG1YMEC6bouhBDC807tun7PPfccv0B5y5YtofPmzWtzt4ozkWQlhBBdxJPfPUl2aXarx1XXVAdb9lsyXDln/5j+tY9NfKxNXdfBSGIXX3xxZXvXqE4l1YBCCCHa7dSu6877P/nkkwh37WUFMrISQogu4/5x97t03Pbt2+uHDRuW447XPLXr+qRJk2oXLlwY50xUsp+VEEIIr3N2XV+yZEnM3Llzy5YtWxbxhz/8IaV3797DIiMjRzqPa951vT2v49dd1zMzM7VUAwohurN2VgPWDhs2rF0l5J4gXdeFEEL4JUlWXcyeo1V8uPWwt8MQQgi3kgKLLubR5TtZl1vMoKQI+idEeDscIYRwC6+PrJRSo89y/32ejsXfHS6vY11uMVrDc1/mejscIYSH+HPtwansdrsC7Kfe79VkpZSaAiw+y/1jPR+Rf/vP94fQGqYOSeT9zYc5WOqWa/GEED4sODiYkpKSLpGw7Ha7KioqigK2n/qYV6cBtdYrlVKl3oyhq9Ba8+6mAsamxvCHq4fxZc4XPL86lz/+8BxvhyaE6EQpKSkUFBRQVFTk8nMKCwstNpstrhPDai87sN1qtd5y6gM+t2allBrtSGK3eTsWf7L5YDl5RTXMPz+dpKhgZmam8E5WAb+4eABJUcHeDk8I0UkCAgJIS0tr03OGDBmyTWud2UkhdQqvr1mdQQ9vB+CP3t1UQJDFxPThPQG4fXI/bFqz+Ks8L0cmhBAd51PJyjmqauWY+UqpLKVUVluGvV1Zg9XG8i1HuGxoEpHBAQD07hHK1SN68fq3ByipbvByhEII0TE+layAdKXUTKXUTMfnp1UKaq0Xaa0ztdaZ8fHxXgjR96zadYyKuiauHZNy0v13XNSPequN/1u3z0uRCSGEe3i7GnAmkOm4RWu9VGu9FGMqMNqbsfmTdzcWkBgZxKT+J6+X9k+IYNqwJP69Pp+KuiYvRSeEEB3n1WTlSE4xjgTV/P5FWut+WutN3orNXxRVNfDl7iJmjErGbFKnPX7Hhf2parDyytf7PR+cEEK4ia9NA4o2en/zIWx2zczRKWd8fFhyFBcPSuBfa/dR09DuHaWFEMKrJFn5uXc3HWJ4ShQDEs/eWunOi/pTVtvEG98d8GBkQgjhPpKs/NjOw5XsOlLJtWcZVTmN6RvDuemxLFqTR32TzUPRCSGE+0iy8mPvbiogwKy4akSvVo/9xcX9OVbVwNKNBR6ITAgh3EuSlZ9qstl5f/MhLh6UQExYYKvHn9svlvT4ML7IPuaB6IQQwr0kWfmpNbuLKK5ubHUK0EkpxdBeUeQcrerkyIQQwv0kWfmppRsL6BEWyIUZCS4/Z1BSBAVldVRLVaAQws9IsvJD5bWNrNp1jKtG9CLQ4vo/4UBHxeBuGV0JIfyMJCs/9HVuCY02O1e6UFjRXIYzWRVKshJC+Bef2yJEtC67sAqlYEjPyJYPrK+ETS9DUz2YzKSYLAwNDCPnaKpH4hRCCHeRZOWHcgqrSI0NIyTQfPaDivfAm3OhePfxu0zA2+ZQnsr/AzC00+MUQgh3kWTlh3KOVh2f0jvzAZ/Ae7eCOQBuXA59zgO7FaqOUP3C1dxX/BvISYGMaZ4LWgghOkDWrPxMXaON/SU1DEw6S7La9G9443qISYX5X0LaBWC2QEAw9Ejj03FLyLGnoN+cB1ve8mToQgjRbpKs/MzeY9VobZShn6Z0H3x8v5GgfroCovucdkhqnz7MbXyIyoRMeP8OKMn1QNRCCNExkqz8THZhJQAZpyYrrWH5XaDMMOM5CAw94/MzkiKoIYRPMh4HUwB8+URnhyyEEB0mycrP5BRWEWgxkRobdvIDm/4N+1bDpY9C1Nm7WsSHBxETGsDm8mCY8DPY9g4UbuvkqIUQomO8nqxO3bpeKTXf8fGkt2LyZTlHqxiQEH7yRouVh+HTh6HvJBhzU4vPV0oxMDGCnMIqmHgXBEfBqsc6OWohhOgYb29rPwVYfMrXK7XWi4B0x9eimZzCqtOnAP97L9ia4KpnwNT6P2lGUgS7j1ajg6Nh4t2wZwXkf90p8QohhDt4e1v7lUBps7vSAWeCynN8LRzKaho5VtVwcnHF4c2Q/SFc8GuI7efSeTKSIqhusHK4oh7G/wzCk2Dl7411LyGE8EFenwZsTmu9yDGqAhgNZHkzHl+T7WiTlJHUrHPF+mcgMALGzXf5PM5rtHIKK41CjMn3wsFvIO9Ld4YrhBBu41PJysmxjvWZ1nqTt2PxJTnOSkDnBcFl+2HHfyDzJmPtyUUDjierauOOUT+C4GjY/JoboxVCCPfxyWQFTNFaLzjTA47iiyylVFZRUZGn4/KqnKPVRIUEkBgZZNzx9T+MUvUJt7fpPFEhAfSMCj7Rfd0SBMOugV0fQoM0uRVC+B6fS1ZKqfnORHWmAgvHVGGm1jozPj7e8wF6UU5hJRlJESiloKYENr0Cw6+DyLZ1Xwdj3Sqneff14deDtQ52fuDGiIUQwj28XQ04E8h03DqT05NKqVylVJk3Y/M1Wmt2H60+UVyx4UUjuZz3i3adLyMxgr3HqrHa7MYdvcdBTBpsfdNNEQshhPt4uxpwqdY6Rmu91PH1SsfX/Ry3K70Zny9x7vA7MDECGmvhuxdg4OWQMKhd5xuYGEGjzc7+klrjDqVgxPWw7yuoKHBj5EII0XE+Nw0ozsw5ZTcoKQJ2LoPaknaPquBEu6aTdg0ePhvQsPXtDkQqhBDuJ8nKT+Q4ksrApAjY8oYxZdd3YrvP1z8hHJPi5HWrHunQewJsfUuuuRJC+BRJVn4ip7CK5OgQIusLjam6EXOMqbt2Cg4wkxobdnKyAhhxHRRlw5HNHQtYCCHcSJKVnzjeZmnb24B2TNl1zMDEiJOnAQGG/hDMgbLXlRDCp0iy8gONVju5RdUMTAiHLW8aO//2SOvweQcmRbC/pIb6JtuJO0NioN/FkPORTAUKIXyGJCs/sK+4BqtdMyH4ABTvNqr23CAjMQK7NjZ0PMmAqVB+AIr3uOV1hBCioyRZ+QHnhovDSz8GcxAMneGW8zorAk9btxpwqXG7Z4VbXkcIITpKkpUfyCmsIsRkIybvAxj0gzb1AWxJamwogWbT6etW0X0gfjDs+dQtryOEEB0lycoP5BRWMSs6G1VbYlQBuonFbKJfQvjxsviTDJxq7HFVX+m21xNCiPaSZOUHco5WcbV5PYTGGcUPbpSRGH76NCAY61b2Jtk2RAjhEyRZ+bjqBivHyio5p/ZbGHwFmC1uPX9GUiRHKuqpqGs6+YHe4yEoSqYChRA+QZKVj8sprOI803YCbbUw6Aq3nz8jKRyAPadOBZoDoN9FsOczKWEXQnidJCsfl1NYxVRTFvaAcEi7wO3nH+jciPFM61YDpkJ1IRRuc/vrCiFEW0iy8nF7CsuZat6EGjjV2CTRzZKjQwgLNJ953aq/YzsxKWEXQniZJCsfZzvwHXGqAjXoB51yfqUUA0/diNEpIhF6jTKmAoUQwoskWfkwrTX9Sr7EqizGlFwnGZRk9AjUZ1qb6n8pFGyAuvJOe30hhGiN15OVUmr0KV/PVEpNUUrd562YfEVRZT2T7d9R2GM8BEd22usMTIygrLaJouqG0x9MnwzaDge+7rTXF0KI1nh7W/spwOJmX48GY8dgoPzURNbdHNy9iVTTURr6X96pr5OReJa2SwDJmUaLp/1rOzUGIYRoibe3tV8JlDa76zqg3PF5HjDF0zH5Er3rQ+xaETN6Rqe+Tv8Eo3w9r6jm9AcDgiFlLOz/qlNjEEKIlnh9GvAU0ZycvGK9FIdPSDq8km1qID0S+3Tq68RHBBEWaGZf8RmSFUDqJKN8XdathBBe4mvJSjhVHiGlfjfZke3fut5VSinS4sPIaylZaTsc+KbTYxFCiDPxtWRVDvRwfB4NlJx6gFJqvlIqSymVVVRU5MHQPMu+dxUAFSkXeuT10uLC2VdcfeYHU8Y61q1kKlAI4R2+lqzeAtIdn6cDK089QGu9SGudqbXOjI+P92hwnlS7cwXHdDTRaaM88nppcWEUlNXRYLWd/uDxdSspshBCeIe3qwFnApmOW7TWmxz3TwHKnV93O3YbgfmrWW0bzqCenVey3lx6XBhaw4GS2jMfkDoJCrfKupUQwiu8XQ24VGsdo7Ve2uy+RVrrlVrrRd6MzasObSKwqYI1egQDEiI88pJpcWEALRdZyLqVEMJLfG0aUADsXYkdEwejxxESaPbIS6a2lqxk3UoI4UWSrHzR3pXsMg2gZ89kj71kVEgAceGBZ09Wsm4lhPAiSVa+prYUfWgjnzYOIyPJM1OATqmxLZSvg6xbCSG8RpKVr8n9HIVmtW0Eg5I8U1zhlBYXdvaRFci6lRDCayRZ+Zq9q2gIiGKrTmeQh0dWafFhFFU1UFXfdOYDUjLBZIGDkqyEEJ4lycqXaA25q9gTPpaggAD69Aj16MunO4os9hefpXw9IAR6joCD33kwKiGEkGTlW45uh+qjrNUjGJgYjsmkPPryaXGOhrZn62QB0Hs8HNoItrOMvoQQohNIsvIluV8AsKxyoMeLKwD6xoaiVAvl6wC9x4G13ii0EEIID5Fk5Uv2rcbaYwDZtREeL64ACA4w0ysqpOVklTLOuJWpQCGEB0my8hXWRshfz7G4CQAeL65wSo9vpSIwKhmiesPBbz0XlBCi25Nk5SsOZUFTLTuCRgJ4ZRoQTpSva63PflDvcTKyEkJ4lCQrX7FvDaBY0zSIuPAgYsODvBJGWlwYVfVWSmoaz35Q7/FQeQgqCjwXmBCiW5Nk5SvyVkPPEWwu8t4UILjQ0BaMkRXIVKAQwmMkWfmCxhoo2IA9bTK7j1Z5NVmlO8rX9xW1kKwSh0FAqEwFCiE8RpKVLzjwNdibOBo7ngar3WvrVQDJMSEEmFXLPQLNAZA8RtouCSE8RpKVL8hbDaYAtpgGA3ilbN3JbFL0jQ0jr6iFC4PBWLcq3GaMCoUQopNJsvIF+1ZD73HsLLZiUjAgMdyr4aTFhbG/pJUk1Hs8aBsc6p6bOQshPMvnkpVSaqZSaopSar63Y/GI2lI4shXSJpNTWElqXBjBAZ7ZcPFs0uPC2F9Si83eQvl6SqZxK0UWQggP8KlkpZQaDeRprVcCeY6vu7b9awEN6ZPJKfRucYVTWlwYjVY7h8vrzn5QaA+Iy5AiCyGER/hUsnJ40nGbrrXu+nNM+1ZDQBi18cPJL60lI9F761VOrW5x75SSaVzM3NIFxEII4QY+lawcySlPKZULlHo7Ho/Yvxb6nsvu4ka09l7niubSXU1WyWOgtgTK9nd+UEKIbs2nkpVSKhooB14AFiul0s9wzHylVJZSKquoqMjDEbpZdREUZUPqJHIKKwHvXhDsFB8RRFig2bWRFRhbhgghRCfyqWQFzAee0FovAGYBM089QGu9SGudqbXOjI+P93iAbpW/zrjtO4nswipCAswe33DxTJRSpMWHtXytFUDCULCESLISQnQ6X0tWxzmKLMq9HUen2r8WAsKg10hyCqsYmBTh8Q0XzyYtLpx9LW3CCGC2QK+RUJDlkZiEEN2XTyUrx4hqvqN8fb7WepG3Y+pU+eugz3i0yUJ2YRWDEr0/BeiUFhdGQVkdDVZbywcmj4EjW4wtToQQopNY2voEpVQqMBroAUQDeUC51vpzdwTkSFhdX00JHNsJ58ykqLqB0ppGnyiucEqPC0NrOFBSy4CWkmjyGLA9C8d2QK9RngtQCNGtuDyyUkrdq5T6FKO0vB+ggArH51OVUp8qpf6plBrZKZF2Nc3Wq3IKqwDfKK5wcqn7OpwospCpQCFEJ2p1ZKWUSgNuA97UWv+llWOjMKbxMrXWL7opxq5p/1qjc3mvUeR8bewL5UsjK5evtYrqDWEJjiKLWzs/MCFEt9TiyMqRqC7RWj+gtd7c2sm01hWOhLZKKXWLm2LsmvLXGftCWQLJLqwiPsJ7Gy6eSVRIAHHhga0nK6WM0ZWMrIQQnajFZKW13teeEVJ7n9dt1JbC0e2QOgnAZ9osnSotzoXydYDk0VCyB+rKOj8oIUS31OZqQKWU9/sB+bv89cZt30nY7JrdR6vI8KFKQKe0uLDWR1YAyY51q8Pfd25AQohuqz2l6/2aF1EopdKUUhe7L6RuYP9a42La5NHsL6mhwWpnUE/f+xsgLS6coqoGquqbWj4weTSgoEAuDhZCdI42Jyut9ffAWEcJO1rrfUCMUuoJN8fWdeWvhd5jwRLkk5WATs6KwP3FtS0fGBwFcQONprZCCNEJ2jMN+BaQC5Q1mxJcidEqSbSmrgwKt0NfY70qu7AKk4L+Cd7dcPFM0uONZJXXWicLOFFkIR3YhRCdoD3TgGOALK11BaAc5epTgD+7NbKu6sC3gIbUiQBsP1RBeny41zdcPJM+PUJRyoXydXB0YC+G8gOdH5gQottpT7KahWMU5UhYPYCY1q7BEg7568AcCMljaLTa+SavhPP6xXo7qjMKDjCTHB3iYrJy7JN5uOtvQSaE8Lx2rVlprRc2+3ofsFE6V7gof70xCgkIYdOBMmobbZw/wHe7x7tcEZgwFMxB0oFdCNEp3NLI1lF0sc8d5+rSGqrhyGboex4AX+0pwmJSTEjv4d24WpAeF8a+ohp0a2tRlkBIOgcOSfm6EML93NZ13TElKFpSsAHs1mbJqpjRfWKICA7wcmBn1y8hnKoGK4WV9a0fnDzGuNbK3kqndiGEaKNW2y21p21Se5/X5eWvB2WC3uMprWlk26EKzh8Q5+2oWjTYcf3XriOVrR+cPBqaaqB4dydHJYToblptt4TR5+95Vy78VUpFKqXuxegnKO2WTpW/HnqOgKAI1u0tRms4f6DvrlfBiea6u45UtX5w8hjjVtathBBu1mrXdUfC+plS6lal1AOABjYBJY5DYjH2teqHcf3VAsdzRHPWBmMacJzRmfyrPUVEhQRwTnKUlwNrWWRwACkxIa6NrHr0g6BIOLQJRt3Q+cEJIboNlzdf1FovBhY7rqvKxEhQPTAKK/IcRRYdppQaDaQ7XnOpO87pEw5tAlsD9D0PrTVf7SlmUv84zD6yjX1LBveMdC1ZmUzGBowyshJCuFl7StcrtNartNbvaq0XO27dWQJ2myNJpTsSV9fg3Gyxz7nkFlVzpKLe59ernAYnRbCvuIb6JhcKJ5JHw9Ed0ORCQYYQQrioXdWASqlbHLsC3+LOLuxKqZkYU4lorRdorbvOFab56yFhCIT2YM3uYgAm+Uuy6hmJXcPuoy6uW9mbjC1QhBDCTdrTG/DPQH+MLe1nA/uUUje7KZ6xQKxSarRS6j43ndP7bFY4+O1J11elx4eREhPq5cBc07aKQGeRRdf5O0MI4X3tGVltcOwc/IDWeipGYcUApdQ1boqpxDmicoy0TqKUmq+UylJKZRUVFbnpJTtZ4RZorIa+59FgtfFNXinn9/ePURUYPQJDA82uVQRG9oLwJFm3EkK4VYcvCtZal2utH8CoCuyoXCDP8Xkexkjr1NdbpLXO1Fpnxsf7dtn3cc7NFvucx8b8MuqabFzg4yXrzZlMioykCHa6MrICx8XBMrISQriPy9WAzeQppTYA9wEbtdbO32AlLTzHVSsB52gqHdjghnN6X/7X0CMdInvy1fpsAsyKCenua16rtaaioYKiuiKK64qpaKyg0dZIo60Rq91KkDmIYEswweZgooOjSQhNID4knkBzoMuvMbhnJB9uOYzWGqVaqWBMHgU5H0F9hbHXlRBCdFB7ktV1wNvA7cAUpVQuUAp8ppSK0FpXKaWu0Vq/19YTa63zlFLlzum/LlG6brfDgfWQ8QPAWK8a3SeGsKD2vPXQZG9iZ8lONh/bzJ6yPeSW55JbkUudta7N54oNjiU9Op30qHT6R/dnWNwwMmIyCDCf3v5pcM9IXv/2AIcr6kmODmn5xM51q8PfQ/qFbY5LCCFO1Z7fmLnAZ84tQZRSozD2s5oK/EYp5RxhtTlZgTHN157n+ayibGPDxb7nUVLdwPZDldx7WUabTnGo+hAr81ey7tA6NhdtPp6Y4kLi6Bfdj2sGXENyeDLxIfHEhcQRHRRNkDmIAHMAFpOFJlsTdbY66qx1lNWXUVRbxLHaYxyqPkReRR4f5X1EdZOxwWKQOYghsUMYkziG83qdx8iEkQSYAhjs7GRxuLL1ZNVrlCPwjZKshBBu0eZkpbVerJQapZRCa73fcY3V94AzeY1GNmI8wXl9Vd/zWLvXKFl35fqq4rpi3t/7Piv2r2BX6S4A+kf35+p+V5OZlMmYxDHEhbinSENrTWFNIVuLt7KlaAtbirawZPsSXtz2IqGWUCb0nMD5yReDyUp2YSVThiS2fMKQGKObhVQECiHcpF1zUS1dBKy13qSUur/9IXUx+eshohfEpPLVqq1EhwYwtNeZ13G01mwo3MDbu99m1YFVWO1WhscN51djfsWUPlPoHdm7U0JUStEzvCc9w3tyWeplAFQ1VvHdke9Yd3gdqwtW8/nBz4kYaOadgmH02zePi/tcTJA56OwnTR4D+9d2SrxCiO6nfQsnrXBzRwv/pbWRrFInoTHWqyaeocWS1prVBat5fsvz7CjZQWRgJHMGzWHmwJmkR6V7JfSIwAgu6XsJl/S9BLu2s7VoK/d9/CpHrd9y35r7iAiMYFrqNK4deC1DYoecfoLkMbDtbag8bJSzCyFEB3RKshIOZfuguhD6nseeY9UcrWzggmZTgFpr1hSs4dnNz5Jdmk1yeDK/O/d3XJF+BcGWYC8GfjKTMjEyYSTTeoXyzOeTeen2Hnycv5z3c9/n7d1vMyJ+BHMGzWFq36knijOaXxwsyUoI0UGSrDqT8/qqvhNZk2NcwDzJsYV9XnkeCzYsYN3hdfSJ6MPjEx9nevp0Aky+uxHj4J6RaG0iSg3lz+dPpGp8Fe/vfZ83st/gga8eYGHWQm4YfAOzM2YTkXQOmCxGkcXgK7wduhDCz0my6kz56yE0FuIz+OrDDfSLDyMmTPPkd0/yRvYbhFpCuX/s/Vw36DqfTlJOQ5q1XRrZO5qIwAhuGHIDcwfPZf3h9by842We3vQ0L257kdkZs/lR4hDipJOFEMINJFl1pvx10Odc6q12vt1XwiUjq7jmg2s4XH2YmQNn8vNRP6dHcA9vR+mylJgQwgLNp/UINCkTk5InMSl5EjtKdrBk+xJe2vESbwTD9dWF/KS2mB6h/tNeSgjhezrcbkmcReVhKNsPfc9jzZ5D6B7/YU31Y5iVmSWXL+GRcx/xq0QFRtulQa3sbTU0digLJy/k/avf55LowbwUFsTl703jmU3PUNXoQm9BIYQ4A0lWncWxXpUXm8aD395KYMw3XD9wLkuvWsqYxDFeDq79BveMIPtIFVrrFo9LjUrliXN/z7JDR5gckc7ibYuZ/t50Xt35Kk22Jg9FK4ToKiRZdZb89XwS1YNZ3/6eensFc1Mf46FzHyTE0kr3Bx83uGckVQ1WCspcaO8UN4B0FcJfAvrw5hVvktEjgyc3PMlVy65iVf6qVhOeEEI4SbLqBDa7jSePfMG9PcKx1SeRXPMb7rvgKm+H5RaDktqwt5XJDL1GwqGNDI0dyuJLF/P8lOcJtgRz95d3c+unt7K7bHfnBiyE6BIkWblZbVMtd628nVcDrVxCOuW5t/D76eeddiGwvxqUFIFSuLa3FRjb3BduA2sDSikmJk/knSvf4aHxD5Fdls2s5bN44tsnZD1LCNEiSVZudLTmKD/55Cd8deQbHioupShvClMG9+I8P9posTVhQRb69gglu7ANe1vZGk/a5t5isnD9oOv56IcfMWvgLN7IfoOrll3FR3kfydSgEOKMJFm5SV5FHvP+O4/8ynz+Hjmaa2qsbGzqy4PTB3k7NLcb3EpF4Ela2OY+KiiKhyc8zBtXvEFSaBIPfPUAt352KwcqD7gxWiFEVyDJyg1ySnO46ZObaLI38fK0lxlfkM131v5cP6Ef/eLDvR2e2w1KiiS/tJaaBmvrB0cmQ3hii9vcD40dyqvTX+Xh8Q+zo3gH13xwDS9ue5Emu1QNCiEMPpuslFL3eTsGV2wv3s5PV/wUi8nCS5e/xKDgBAJKsvneNJS7Lhng7fA6xeCeEWgN2YUurDMpBcmZUNDyps9mk5nrBl3HsquXMSl5En/b9DfmfDiHnSU73RS1EMKf+WSyUkpNAcZ6O47WbD62mVs+vYWIwAhevvxl0qLS2Pb1J5jQpI6eSkyY69vG+5PBPdtQEQiQkgkle6G2tNVDE8MSefqip3n6wqcprS9l7kdzeWbTMzTaGjsSshDCz/lksvIH2aXZ3LHyDmKDY3np8pdIiUjBarOz+9tPaCCQqVOnezvETpMSE0JEkMX1IosUx98dbegTeEnfS/jP1f/hB+k/YPG2xVz34XXsKNnRjmiFEF2BzyUrpdRorfVKb8fRkn0V+7jts9sICwxj8dTFJIUlAfBW1kEG1m+hOn4kQcGhXo6y8yilGNQzwvXy9V6jQJlanQo8VVRQFH+c9Ef+cck/qGyoZN5H83hu83OyliVEN+RzyQrw6YZ5h6sPc+untwKw+NLF9Ao39mo6VF7HohXfM9R0gB5DLvJmiB4xuGck2UcqsdtdKDUPCoeEoW1OVk4XpFzAe1e/x7S0afxzyz+54b83kFee165zCSH8k08lK1dGVUqp+UqpLKVUVlFRkadCA6CioYLbPruNWmstiy5dRGpUKgBFVQ3c8OK3DLXvwoQdlTrJo3F5w+CekdQ02jhYVuvaE1IyoWAj2O3ter2ooCieOP8J/nrhXzlcfZjZH87m9V2vy3VZQnQTPpWsgHSl1Eyl1EzH56NPPUBrvUhrnam1zoyPj/dYYE22Ju7+4m4OVR/i7xf/nYweGQBU1Dbx4//7jsKKeh4ZVgrmwBNrNF3YoKQIoA2dLFLGQkMFlOzp0Ote2vdS/nP1fxiXNI4nvnuC21fdTlGtZ/9oEUJ4nk8lK631Uq31UoypwGgvh3Oc1prff/17so5m8djEx453Ta9psHLTS9+Re6yaF340hqSyjcZFsAH+3azWFRnH2y61sciinVOBzcWFxPGPS/7Bw+MfZmPhRq754Bo+P/B5h88rhPBdPpWsnByjp35a69PbHnjBoq2L+CD3A+4YeQc/SP8BAPVNNm57ZSObD5bzzJyRXNA3GA5vhr4TvRush4QGWkiLDWPH4QrXnhDbH4Kj3JKswCjyuG7Qdbx15Vv0DOvJXV/cxePfPE69td4t5xdC+BafTFa+ZNWBVTy7+VmuTL+Snw3/GQBWm51fvvE9a/cWs2DmCC4f1hMOfAPaBmnnezlizxmf3oNv8kppsrmwDmUyGRcHH3RPsnJKj0rn1emvcuOQG3kr5y3mfDSHPWUdm2oUQvgeSVYt2Fexj4fWPsSw2GH8/rzfo5TCbtfct3Qrn+48yqNXDWXmmBTHwauN9are470btAdNHphAdYOVrP1lrj0hZSwc2wkN7u2wHmgO5J6x9/D8lOcpqy9jzkdzeDvnbSm+EKILkWR1FrVNtfzPF/9DoCmQv174VwLNRjeKP3y4k/e+P8Q9Uwdy43mpJ56wb42RqLrBepXTxP6xWEyKL3cfc+0JKWMBfcamtm6JJ3kiS69aSmZiJo998xi/Xv1rKhtdXFMTQvg0SVZnoLXmt+t+y77KfSyYvICe4T0B+PfX+3lp/X5unpTGnRf1P/GE2lI4shVSu88UIEBEcACZqTGsznGxGi/F0YHdTetWZxIXEsdzU57jV2N+xRcHvmDWB7PYWrS1015PCOEZkqzO4PXs1/k0/1N+OeqXTOg5AYA1u4t4dPlOpgxO4DfTB6NUs80U89cBGtIu8E7AXnRhRgLZhVUcqXBhm/uQGIgbCAVZnRqTSZm4adhNvDztZZRS3Pjxjby842Xsun3XeAkhvE+S1SmyS7N5KuspJqdM5qfDfgrA3mPV3Pn6JgYkhPP09aNO3/V331cQEHpi76Zu5KKMBIA2jK7GGiMrD6wnDY8fzttXvs2FvS9kYdZCfvH5LyivL+/01xVCuJ8kq2bqrHXct+Y+ooOieWziYyilKKtp5OaXNxBkMfHijZmEB1lOf+K+NdDnXLB0zS7rLRmYGE7PqGC+dDlZZUJtMZR6pl1SZGAkf73wr/xm/G/4+vDXzFw+k83HNnvktYUQ7iPJqpkFGxawv2I/fzr/T8QEx9BotfOzVzdypLyeF340hpSYMzSnrT4GRbu6Vcl6c0opLsyIZ93eYtdK2Puca9we+KZzA2tGKcWcQXN4dfqrBJgCuOmTm3hp+0syLSiEH5Fk5bAyfyVLdy/lpmE3MaHnBKPIYtl2vt1XyoKZwxnT9yz9dfetMW674XqV0+SBCVQ1WNmY70IJe1wGBEfDgfWdHtephsQO4e0r3+aiPhfx1Man+OXnv6SiwcWLmoUQXiXJCiiuK+bRrx9laOxQfj7q5wD8a+0+3so6yM8v6s+MUclnf/K+NRAUBUkjPBSt7zlewu7KVKDJZIyuPDiyai4iMIKnJj/Fg+MeZN3hdcxaLtWCQviDbp+stNY8/s3j1DbV8qdJfyLAFMDq3UX88b+7mDYsiV9dOrDlE+z/ClIngvkMa1ndhLOE/cscF6+36jPB2Dm42sXj3UwpxdzBc3ll2iuYlIkbP7mRV3a+IhcRC+HDun2y+mT/J6w6sIo7R91JenQ6xdUN/PrtzQxMiOCp2SMwnVr511z5QaNQoBtPATo5S9gLK1zozdf3POPWS6Mrp2Fxw3jrirc4P/l8FmxYwP98+T9yEbEQPqpbJ6viumL+9O2fGB43nBuH3IjWmgfe3UZlnZW/zRlJaGAroyXnelU3uxj4TC7MMLZrWe1KN4ueI8ESDAe+7tygXBAVFMXfLvob92Tew+qDq5m9fDY7SnZ4OywhxCm6bbJqPv332MTHMJvMvLnhICt3HeW+yzMYlBTZ+klyP4ewBEgY0vkB+7iMxAiSIoP5ItuFdStLoNHU1geSFRjTgjcOvZElly/Barfyo//+iLey35JpQSF8SLdNVqsOrDpp+i+vqJo/LN/JpP5x/HRiWusnsNsh7wvod5FRNNDNtbmEve+5RouqhurOD85FIxNG8s6V7zCu5zge//Zx7l9zPzVNNd4OSwhBN01WNU01PPHdE2TEZPDjIT+myWbnf97aTKDFxMJZraxTORVuhdoS6HdJ5wfsJy7MiHe9hL3PBGNLlU7sE9geMcExPHfJc9w1+i5W5K/g+g+vJ6c0x9thCdHtdctk9ez3z1JUW8Qj5z6CxWTh76v2sKWggieuOYekqGDXTpK7yrjtd1HnBepnJvaPc72EPWUcKJPPTAU2Z1ImbjnnFv419V/UNNUw77/zeHf3uzItKIQX+VyyUkrNd3w82Rnn31Wyi9ezX2fWwFkMjx/OxvxSnv1iLzPHpDD9nJ6unyj3C0g6B8ITOiNMv9SmEvbgSOP988Fk5ZSZlMk7V77D6ITR/P7r3/Pg2gepbar1dlhCdEs+layUUlOAlVrrRUC642u3sdlt/OHrPxAdFM1dY+6iqr6Ju9/aTHJMCL+7sg1FEg3VRtl1v4vdGV6X0KYS9j7nGh3YbU2dH1g7xYbE8vylz/OLUb/g430fc92H18m0oBBe4FPJCkgHnAkqz/G12yzdvZTtJdu5b+x9RAZG8ujynRwqq+N/Z48kIjjA9RPtXwv2JklWZ9CmEvY+50JTrVFo4cNMysT84fN5ceqL1DTVMPejubITsRAe5lPJSmu9yDGqAhgNuG3jo4qGCp7d/Cxjk8YyPW06y7ccZunGAu64sD+ZqWfp+3c2uavAEnKiKas4rk0l7M73L39t5wblJmOTxvLOle8wNmksj33zGPeuuZeqxipvhyVEt+BTycpJKTUa+Exrfdr+5471rCylVFZRkYvbUgDPb3meysZK7h97PwdL6/jNe9sY3Seau6YMaHuAuZ9D6iSwBLX9uV1cm0rYIxIhfhDkrfZMcG4QGxLLc1Oe4+7Rd7MyfyWzls9iW9E2b4clRJfnk8kKmKK1XnCmBxyjr0ytdWZ8fLxLJ8srz+ON7De4dsC1pEUO4Bdvfo9S8LfrRxFgbuNbUJZv9LXrLyXrZ+MsYc/a70IJe/qFkL8erA2dHpe7mJSJm8+5mZcufwmtNT/++Mcs2b5EthwRohP5XLJSSs13Jip3FFhorVmwYQGhllB+PurnPPVpDlsOlvPktcPp3eMM+1O1Jvdz41bWq85qYv84woMsvLx+f+sHp18I1jo4+F1nh+V2IxNGHt9y5K8b/8odK++guK7Y22EJ0SX5VLJyJKcnlVK5SikX/ixv3VeHvmLd4XXcNuI2tuZbeWFNHvPG92FaW8rUm8tdBZEpENdKN/ZuLCI4gFvPT+eTHYVsPlje8sGpk0CZjW4gfigqKIqnJj/Fbyf8lqyjWVz7wbWsKVjj7bCE6HJ8KllprVdqrWO01v0ctys7cj6r3cpfNvyF1MhUpiRfw6/f3kJGYgS/vaKdvfysDcb1VQOmgHKhy0U3dvP5acSGBfKXFdktHxgUASljIe9Lj8TVGZRSzM6YzVtXvEVcSBx3rrqTP3/3Z+qtLpTvCyFc4lPJyt2W7V3G/sr9/HLU3dz7zg5qGq08O3cUwQHm9p1w/1fQWA0Z090baBcUHmThzov6s25vCWv3tDI1ln4hHP4e6twymPaaftH9eP0HrzNv8Dxe2/Uacz6aI9dkCeEmXTZZ1VnreG7zc4yIH0FOXh/W55bw6FVDGZAY0f6T5nwMAaGyf5WL5k3oQ3J0CH9Zkd3yNUnpF4K2w76vPBZbZwkyB/HAuAd4fsrzlDeUM+ejOby0/SUpvhCig7pssnpt12sU1RUxvdfN/O/KPVw5ohezM3u3/4RaG8mq38UQEOK+QLuwIIuZu6cMYEtBBSt2FJ79wJRMCAz366nAU01Mnsh7V73HBSkX8NTGp7h5xc0UVBV4Oywh/FaXTFYVDRX837b/Y1zCJJ7+yEZydAh//OEwVEfWmQq3QuUhyJjmvkC7gWtGp9A/IZy/rMjBerbrrswBRqFFF0pWYHRw/98L/5fHJj7GrtJdXPvBtSzdvVQ6XwjRDl0yWb247UWqm6rZuXMijTY7i3+cSWRb2imdSc7HgIIBl7klxu7CbFLcMzWD3KIa3vv+0NkPTL8QSnOh/IDHYvMEpRQz+s/gvaveY1jcMB79+lHuWHUHhTUtjDSFEKfpcsmqsKaQ13a9TlD9OCor4nj5pnFkJHVgncop57/QexyEu3YhsjjhsqGJjOgdzdOf7aa+yXbmg9IdW610sdGVU6/wXiyeupgHxj3AxqMb+eH7P+S9Pe/JKEsIF3W5ZPXc94tostmoPHIx//rJWEb0ju74SSsOwZEtMgXYTkop7r8sg8MV9bz27VlGTvEZEJ5kXBrQRZmUiXmD5/Hule8yqMcgfrf+d9z22W2yliWEC7pUssorO8h/9r6HtWIsz18/hQnpse458e5PjFspWW+38/rHMal/HP/4Yi/VDdbTD1DKaGGVu8qntwxxh96RvfnXZf/iofEPsaVoC9d8cA0v73gZq/0M74sQAuhCyarBauOny55EAw9P/DkXDXLjpog5H0OPdOla0UH3XpZBaU0jL36Vd+YDBl0B9RXG9WxdnEmZuH7Q9bw/433GJ41nYdZC5n40lx3FO7wdmhA+qUskK6vNzvzXPqNYrSWzx+XMyxzhvpM3VMG+1caoSrpWdMiI3tFMG5bE4jV5bC0oP/2AfhdBQBjsWu7x2LwlKSyJZy5+hoWTF3Ks9hhzPprD4988TkVDhbdDE8KndIlk9dyXuXxT9g4WpfjzJXe79+TZH4GtEQZf6d7zdlMP/WAwMWGBXL/oG77MOWWDxoAQGHAp7PoQ7GcpxOiClFJclnoZH/zwA+YMmsM7u9/hqmVX8f7e9+ViYiEc/D5Z2e2a1zd+T2D0RmZlzCQpLMm9L7DtHYjuA73Hu/e83VRKTCjv3X4eqbFh3PJyFks3nlJcMPhKqDkGBRu8E6AXRQZG8uD4B3nzB2+SEp7Cw+se5ob/3sCWoi3eDk0Ir/P7ZPV1XgllgSswm0zccs4t7j15dZFRnTZspkwBulFCZDBv3TaB8ek9uOedLfzji70nSrgHTAVzYLeaCjzV4NjBvDL9Ff446Y8U1hRyw39v4IGvHuBw9WFvhyaE1/h9snotaxuB0RuZ0W8GiWGJ7j35zmWgbXDOLPeeVxARHMCSn4zj6pG9+MuKHB55fwc2u4bgSKOl1a4PjBZX3ZRJmbiq31V8+MMPufWcW/ls/2dc8Z8rWLhhoaxniW7J4u0AOsKuNV8WLsUcY+fm4Te5/wW2vQMJQyGxnVuKiBYFWkz87+yRJEYGs2hNHkVVDTx9/UiCB19pXC5QuBV6urFYxtO0huI9kL8OyvYZ3TnKD0B9JaCN5r3KDKGxxsXmYQlG1Wl8hlF5GtWb0IBQfjn6l8zOmM2z3z/Lv3f+m/f2vMdPhv2EeYPnERYQ5u3/SyE8QvnzFfRpg4fqsHuDOa/XBSy6/H/de/Ky/fC3EXDJ7+D8X7n33OI0/1q7j8c+3Mmw5Egen9qTkW+Og0n/A5f81tuhtY3dblwrtm2pUUVadcS43xwEUSnG+mdwFJjMoEzGNWW1JVBTBNVHT94mJSgKkkdB8hhjz6/e49ndUMwzm55hdcFqooOiuXHojcwdNJfQgHbsei26LaXURq11prfjaAufS1ZKqZlAOTDaub392USk9tSpj8ax9MqlZPTIcG8gXz0Fq/4Ad22FmL7uPbc4oxU7Cnnk/e0crWxgRcxfSA+pJuCXWd4OyzV1ZfD9a7DhRWMUFdID0idD2mRjS5mYNDC5MOteWwpFOVCUbYwsC7Lg6A5jOhoFiUOh70S2xfXlubLvWVv4LVFBUcwdNJc5g+YQExzT6f+rwv9JsuogpdRoIF1rvVQpNR/I0lpvOtvxIanh+pIFs/hw9hL3B/PcuRAUCTevcP+5xVnVNlp5fnUe1V89xyOmJbw0/FVm/mAa4UE+OmNtt0HW/8HnjxkXNPc5F8beAoOvAkuge16jsdbYnDJ/PeSvhYPfQVMtoNjacxAvRoXzRcNRgs1B/HDANcwdNJfUqFT3vLbwOK01ddY6KhsrqWiooLKxkurGaqqbjI+aphpqm2qps9Yd/2iwNVBvrafR3kiDrYEmWxONtkas2orVbqXJ3oTNbsOu7Vi1la/nfi3JqiOUUk8Cn2mtVyqlptDK6CokLUQvX/UlU9LdXFZ+dAf88zyYvhDG3erecwuXHDlyiNhFI3mn6XyeDrmDe6dmcG4/N7XPcpPAIxuJ+fJBAou2UZ8ykfJJj9CUMLzzX9jWSODRzQQXrCOoYD2BhVnsU1aWREXyUXg4VgXjgntzZZ+rGZl+DWZfW9fSdlRTLabGKlRjNcpai6mpFtVUB7ZGlK3B8dEEdivK3gTahtLaGGGe6XeWMoFSaJRjitWMNplBWdAmC5jMxu3xr523AWiz436z5eTjleX4dK1W5hNTt8qEViZAGR+q+a0zHsfnzWKtsdZQXF9EaX0xpQ0llNQXU95YRllDKRWN5VQ0VlDZVEFFUyVN9pZbjpkwEWwOJtgcSJApiCBTIEGmQAJNgQSYLAQoCwGmACzKjMVkwaxMmJUZszJhwsQfL/urJKuOUEq9ALygtd7kSFaXaq3vP9vxMalhumx/jfsD+eRB+G4R/DoHwuLcf37hmmV3Ytv+Lj+Ofpl1Bb7TN09h5xfmZdxteZdjRPN40w18aJ+A8cvL8wKwco7KY4JpFwMDdrEv6ggfRgZwzGIhwWplchX0r4yjpjGFIzqWwzqWQt2DMsIp1+FUEYq9DYXBJuyEUk8oDUSoWiKoI0LVEkUNUaqGSGqJUjVEUU20qj5+v/OxcOowKd/5veMOGigzmThksVAQYOGQxcIRi5lDFguFFjNHLRaqzzANHGK3E2uzEWuzE2OzEWO3E22zE2W3EWW3E2WzE2E3PsLtmjC7nXCtCdK6Q99t6tFKv0tWPjq3cnaO6cH5AIOSA4wpkkA3Li43VMH3r8KQGZKovG3crZg3v8qrY3JZfelMiqoavB0RAU2VjPv+QXodW01+8hVsOue3TLaEMdnbgTEagCYgRWvuqs3nQNFyvqvN4t3oIuwx5QxvOMZl1TXMr6klyXaiQ4hGYTMHYzMFYTMHYTc5935TgMZkt2LSTZjsTZht9Zjtja1GYzMF0hgQRWNgFE2WCBoD4mkMiORoQAQFARE0WcJpsoRjtYRhNYcYr+/8MAViNwViN1mwqwC0yYJdOUY4KMeo5gSFBq0dt3aUtqO0DZO2oRwfJrsVhQ1ltxr3H/9/sqK09fixJnuT4zn2k+5X2o622yizV3NMV3DUXslRXU2RvYqjuppjuoZ6Tv6DKpxA4lQocSqUfiqUWELooUKIMYUQTSjRKoQgUwDOEZp2jNC0Y5Smm43a6hwfRQq08w8L5zEoUJz43PmunHZtaPOvf9bqv6Gv8bWRVfNpwJkY61dnnQbM7GXWWZ+8CcPdeB3Ut4vg43vhllXGduvCu16cYhQv3LnBtQKFznRsF7wxByoOwuV/Ntam/OBi8WO1x1ieu5xP9n1Cdlk2AMPD+zA5PI0LghLJsJtQTbVgrTc+bE0nT7WZA43dnM0BRkusgDDjD8TAMGNdNyjSuD4uOAqCoyEk2jjOD2mtKa4rZn/lfg5UHiC/Mp/8ynwOVB3gYNVBGmwn/mAKMAWQEpFCn4g+pESkkBKeQkpECsnhySSHJ/t0haYUWHSQo8AiU2u9SCl1H7CypQKLzN4hOuuJ6XDDu+4JwG6Hf4w1fuhu/dw95xQds/VteO9WuOE9YwsRb8lfD29cD5ZgmP0K9PHP9lv5lfl8uv9TVh5Yyc6SnQAkhCQwodcEMhMzGZs0luTwZJQfJOH20lpTUl/CwaqDRiKqPMCBqgPHP6+11h4/NsAUQO+I3vSJ7EPfiL70iexjfET0ITE0EbPJ7MX/k/aTZOUGjmm+PIxR1aKWjs3MSNZZc2vhV9kQ4YbuFXtWwmvXwjWLYfjsjp9PdJy1Af46xNilec4b3okh+yNY+lOI6g0/es+4VqoLKK4rZu2htXxV8BUbCjdQ1mBc45UQmsDwuOEMixvGsLhhZMRkEB0c7d1g26jOWseR6iMcqj50/ONg1UEOVh2koKrgpIRkVmaSw5ONhBTZlz4RfUiNTKVvVF+SQpP8NiG1RJKVh2WOHKazZhyEy/4E597Z8RO+ei0UboO7t7uv7Fh03KrHjOve7tri+WveNr4MH94NvUbD3LchzLcqEt3Fru3klefxXeF3bC7azPbi7RysOnj88fiQeAbEDCAtKs0YaTimvhJDEz063aW1prKxkpK6EorqiiiqK+JY7TGO1hzlaO1RjtQcobCmkNL60pOeF2QOIjk8md4Rvekd0ZuUiJTjialneE8Cjq/TdQ+SrDwsMzNTZ80PB7sVfra2Yycr3gPPZsKFv4ELz1qAKLyhogCeHg5jboQr3NyppCXrnoHPfgv9L4XZLxtrNN1IeX05O0p2sKdsD3vK97CnbA/7K/dTZ6076biIwAgSQxOJCY4hJiiGmOAYwgPCCQsIIzQglBBLCAGmAKOU2mRBodCO/2zaRpOtiSZ7Ew22BuqsddQ21VJrraW6sZrKxkqqGqsobyinrL6MsoayM+6oHBEQQWJYIomhifQM70mvsF4khSXRO6I3yeHJxIbEYlJ+3wrVbfwxWfldNeBphl8Pn9wPR3d2rIffty8YC8mZndBjUHRMVIpRzLBhMYz5Sef3C9QavvgjrPkLDL0GfvhCtxxpRwdHMzF5IhOTJx6/r/l6T0FVAUdrj3K05ijHao9R3lDOnvI9lNWXUd1YjVW3/3KDEEsIEYERRAZGEhkYSa/wXgyLG3Y8GcaHxBMXEkdcaByJoYnSI7Eb8P9kNexaWPEb2PomXPqH9p2jJBc2vgQjrofwBLeGJ9zkot/A9nfhv/fCT1d0XhWe3Q4rHoRvn4fRP4YrnjYuBhWAsVFkXEgccSFxjEoY1eKxjbZGappqqLPWHe+icOqoyGKyHB91BZgDCLWEEmwJllGQOI3/J6vweOg/Bba8BRc+2L6S2U8eMKq8LvazpqndSUg0TPk9fPBz2PqW8YeFu1kb4f07jG77E+6Ey/7oF6XpvirQHEigOZAYpF+h6Liu8efLeT+H6kJjjaGtcj6BPZ8a61TuqCgUnWfkPKMD+ae/dWyz4UYNVfD6bCNRXfKIJCohfEzXSFZpF8DQH8Lavxpbe7iqqd4YVcUNhHG3dVp4wk1MJpj+F2M7jS/+5L7zVh+Dl34A+9bA1c/B+b+WRCWEj+kayQpg6h+Njew++Y3rz/n6WWM7h8v/3C0X0P1S8hgYezN8+0+j23lHHfwOXpgMRbuN67hGzev4OYUQbtd1klVUMky+F3I+gj2ftX784c3GtTuDrvBuZwTRdpf/GQZcBh/+yii6aA+tjdZaS6Ybf6jcvAIGXubeOIUQbtN1khUYi+Kx/eHj+4wpvrM5/D38+ypjO/FpT3ouPuEe5gCY9ZKxd9R7813746S5ysOw9CajB2T/KTD/y84vhxdCdEjXSlaWQJi2AErz4P+mGjuunurQRvj31caW4T/5yLiGR/ifwFCY+6axc+5bN8CXT0JDdcvPaaw1jvv7GKOF0iWPwPWvQ4hUqwnh6/y/g0XWGbY93/UhLP8lNNYY114NuRoKt8ORzUbFYEg0/OTDLtPjrVurKTbaIe1aDmEJMPk+GHwlhMaB2WKMsPPXwd5VsOM/UHXY+H6Y8ij0SPN29EJ4hT92sOiayQqg6ii8fyfsPWWKqOcIuO41iO7d+QEKzzm4AT57BA6sP3FfSA9oqgNrHZiDIHUSXHAP9D3Pe3EK4QMkWXlYi8kKjEX07e8apck9h0PiMGNUJbomrWH/WijOgeoiqDlmXOzd72LoO9G9m3QK4cf8MVn5fweLligF58z0dhTCU5SCtPONDyFEl9K1CiyEEEJ0ST43snJsvgjQT2ste3UIIYTwrZGVUmoKxlb2i4B0x9dCCCG6OZ9KVkA64ExQeY6vhRBCdHM+NQ3oGFE5jQbe8lYsQgghfIevjawAUEqNBj7TWm/ydixCCCG8z+Mjq2YFFM3laa1XNvt6itZ6QQvPnw/Qp490oBBCiO7A5y4KVkrNd04HKqWmnJLETtLqRcFCCCFO448XBftUsnJU/70DlAI9gFktJSulVBVwhm613VIcUOztIHyEvBcnyHtxgrwXJ2RorSO8HURb+FSyaiulVJa//XXQWeS9OEHeixPkvThB3osT/PG98MkCCyGEEKI5SVZCCCF8nr8nq0WtH9JtyHtxgrwXJ8h7cYK8Fyf43Xvh12tW3ZFSaiZQDoxuobx/tFyjJrorV35GHMfd19Ljwrf4zchKKTVTKTVFKXVfex7vChwXS+OokCx3fn3KMVOAxZ6OzRtc+J6Y7/h40tOxeZoL78UUx0eXfi9c+RlxHDcFGOvJ2LzBhe+LJx23Z7r+1af4RbJq7RvQ1W/QLuA6jL8YweideFqjX8d7UOrBmLzChe+JbtMU2cWfj0sdj4/uwj8f4MLPSHfh4u/F+UqpXIz3yqf5RbKi9W/A7vINGs3JiSjWS3H4gtb+zbtTU+QW3wut9aZm2+2kd/Ep4mha+RlxTJOf9frNLsSV34uztNb9/OH98KlGti2IpuVvwNYeF11PNC38m3ezpsjRuPD975gKus0TAfm4Ht4OwEOiaf37YrRSClpZ3/MF/jKyEoZyTvygRQMlXovET0hT5BMcv4xuU0pFezuWTlROCz8j3WhU5RKt9QLH+xHr61Pl/pKsymn5l3Rrj3cVb3FiOisdWAnQxX/5nE05rv2bn7UpchdSTiu/oJutV+ThaATdRbX2M5LuKDqY6fi8K6/fldPy94XzfcDxmE9PlftLsmrtG/CMj3c1ztGB4y+g8majhVXOYxzffJnNvgm7qlYTt6Mp8gLH5z79V2MHtfZeTOHkX1o+v5jeXq39jGitl2qtl2K8H9FeCdJzWvu+yOPE78p+gE93Bfeb66wcpZV5GAvEzq7sG7XWY872uOjaWvqeaGtTZH/XynsRDczGeC8u1VrLulU34eLvzVLH4z49A+E3yUoIIUT35S/TgEIIIboxSVZCCCF8niQrIYQQPk+SlRBCCJ8nyUoIIYTPk2QlhBDC50myEkII4fMkWQkhhPB5kqyEEEL4PElWQriZo3FsrlLqnWZfR3s5LCH8miQrIdxvCjAGeMG5XbjWutyrEQnh56Q3oBCdxDGa6qG17rJdzoXwFElWQnQC57SfjKiEcA+ZBhTCzZRS6XAiUTm/FkK0n8XbAQjRlTh2ns0ESpVSKzHWr8rpwhseCuEJMrISwk2aTf0twtiZdR8wtitv+iiEp8ialRBCCJ8nIyshhBA+T5KVEEIInyfJSgghhM+TZCWEEMLnSbISQgjh8yRZCSGE8HmSrIQQQvg8SVZCCCF8niQrIYQQPu//ASQg0RMDdOmwAAAAAElFTkSuQmCC
 "
 >
 </div>
@@ -15308,8 +15043,8 @@ Wall time: 2.57 s
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 2.61 s, sys: 64.7 ms, total: 2.68 s
-Wall time: 705 ms
+<pre>CPU times: user 1.77 s, sys: 54.2 ms, total: 1.83 s
+Wall time: 869 ms
 </pre>
 </div>
 </div>
@@ -15346,8 +15081,8 @@ Wall time: 705 ms
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>CPU times: user 3.54 s, sys: 87.8 ms, total: 3.63 s
-Wall time: 954 ms
+<pre>CPU times: user 2.12 s, sys: 33.2 ms, total: 2.15 s
+Wall time: 1.11 s
 </pre>
 </div>
 </div>
@@ -15388,7 +15123,7 @@ Wall time: 954 ms
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA0+0lEQVR4nO3deXhc5X33//c9M9r3XZYsW5Zs493GFsEGkzRgtizESVzSQKGhSeDJ06Zpn5+TNP1loSlNCqV5krQJgTSQ0oTEhMVJCNSBkM1stjAY77YsyZIly9o12qWZuZ8/ZmQbY2xLHumcGX1e1+XLmjlnzvnqIPzROed77ttYaxEREXEbj9MFiIiInIkCSkREXEkBJSIirqSAEhERV/I5XYCIiIzfq6++Wujz+f4TWEJsn2yEgN2BQOATq1ataj11gQJKRCQG+Xy+/ywuLl5YUFDQ5fF4YrYdOxQKmba2tkUtLS3/Cdxw6rJYTl0RkelsSUFBgT+WwwnA4/HYgoKCHsJngm9e5kA9IiJy4TyxHk5jIt/HW/JIASUiIpNi7969iddff33FRD+vgBIRkUmxaNGikWeeeaZ2op9Xk4SISIz77GM7yw629KZGc5vzizMG/nXD8sazrXPvvffmr169euDll19O3bhxY/vmzZsz7rnnnuJPfvKT7YcPH0687rrrej/3uc+Vvvjii4fG1s/LywsePnw4sbKycuS2227rOtv2FVAiIjJuX/ziF4uuu+663rVr1w60t7d777333vyNGze2f/rTn559avBkZWUFATZv3pyRl5cXvO2227quv/76irvuuuv4ufahgBIRiXHnOtOZDM8//3zmTTfd1AUwf/784fvvv79g48aN7UuWLBk40/pr164d+NKXvlQ8b9684auuusp/PvtQQImIyLgtX7584ODBg0mLFi0aOXjwYNKqVav6z7Z+a2ur99prr/UvWLBgeO3atWcMsdOpSUJERMbtvvvua6qurk7dvHlzRnV1depdd911fPPmzRm7d+9O3bp1ayrA1q1bU3fv3p26d+/eRID777+/4G/+5m9mXn/99RVj65yN0XxQIiKxZ+fOnfXLly9vd7qO8/WpT32q9L777mt6u9c7d+7MX758efmpn9ElPhERmXQ333xz10MPPZQzb9684UOHDiXdfPPNZ+3gAwWUiIhMgbVr1w6M3XvSPSgREYlpCigREXElBZSIiLiSAkpERFxJTRIiIjIpNm/enAGwZcuWzFNbys+XzqBERCTqtm7dmlpdXZ26fv363p07d554WHc8dAYlIhLrNv9VGa17ozqaOYWLBlj/nbcd429s5PLPfe5zLdXV1amVlZUjOTk5gUcffTT329/+9tGxtvL29nZveXn5yKJFi0bGW4LOoEREZNzWr1/f29jYmLR+/frem266qev73/9+/vr163tXrlzZf+owRlu3bk2tqKgYmsg+dAYlIhLrznKmM5lOHbl8+fLlAwB5eXnBU9dZv35976OPPpr70EMP5Zxr/qfT6QxKRESi7lOf+lTpvffemw+QlZUV6Ojo8I53GzqDEhGRcTt1pPKnn346c6wR4tlnn83MysoKfPrTn247ePBg0ubNmzN6enp8GzduHHcXn0YzFxGJQbE2mvm5nGk0c13iExERV1JAiYiIKymgRETElRRQIiLiSgooERFxpZhrM8/Pz7fl5eVOlyEi4qh77rmHvXv3zj7f9YeHhwMXX3zxzsmsKdpiLqDKy8uprq52ugwREUft27ePhQsXnvf6u3fvHvdYeBcqMzNzxZIlS/qvvPJK/1133XV8vJ+PuYASEZHY8PDDDx9ev35970Q/r4ASEYlxd2+7m/2d+8+6Tl9/X7Kv3nfR+W5zbs7cgX+6/J8mPJp5fn5+sKury7d3797EiYxkDmqSEBGRCTif0cw7Ojq8hYWFwZtuuum875WdSmdQIiIx7vPv+Pw519m9e/fQkiVLDkRzv+cazXzjxo3tEB4sVqOZi4iIK9x77735p84LNREKKBERGbezjWa+ZcuWzI997GNdAA899FAOwHjPniAGRzOvqqqyajMXkeluAm3mA0uWLNk3iSVdEI1mHqf8Q6P814v1BIIhp0sREYkaBVSsCoUgOArAwy/W85Vf7OFXu445XJSISPQooGKRtfDTj8ID74bRIZ56IxxMP9haR6xdshWRiYuX/99DoZAB3nIJSAEVi/Y8CQf/B47vonPL19jf0svikkzeONrDq0fGfR9SRGJQcnIyHR0dMR9SoVDItLW1ZQG7T1+m56BizXAvbPkHKF4GBReR9ep/sMAzg+/cdCsf+M4L/GBrHVXluU5XKSKTbObMmRw9epS2trbzWr+lpcUXDAbzJ7msiQgBuwOBwCdOXzDlAWWM2QDcYa29+gzL7rbWnvuJs+ns9/dA7zG48b+xuXPo3b2Ff0/7IeW5t/PRd8zigT8cprFzgLLcC3r8QERcLiEhgTlz5pz3+osWLdplra2axJKibsov8VlrHzvT+8aYdUDFFJcTW1r3w8vfhYtvgbJLONCbyFeG/5x5o/th2/f5i8tm4zGG/3qx3ulKRUQumCvuQRljKoBap+twNWvhmc9CYjqs+0cAntp5jF/ayxkpvxJ+81Vm+Pp5z9IZbNreSN9wwOGCRUQujCsCCqiw1r5tQBljbjfGVBtjqs/3emvc8TdD3R9g7d9CWh6jwVGe2tXImsp8Eq/5Coz2w8Et/OXaOfQOB3h0+9sOQiwiEhMcDyhjzDpr7XNnW8da+4C1tspaW1VQUDBVpblLy67w37PWAPCJ//lrWtP/jfcunQEzlkN6MdQ8y4qybFbNzuGHL9YTDMV2d4+ITG+OBxTQaYxZF2meqDDGrHS6IFc6HgmoosVsbdrKjvYX8aYcpaiwCYyBuevg8PMQDPDxtXNo6BzgN/vGPYGliIhrTHlARZohqiKBhLV2R+QMKhfInup6YkbLLsitIJCQwr3b78UTyMNr0/ll/aPh5fPWwVAPHN3ONYuKKM1O4Qdb65ytWUTkAjjRxfectTbn9G6+yGW8SmvtjqmuKSa07IKiJTxx6AkO9xymv+U6Vhe8h982/pamviaoeDcYL9Q8i8/r4WOXlfNKXSe7m3qcrlxEZELccIlPzmW4Fzpr6StcwHde/w75vgWYgaX8n0s/hsGwaf8mSMmGskvh0K8BuPGSMlITvTz4gs6iRCQ2KaBiwfE9ADwYaKVzqJOBY+/hinmFzM8v46pZV/HYoccYGB2AeVeHz7R6W8hKSeDGqjJ+ubOZ1t4hh78BEZHxU0DFgpZdDBv47+MvsLpwHcfbC3nfshkA3LzwZnpHevlV3a/CAQVQE26K/Nhl5QRClh+9dMSpykVEJkwBFQta3uBoWh5DwWFC/QtI9Hm4elERABcXXszC3IU8su8RbOFiyJhx4jJfeX4afzK/gCdfb3KyehGRCVFAxYKWXTQWhEeB2lnn413zC8hITgDAGMPNC2+mpruGZ+r/J9Ju/jsIhkeSuHhWDke7BhkcCTpVvYjIhCig3C4YgNZ9NGaEByHu6M44cXlvzPsq3sfivMXcvf1ueuasheEeOLoNgLmF6VgLte19U166iMiFUEC5XUcNBIZoTErBRwpJnnTWLSx60ypej5c7L7uTnuEevtG9Ezy+E/ehKgvSAahpVUCJSGxRQLldZIijRgIER3K5ckERaUlvnSVlQe4Cbl18K0/UPcX2koVw5CUAyvNT8Rg43NY/pWWLiFwoBZTbtbwB3kTqBjsYGcrlinlvPxbhp5Z/itL0Ur6aHKCveQeBkX4SvR5m5aZyuE1nUCISWxRQbteyi2DhAloGjhEayWNeYfrbrpriS+HLq79MfbCfNWWFXPyT1Sx7eBkjBd+lprV3CosWEblwCig3sxZadnG8cD5BG8CO5p64p/R2Liu9jG9f/jU+09nNX+dczPVzrqfX7Ke+b69GNxeRmKKAcrPeFhhopyEr3LWX7ikiJy3xnB9799z384nEEu7wD3DnmjtJ9KRgMl+iqWtwsisWEYkaBZSbjTVIJIfPmsqzZp3/Z2etgcZXSPUmcUXxdfgy3uD1Zk1iKCKxQwHlZh2HAGg0QbBeFhSUnf9nZ62BYT8c38NfLPkoxhPk6bpfTlKhIiLRp4Bys+4GSEzncF8rwZFc5hVmnv9nZ4dn3qXhJS6esRAzVMGO7qcJ2dDk1CoiEmUKKDfrboSsMup6GrCjucw9SwffW2TPgsyZcORFAEo8VzFo23ih6YVJKlZEJLoUUG7W04DNKuP4YBOhkTwqxxNQED6LangJrGVF3hUQzGDTgU2TU6uISJQpoNysu4GurGJGQoP4QvmUZCWP7/Oz1kDfceisZV5hNsNdVfzh6B9o6W+ZnHpFRKJIAeVWQz0w1ENjSgYAxakzMcaMbxuzLwv/3fASlQVpBPoWYLEc7DoY5WJFRKJvygPKGLPBGPPsKa+zjTErI+/fPdX1uFZ3uCW8MSH83FNl9jhazMfkXwQpOXDkpfCo5iO54W32qt1cRNxvygPKWvvYaW/dCFSNvW+MuX2qa3KlnnCI1IZGsdawuGjO+Lfh8YQv8zW8RElWCkmeTHwkcbT3aJSLFRGJPscv8VlrH7DWPhB5WQHUOlmPa0TOoA4M+rGBTC4qzJ3Ydsouhc7DeAY7qMjPIMEWKKBEJCY4HlBjjDEVQKe19rkzLLvdGFNtjKlua2tzoDoHdB8BXzJ1/a2ERnKZW5g2se2UXRr+u3EbcwvTGR3O0SU+EYkJrgkoYIO19o4zLYicZVVZa6sKCt5+uom40tMIWTNpG2qG0Xxm500woEpWgCcBGl+hsiCdgYEsjvYdxVoNHCsi7uaKgDLGbLDW3hP5eqXT9bhCdwMDWTMZCnWTlVBMgneC/6kSUsIh1biNysI0QiN5DAeHaR9sj2q5IiLR5kQX3zqgyhiz4ZTXdxtjXjXGvApM8GZLnOlu5GhGHgCl6TMvbFtll0LzDubmJRKKdPId7dN9KBFxNye6+J6z1uaMde1FXldaa1dF/rzlHtS0M9IPA+0cSQpf1puXO/vCtlf2DggMMWf0MIyq1VxEYoMrLvHJaXrCZzcHg+GXSworLmx7M98BQNKxakozSgCjTj4RcT0FlBtFWswPjYxgg0ksnVF8YdvLnBEePLbxFeYW5OANZSugRMT1FFBu1H0EgLqRPkKjOcwtzLjwbZZdGm6UyE9ldCiHBl3iExGXU0C5UU8jeHy0jnaRSB5pSb4L32bZpdB7jGUZvQRGcmnwK6BExN0UUG7U3QBZM+kPtZOTWBSdbUYe2F0c3I8dyaVruIPBwGB0ti0iMgkUUG7U3UhPVinWDFKSVhKdbRYugsR0Snp3EhoNt6839TZFZ9siIpNAAeVGPY3UJYfbwStyyqKzTa8PSleRfKyaDG8hoFZzEXE3BZTbBIah9xj7CE9OuKSwPHrbLrsUju9mQUY4oPSwroi4mQLKbSLPQB2IPANVNbMyetsuewfYEO9O64RQslrNRcTVFFBu090AwOFAAEKJzMmJ4uC4JeFhDld4awmO5FAbaWcXEXEjBZTbRCYqbBwdIJE8PJ4o/idKy4OccsqH9xMayeWIWs1FxMUUUG7T3QDGQ2eoh6yEKLWYn6pkJbndu7GjebQOHiNkQ9Hfh4hIFCig3Ka7kWD6DEK+LmakzYj+9ktX4ettIjOYStCO0jrQGv19iIhEgQLKbXoaaUspwngHKc++wGk2zqQ0fB+qKjHchaFGCRFxKwWU2/ib2O/LAmBRQXn0tz9jORgPl3t7AbWai4h7KaDcxFrwN7OPJCDKz0CNSUyDgoWsDjZgrYe6SNegiIjbKKDcpL8dgiMcDIb/s4TnbpoEpSuZ1b8fG0intqt5cvYhInKBFFBu4g+PjVcbDOAhgbzkvMnZT+lKEke6SQik0Nx7fHL2ISJygRRQbuIPn8202GEyfYUYYyZnP5EHdrOC0D7YPjn7EBG5QFMeUMaYDcaYZ8/w3jpjzO1TXY+rRM6gBhMGKUydhBbzMUWLwZvELAL0Bbombz8iIhdgygPKWvvYqa+NMRsi7z8Xeb1uqmtyDX8TIeMjlOCnPGsSWszHeBNgxjLmhnoZsX4CocDk7UtEZILccInvEqA28nUtsNLBWpzlb6Y1qQDjG2B+3qzJ3VfpKuaNtoOxdA51Tu6+REQmwA0BlX3a67d0BhhjbjfGVBtjqtva2qamKif0NLHXlwNAWUbp5O6rZCXFgWEAGnpaJndfIiIT4IaA6gZyz7aCtfYBa22VtbaqoCCKo3u7jb+JPaQCUJI+SS3mY0pXkR8Mjyaxr1Uz64qI+7ghoLZz8iyqAnj27VeNY9Zi/c0ctD4AStMn+Qwqt4JcTwoAtV3HJndfIiIT4EQX3zqg6pTmiMeAisj72WPNEtPOQAcmOEyzz4vX+MhLmaRnoMZ4POTlLQCgUZf4RMSFfFO9w0gA5Zz23j2RL6dnOMGJFvMOX4iC5GI8ZvJ/d0iZsYys40209mtEcxFxHzdc4hM48ZCuP6mfypw5U7PPosUUBAP0DWm4IxFxHwWUW/QcpcfjYTSpm1VFF0/NPouXkh8MEgjGcWekiMQsBZRb+JvZkZQMwIrCFVOzz4IF5AdCjBo/gaBm1hURd1FAuYT1N/FCUhYGD0vyl0zNTpPSyfKkMegbobl7cGr2KSJynhRQLjHc0cjryYkUJVeS4kuZsv1mpxQRNLC/VaOai4i7KKBcYqTnKLVJsCRv+ZTutzCnAoCDxw5P6X5FRM5FAeUG1lIX6GDUY1k7c9WU7rq0eDEAna07pnS/IiLnooByg4FO3kgM/6dYW3bJlO66qLQKgMGeA1O6XxGRc1FAuYG/ideSk0gLplGUVjSluy4oXAZAYLhxSvcrInIuCigXCPUcZWdSIiW+8infd2piOkkWrG3HWjvl+xcReTsKKBeoad5Nq89HRdbUNkgAGGPIJomgr5/u/pEp37+IyNtRQLnAK627AFhZdoUj+89JyKbHa2luOOTI/kVEzkQB5QK7BhpJCVneNWeFI/vPT5tBm9dLX8NOR/YvInImCigX2B/qpmLIS0l2miP7L8mvpN3nJdSyy5H9i4iciQLKYW0DbRzxBZgdzMAY40gNM7Jm0ufx4O3c68j+RUTORAHlsG+++n/xAlVM0RQbZ5Cfkg+Ad6jGsRpERE6ngHLQ662v84vaX3Jrj5+SrHmO1VGQUgCANR0QGHasDhGRUymgHBIMBfn6tq+T48vi9m4/6cUVjtUydgbV6TUMt6qTT0TcQQHlkM01m9nbsZcPJl1GqrUUzHTuDGosoNp8XjqP7HGsDhGRU/nG+wFjzAqgIvKnG+gEaq21r0ezsHjmH/HzrR3fYmXhSpY2JwBQNHu+Y/XkJOfgNV7avV4Gm9UoISLucF5nUMaYcmPM94wxW4A7gEqgBzCRr/+XMebXxpj7jDHl4y3CGLPBGLPOGHP7eD8bizbt30TXcBdfuPQLmO5Gek0a3tQcx+rxGA85SXkc8aZh2zRorIi4wznPoIwxnwVygc9ba3vOsW4WcLsxpsta+5/nU4AxZh3hM7AdkZBaaa2N67kfttRvYUXBChbkLqCr/yjdiSVkOFxTUVoBTZ2dpPhrHa5ERCTsrGdQkXB6zFr7hXOFE4C1tsda+6/Ab4wxG8+zhmrgZ8aYlUBFvIfTEf8RDnQd4JryaxgaDZIXaGE4vdTpsshPyafT5yNv8AiEQk6XIyJy9oCy1v6rtbZuvBu11tZZa+89z3W7gfuBnwFnnK3PGHO7MabaGFPd1tY23nJc5df1vwbg6tlXc7i1l5mmHU/ObIerCgeU32dJskPgP+p0OSIi4+/im8g9pnNsbx3wnLW2Eug2xmw4fR1r7QPW2iprbVVBQUE0dz/lttRvYXnBcorTimk42kCqGSatqNLpsihKK2LAM8wIEGo96HQ5IiITajPPMcZ8YuyFMebDxpgrL6CGU+85fZ3w/a64dOLy3uxrAOg8Gh65Ibd0rpNlAVCcWgxAq89Lf7NazUXEeeMOKGvta8DcsVCy1j4OXGOM+fgEa3ggcglvHXCjtfaBCW7H9cYu711THg6owdZwQ0JCnnPDHI0pSg3P5FvjzWCweZ/D1YiITOw5qC3ADuBVY8yKyPNPXwdqgR+Md3uRe1BxG0qn+vWRX7OsYBnFaeGzFbobwn9nlzlXVMTYVPO7vXksbtdoEiLivIlc4qsE7o909ZlIa/n3I3/kbTT4G9jfuf/E5b3RYIiUgSYGfFmQ5HST+alnUJmk+Q87XI2IyMQC6hrg88aYzMjlvnXANmvt30e3tPjy6yORy3uRgDrSMcBMWhlKm+lkWSekJ6aTlpDG8aQUUgNdMNDpdEkiMs1N5B5UrbX2U9Zaf+T140DPBTZKxL3fN/6eJXlLmJE+A4Ca1j5mmjZXtJiPKUotwp8cHnqJdnXyiYizojJYrLX2+8C4n5eaLkI2xMGugywrWHbivcOtfmaadlJd0GI+pjC1kIHEYPiFhjwSEYdFbTTziTzQO10c6z/GQGCAuTkn28mPNzeQZEZJzHPXGdSgp48hm8DI8f1OlyMi09w5hzqa4OCvc8Yx1FHcq+kKP+80L/vklBoDkRZzsl0UUGlFDAS7OWRnMHxMASUizjrnUEfA1caYr59PUBljMo0x/wJ8+HyHOpoODnWH27Yrs8OX80Ihe7LF3GX3oCwhXvcU4+3UPSgRcdY5n4Oy1n7fGDOH8JQaFxN+3qkbOAxkA3mRvysj792jy31vVtNdQ3FaMRmJ4Xbypu5BCoPHw78eZDn/DNSYseez9npz+PP+7TA6CAkpDlclItPVeT2oGwmcv4fw5TtOTljYQ7g5ojbSci5ncLj7MHOzT95/qmnro8y0MZKcT2JiqoOVvdnYs1BHkzMx/RbaD8GMZef4lIjI5Bj3SBKRsKoDfhP9cuJPIBSgtruWNTPWnHhv/7FelrisxRxOBlRfehr0Ax0KKBFxzrgDCiAyWOzYJb1Hx56Jkrdq7G1kJDTypg6+V+o6eL+vA1/umrN8cuplJWWR5E1iNC3yY9GhESVExDkTmW7je8BcwtO93wjUXcBAsXGvpjvcwTd2iS8QDPFqXTvFtLmqQQLAGENRahEmqZ8mm0+oTY0SIuKciZxBPRsZPQIAY0w28PfGmA9Za5+IWmVxoqarBoNhTlZ4xPI9zX7SRtrxJQcge5bD1b1VUVoRLT3dHA7NIL/1EElOFyQi09YFP6hrre2OjMOXF4V64s6h7kOUZZSR4gt3w71c20GZicwK7KJnoMYUphYyEOqgzhbj7aoBa50uSUSmqYkEVK0xZrsx5oPGmMxT3u+IVlHxpKa75k0dfC/XdrAyK3LLzoUBVZRaRM9IO4ftDHyjfdDX6nRJIjJNTSSgPgI8CnwUqI+E1SbCbecAaODYsOHgMA3+hhMNEoFgiO31XazJ7ACPzxXzQJ2uKLWIgA3QnFIQfqOjxtmCRGTamkhAHQZ+Zq290VqbC9wOVBOeVbfDGLMduDuaRcaq+p56gjZ4YoijPc1++oYDLDQNkH8R+Nx3h2ds4sLRvMgV2w5NXigizpjIdBvfB3LGhj6y1r5mrf1Xa+011to84A6gK7plxqaxIY7GLvG9XBu+Cpo/UANFix2r62yKU8OjSSTkpTBEAlaz64qIQybUJBEJpfq3WbYD+PyFFBUvarpq8Hl8zM4M32t6ubaD5fkhvL1NULzE4erObOwMKj1jkLpQMcPH1WouIs6I2nQbpxrvsEfGmJXGmA3GmA2TUY9TarprKM8sJ8GbQCAYorq+i/cVRWaqdekZVG5yLj7jIyHRT52dQahNZ1Ai4oxJCagJ+IK19jEg1xhTcc61Y0RNd82J+097j/npHQ6wOq0lvLBoqYOVvT2P8VCYWkjQ002tnUFyXyMER50uS0SmIccDyhhzO7DdGFNhrX3AWlvrdE3RMDA6QFNf04kOvrH7T3ODdZCaD+mFTpZ3VkVp4Vbz1oQyPDYAXUecLklEpiHHA4rwmH55QKcx5v7IyBRvYoy53RhTbYypbmtrm/ICJ6KuJzzjSEVW+ITw5dpOKgrSSOnaH77/ZIyT5Z1VYWohxweOE8yNTEevTj4RcYAbAgrgsLW2G3iVcNv6m0TOrKqstVUFBQVTXtxE1PnDAVWeWR5+/qmukzXlWdC6D4rc2SAxpii1iOP9x0kpng+gTj4RcYQbAmr7KV9nE54MMebV99TjMR5mZc46cf/pysJeCAzFREANBYcomJFFh81g8NgBp0sSkWnI8YCKNEdkG2PWRV4/4HBJUXHEf4SStBISvYkn7j+tSm4OL3Rpi/mYsVbznMwBau0MRlsVUCIy9SY0H1S0WWvviXz5nKOFRFG9v57yrHIAXqntpCI/jeye6vAQR/nznS3uHErTSwFISOqiLjSDxd27Ha5IRKYjx8+g4lHIhjjiP0J5ZjnBkGVbXSeXVuTB8T2uHeLoVGNTg7QOHeFYwkxSRzpgqMfhqkRkulFATYLWgVYGA4PMyZrD3ubI808VuXB8t2sf0D1VWkIaM9JmUNtTy0j2WCefBo0VkamlgJoEYy3m5ZnlJ+4/rZnhAb97hzg6XUV2BYe7D5NYFH7QWJ18IjLVFFCToN5fD8DszNm8XNtBRX4ahQORMxCXd/CNmZs1l7qeOrJL5xG0hv5mNUqIyNRSQE2C+p56Un2p5CUXsK2+k0vHLu9BzARUZXYlI6ERsnJGaLSFDB7b53RJIjLNKKAmwRH/EWZnzmZ/Sy+9QwFWV+SFAyqtADKKnC7vvFSO3XtKbKHGluDVaBIiMsUUUJNgrMV87P7TpeW50LgNit05QOyZjA3R1DbUwFFvGZkDRyAYcLgqEZlOFFBRNhQYormvmTmZc3i5toM5+WkUD9dC+0FY8F6nyztv6YnpFKUWcbjnMINZlfjsKHRr0FgRmToKqChr6G3AYpmVMZtX6jrD7eW7nwDjgYUfcLq8cZmbPZfa7lo8hRcBYNvUKCEiU0cBFWX1PfUAtHRk0DsUYG1lPux+HOa8C9JjY6DbMRXZFdT21JJWuhCAvqa9DlckItOJAirKxlrMf/rCIBX5aVybewy66mDJh50tbALmZs9lODhMRr6h1WbTr4ASkSmkgIqy+p56MhPyOXR8lM+sm4dv7xPgSYCF73O6tHEba5Qwia3UhErwtB90uCIRmU4UUFFW769nsD+Xi4oyeP/SYtjzJMxdByk5Tpc2bhXZ4YBqHTpCo7eMjL46sNbhqkRkulBARZG1lkOddfT35/J3V8/Dc3RbeHijGLy8B5CZmElhaiG1PbX0Z1aQEuqDvuNOlyUi04QCKopaB9oZCvVRmDyTaxcXh5sjfClw0fVOlzZhlVmV1HTXYAois+u27Xe4IhGZLhRQUfRf28OTA//ZipWY4Ajs3Qzzr4WkdGcLuwCV2ZXU9dSd6OTrPapGCRGZGgqoKBkOBHl05w4AbrhoIWy6BfrbYOWtDld2YSqzKxkKDpFcmEavTaHv6B6nSxKRaUIBFSWbtjfSG2ogyZNMyS83wqEt8L5vwtyrnC7tgoyNyWeSWjlsSzTthohMGVdM+R5TrIWWXRAcDc+M60tmeHSULb/ZSmFJLXND4K37HdzwH7DyFqervWAnxuQbbsB6y5jj1/TvIjI1XBVQxpi7rbWfd7qOMwoGwveUXvhmOKBOkQQ8aGC1p4xlPb2w/j5Y8VEnqoy6rKQsilKL2NO+h5Xpc8jq/V14+vfkLKdLE5E455qAMsasAyqcruOM6v4Iv/hr6KqHvHnhS3eZJRAYZmiwn68+tR8KhgmYX7Hs3XfB0vgIpzGrZ6zmt42/ZXn+R6EXbNtBTNklTpclInHOFfegjDEVQK3TdZxR6z746U3g8cFHfgR/tQ2qbgt35y26gR/4L+GRwXeQsXwOAEsrr3W44OhbW7oW/4if7oI0APyNapQQkcnnioACKqy1bxtQxpjbjTHVxpjqtra2qauqrw0euRESUuDWn8PC94Pn5CF7raGLb//mEOsWFtIVOExRahGFqYVTV98UWT1jNR7j4VhSG8PWh1+dfCIyBRwPKGPMOmvtc2dbx1r7gLW2ylpbVVAwRSOCjw6Fz5z62uCjP4GsmW9a3Ng5wCcfrqYoM5m7P7yMN9rfYFnBsqmpbYplJ2ezJG8Jhwdeo94WE2rVmHwiMvkcDyig0xizzhizAagwxqx0uiAAnvo7OLoNPvg9KF31pkU9g6P85Q+3MxII8eDHLsH4+mnqa2JpfuzMmDtel5dezoGuvezzlZDqr3G6HBGZBhwPKGvtjsgZVC6Q7XA5YQ0vw85H4IqNsHj9mxaNBkP81Y93UN/Rz/23VDG3MJ1dbeGuvngPqJAN8XpONrkjzTAy4HRJIhLnHA+oMZHLeJXW2h0OFwK//hKkF8MV/+e0RZYvPrmbrTXtfP1Dy1hTmQfAG+1v4DVeFuUtcqLiKbEkbwmZiZkczLB4CRE8riGPRGRyuSagXGP/U+FLe+/+B0hMe9Oi7/2+lk3VjfzNlXPZsOrkPaldbbuYlzOP1ITUqa52yng9XtaUrOGIrwULHNv/itMliUicU0CdKjgKz90J+RfBipvftOhXbxzj7v/ZzwdWlPB3V88/8X7IhtjdvjuuL++NubzkcvzBHl5LyKCnztkTXRGJfwqoU+14GDpq4Op/BO/JZ5hfa+ji7x59narZOdz94WUYY04sq/fX0zvaOz0CqvRyAJ5JKyaxXa3mIjK5FFBjhvvgd/8Csy+H+dedeLujb5j//eMdFGcm88CtVSQneN/0sTfa3gCI2xbzUxWmFjI/Zz6vZyZROlzL8MiI0yWJSBxTQI157UfQ3wpXfQUiZ0jBkOVvN71OR/8I9/35SnLTEt/ysV1tu0hPSGdO1pyprtgRV5RewSFvHwPeUfbted3pckQkjimgAEJBeOU+KLsUZl164u1/f/4QfzzUzldvWMzikrcOjhoIBXj52MssyV+Cx0yPQ3nD3BsIEuKp9DSa9qlRQkQmz/T4V/VcDjwdHgh2zV+deOsPB9v41m8O8aGVpXzkkrIzfuzJmidp6G3gxotunKJCnVeRVcHFBct5PCOdkaOvOV2OiMQxBRTAS9+F7Fn0VryL0eAox3oG+dtNrzOvMJ271i95U1PEmP7Rfr7z2ndYWbiSdbPWOVC0cz40fwP1iQl0B/bRPxxwuhwRiVMKqKYdhBpe5L65VVy+6Z2s+tEqrn/iakYKv8nVa/aR4LNn/NiDux+kY6iDjVUbzxhg8eya2deQioc9mZ1sq+1wuhwRiVPTPqAGXvp3NhYX892Oaq4tv5ZFKR9m0D+P8rx0Hj7wHW761U3s6XhzS3VLfwsP73mY6+dcz9KC+G8vP11qQirXZS7gD2k+qve97nQ5IhKnXDNhoROOtbzOX3e9RE1KIhurNlIQvJr//cxrfOyyDdx5w2J+0/Ab/vnlf+bmX93MB+d9kCV5S5iVOYufHfwZIRviMys/4/S34Jg/rbyBJ17byxvNjwPxNweWiDhv2gZUyIb4/G//lmafl++u/kdmFVzH9d/6IyvKsvmH9ywE4KpZV3FJ8SV8o/ob/Lzm5zx28LETn79tyW2Uppc6Vb7jFs97L/Nf/iqNCW/Q2T9yxhZ8EZELMW0D6peHnuS1kQ6+mjiLy+Z/kFsf3AbAf9x0MYm+k1c+MxMzufOyO/nS6i/RMtDCEf8R2gbauKb8GqdKdwWTks0No4ncm97P47u28cnVa50uSUTizLS8B9Uz3MM3tt/D8qFhPnDpRh7f0cQfD7Xz+esuYmbOmQd89Xq8lKaXclnJZXxg7gdI8aVMcdXu84HcxSSGLD+vfezcK4uIjNO0DKj/eO0/6B4d4P8PpNFReBn/9NReqmbncPOls50uLaZkl6zk+v5+Gob/SN9In9PliEicmXYBtbdjL48e2MRH/L0sXHU7//jUPgZHgvzLh5fh8UyvdvELVryMj/j7sJ4RfrznSaerEZE4M60CylrL11/5OtnGx1/3jfC75HU89cYxPn3lXOYWpjtdXuwpXcWSkRFyh9J49MCjWHvmZ8ZERCZiWgXUtpZtvN72On/V0Unywg/xhWcauKgogzveVel0abEpvQAKFvDeXmgdrue1Vg19JCLRM60C6sHdD5LnTeED/i4eGLySFv8Qd29Y9qauPRkfU76WTw7UQyiZn+7/qdPliEgccfxfZmNMtjFmpTFmgzHm7snaz96OvbzY/CK39A0zUrCKe99I4rbL5rCiLHuydjk9lK8lJzRIVnclzx55lo5BDX0kItHheEABNwJV1trHAIwxt0/GTh7c/SDp3mRuPH6Eb/n/hJk5KWy8dv65PyhnNzs8y+4VPQkEbIAna9QsISLR4XhAWWsfsNY+EHlZAdRGex8N/gaePfIsNwaTIKGAH3Yv52sfXEpq4rR9Tjl60gux+Rdxg6eRLBbyswM/IxgKOl2ViMQBxwNqjDGmAui01j4X7W3/cM8P8eLhzxv28L2BK7nh4tm8c35BtHczbZnytVzMfvqOV9Hc38wfm/7odEkiEgdcE1DABmvtHWdaYIy53RhTbYypbmtrG9dG2wfb+XnNz7khoYCMoI8tydfx5fcvikrBElG+luTQILO6EshNKlCzhIhEhSsCyhizwVp7T+Trlacvj1wGrLLWVhUUjO/M55F9jzAaGuWW2jd4PHAFf/+hy8hO1cCmUVUeHodvjecA81LW8ULzCxzxH3G4KBGJdY4HlDFmHXC3MeZVY8yrQG60tj0wOsCmA5u4PKGUytFBmi76C9YtKorW5mVMeiHkX8S6lIMcqV+Kz/jYdGCT01WJSIxzPKCstc9Zayuttasif6J2D+rJmifxj/j5aMNBXjIruGPDe6K1aTld+VpW2H3UHrMszVnL5prNDAYGna5KRGKY4wE1WQKhAP+9978pp4B3DrWT+s5Pk5WS4HRZ8at8LQnBAa7Kaqbl6Cp6R3p5pu4Zp6sSkRgWtwH17JFnaepr4paWozQmL2D5n3zY6ZLiW+Q+1KfKj3PwSD4lqRX8dP9PNT6fiExYXAaUtZYHdz1EZiCNDYPHyX3fV8BopPJJlV4IBQtZPvASxZkp2J7L2de5j20t25yuTERiVFwG1PaW7ezv2sdfdHXSl7ectMXXO13S9LB0A57Gl/g/lyRx8PB8shJz+cGuHzhdlYjEqLgMqH/b9h2SAon8Rf9xMq//ss6epsqyjwDwQe9W8lLTSB18Ny8de4k9HXscLkxEYlHcBdQzNX9gb/cOPt7Ti6/kEqi8yumSpo/sMii/goTdm/jE2jkcrFlKqi9dZ1EiMiFxFVB9Q6N88ff/SupoEn/Zexzvlf+gs6eptvyj0FnLrbNayUxMJyfwJzx35Dnqe+qdrkxEYkzcBFQgGOKWnz7EiK+ejb2dJM2+Aire7XRZ08+iG8CXQtq+n3Hb5XM4cHA5Pk8CD+15yOnKRCTGxEVAWWv5x1/u5sDwo5SEEvlgXx+875s6e3JCUgYsfD/sfpzbLp1BqjebAq7gF4d/QUt/i9PViUgMiYuA+sHWOn6y9xd4k4/zd+3N+N75Wcif63RZ09fyP4OhHrKPPs+fr5nNoUOrAMO3dnzL6cpEJIbEfEBt2dPCPz+zk5zS57goYLkmtQwu/4zTZU1vFX8C6cWw86d8Ym0FCaF8Znnew1O1T7G9ZbvT1YlIjIjpgNrZ2M1nfvoaJXN+wxAdfL6tDc/7/x18Gq3cUR4vLP8IHNxCwWAtH33HLPbsraIwpZivvfI1RkOjTlcoIjEgZgOq1T/Ex/+rmqzcWvyJv+eWHj+XLL0FZl3qdGkCcNlnwvejnv4sd7xzDqkJKfQ2vZ+a7hp+vPfHTlcnIjEgZgPq0epG2ge6SC78CZUjAT6TvgCu/Weny5IxaXlw1Zeh/o/MaHyaRz65mpHeBXiHFvOd17+rhgkROaeYDain3jhGRcUT+Ee7+dpwEkkfeQR8SU6XJada9TGYsQJ+/UWW5Ht45BOrMR3rGQoE+OzvvqhLfSJyVjEZUAeP99Iy8jhtCbv5X30jLPqzx8K/sYu7eLzw3n+D3mPw+7tZVJLJpo+/F1/Xh3i9/RX+v+e/qNHOReRtxWRAffv5rxAsep6rB4b4+Hu/r5ZyN5tZBStvhZfvg6PVzC/K4Gc3/y0+/7X8tulp7vzjvzldoYi4VMwFVJu/gd+PPMu6/gD3vO8RfHPe5XRJci5X3QmZJfDwB6DuD8wtTOfxP7sTX/9qnqj7L77xskaZEJG3irmAah3tZU2vl8uX/Ahf2SVOlyPnIy0P/nILZJXBjzbA/l9RUZDO4396L76hxTx04BvcvHkj/qFepysVEReJuYDKsAn8oflOrlq11OlSZDwyS+C2p6F4KWy6BbZ+k4osH09s+B75wWvZ2f1r3vWT9/Ho7uedrlREXMIVAWWM2WCMWWeMuf1c6w4EZrB6Xgk5aXoYN+ak5sKtP4d5V8NzX4H/u4Q5u77H8x/5Ap+s/DcCQS//9OpnuOqRj/CTfY/iH/E7XbGIOMg43UVljNkAYK19LBJQtdba595u/aQZ8+yPn/otG1bNnLIaZRI0vAIvfBMOPA3GC0WL6Clczpe7etgaqmUksRef8bGqaCVzc+ZRmV1JeWY5ucm5ZCVlkZWURYInwenvQiRmGGNetdZWOV3HePicLgC4BNgU+boWWAm8bUAZ4JrFRVNQlkyqWZfCrJ9A6z7Y9Rg0VZN14Bd8a9iPBfYmJvJUeio7B//IE80vM+h568m+z1oSLCRY8Nnw5QAz9ifye9eZxrPXGPciscENAZV92uu3PNAUObO6HSCndA6ZyfrNOW4ULoSrvhT+OhSCrjqMv5mL/Mfp2b2fpV0deEaG6cNPp+lj0IzSb0YZMAFGCREwIUaNJYjFAqHI3wCYU76O0FNXIrHDDQHVDeSebQVr7QPAAwBVVVX6NyZeeTyQVwl5lfiAy5Y7XZBI/PjPO2Lv2oEbmiS2c/IsqgJ41rlSRETELRwPKGvtY0CFMWYdkH22BgkREZk+3HCJD2vtPZEvFU4iIgK44AxKRETkTBRQIiLiSgooERFxJQWUiIi4kgJKRERcyfGx+MbLGNMLHHC6DpfIB9qdLsIldCxO0rE4ScfipIustRlOFzEermgzH6cDsTbg4WQxxlTrWITpWJykY3GSjsVJxphqp2sYL13iExERV1JAiYiIK8ViQD3gdAEuomNxko7FSToWJ+lYnBRzxyLmmiRERGR6iMUzKBERmQZcHVDGmA3GmHWRCQvHvTyenOexmBZTlZztWBhjso0xKyPr3O1EfVPpPH4u1kX+TPtjccp60/5YGGO6jDHPGmM+N9W1jYdrA8oYswFgbPqNyHQc5708npzP9xqZtiTuncexuBGoGjse8fzLy3n8P7ISWBlZvtIYUzH1VU6N8/33IPJ+3B4HOO9j8afW2qtPmUnClVwbUMAlQG3k61pg5TiXx5Pp9L2ey1mPhbX2gcgMzBD+h6iW+HWuY7HDWnuPMSYbqLXWTttjARAJ6Hg+BmPO59+L7Fj4hcXNAZV92uu8cS6PJ9mnvY7n7/Vcsk97fcZjEfmfrzPOJ8DMPu312/1cVAGHJ7cUx2Wf9vpMx6IizkN6TPZpr890LHKBTmPM/ZNfzsS5OaC6CR/EiS6PJ91Mn+/1XLo5v2OxwVp7xyTX4rRuzuNYREK6cuzST5zq5izHwhizLs5/WTlVN+f4uYhcaegGut38c+HmgNrOyd8EKoDTGwDOtTyeTKfv9VzOeSyMMRvGrq1H7sPEq7MeC2PM3afcg+smvn/JOdfPRWekaWADUDHNfy5uj5Xv37UBFbnJXRG5wZd9yg2/Z8+2PB6d61hEvl4HVLn5t6FoONexiLx/tzHmVWPMq8TxP8rn8XNxP1B7yvKYe1DzfJ3Hvxc7Iu/l8tZLYHHlPH4uHo283nDK+q6kB3VFRMSVXHsGJSIi05sCSkREXEkBJSIirqSAEhERV1JAiYiIKymgRETElRRQIiLiSgooERFxJQWUiIi4kgJKJAqMMRXGmMOnDLkU1/MviUwFBZRIdHweuBrYEZmxtWqaTO0gMmk0Fp9IFBhjsq213ZHJAaviefBikamigBKJkrEpDKy1O5yuRSQe6BKfSBREpi6oHQuneJ/2RGQqKKBELlBkUsAK4PvGmOzIPahuZ6sSiX0KKJELEOnUq43M4FsL1AGHdQ9K5MLpHpSIiLiSzqBERMSVFFAiIuJKCigREXElBZSIiLiSAkpERFxJASUiIq6kgBIREVdSQImIiCspoERExJX+H7sEURV1k1hAAAAAAElFTkSuQmCC
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA1m0lEQVR4nO3deXydZZ3//9d1crLve5o0bZq0pXshDVKg6CgFxQWrVhhhYHTU+vU78/3pzK/izPwYZRxGB6b6RR1F6ggOKtLKUgXFQnEteyiUtumWZu2SZt/Xc871++OctKWUZunJue+TvJ+PRx/J2e7705Plneu6P/d1G2stIiIibuNxugAREZFzUUCJiIgrKaBERMSVFFAiIuJKXqcLEBGRiXv11VfzvF7vfwPLiO7BRgDY6/P5PrNq1armMx9QQImIRCGv1/vfBQUFi3Nzczs8Hk/UtmMHAgHT0tKypKmp6b+B6898LJpTV0RkJluWm5vbHc3hBODxeGxubm4XwZHgmx9zoB4REblwHreHU1VVVdx1111XOtbzQv+Pt+SRAkpERKbEkiVLhn/yk5/UT/b1CigREZkSVVVVcQcOHIif7OvVJCEiEuW+9Mju4kNNPUnh3ObCgtT+/1y/svF8z9m0aVPO6tWr+1988cWkjRs3tj7wwAOZW7duzbzhhhs6jhw5EnfTTTd13HbbbUXPP//84dbW1ph77rknp6Kior+ysjIpIyPDv3HjxtbzbV8BJSIiE3b77bfnV1RU9K9Zs6a/tbU1ZtOmTTkbN25s/cpXvlL01FNP1Yw+Lz093Q+wc+fOpIyMDP+6det67rvvvtwzn/N2FFAiIlFurJHOVHj11VeTb7rppg6AhQsXDt133325GzdubF22bFn/uZ6/bt26nk2bNsVv27Yt9Zvf/ObR8exDASUiIhO2atWqvkOHDsUvWbJk+NChQ/GrVq3qO9/zd+7cmfT+97+/e8mSJcPj3YeaJEREZMLuvPPOk5WVlUnbtm1LraysTLrzzjtPbtu2LXXv3r1JO3fuTIJgKO3duzepqqoqbs2aNf0f//jHy6677rrSz3/+80Wtra0xY+3D6HpQIiLRZ/fu3XUrV648b5OBm9x+++35X/ziF1tzcnL8VVVVcd/97ndz77333mOjj+/evTtn5cqVJWe+RlN8IiIy5SoqKvqfeOKJtMzMTF9HR4f35ptv7hjrNQooERGZcuvWreuZ6Gt0DEpERFxJASUiIq6kgBIREVfSMSgREZkS27ZtSwXYvn172pkde+OlEZSIiITdzp07k7Zv3562bt26nt27d586N2oiNIISEZGwW7NmTf+aNWv6ARobG+NHP58IBZSISLTb9rfFNFeFdTVz8pb0s+57b7vG37Zt21Lvvvvugttuu62psrIyqaysbDgzM9O3devWrO985ztHc3Jy/BA8Qfe73/3upK4JpSk+ERGZsHXr1vV0dXV5161b13PTTTd1bN26NXPdunU95eXlfWdO5915550n77vvvtzxLG10No2gRESi3XlGOlMpPT3dN/p5SUnJEEB2dvapy2tAcKqvpKRk6J577sm58847T05k+xpBiYjIpIxe6+lcfvvb36aOjpq6urq8ZWVl417FfJRGUCIiMmFnrlz+29/+NnX37t1JVVVVcVu3bs3MzMz0f+c73zn64x//OPOBBx7wAnzqU58ac+29s2k1cxGRKBRtq5mP5VyrmWuKT0REXEkBJSIirqSAEhERV1JAiYiIKymgRETElaKuzTwnJ8eWlJQ4XYaIiKPuvvtuqqqq5o73+UNDQ75LLrlk91TWdLbPf/7zRffee++xTZs25WzcuHHCHYdRF1AlJSVUVlY6XYaIiKP279/P4sWLx/38vXv3TvhE2Qv1s5/9LPfJJ5/MnOxafFEXUCIiEh0efPDBI+vWreuZ7OsVUCIiUe6ul+/iQPuB8z6nt683wVvnvWi825yfOb//3678twtazbyysjIJoLKyMmmi6/CBmiRERGQSxrOa+Z133nly3bp1PW1tbd7Rq+tOhEZQIiJR7svv+PKYz9m7d+/gsmXLDoZzv+dbzfyBBx7IhOAafNnZ2b7q6up4YELTfRpBiYjIpJxvNfMFCxYMfehDH+oGqKmpSVi9erWuqCsiIlNvrNXMH3roofpNmzblZGdn+0tLSwcnc8n3qFvNvKKiwqrNXERmukm0mfcvW7Zs/xSWdEG0mvk01T04wv88X4fPH3C6FBGRsFFARatAAPwjADz4fB1f/dU+fr3nhMNFiYiEjwIqGlkLD38CNr8bRgZ58o1gMP1oZy3RNmUrIpM3XX7eA4GAAd4yBeRIQBljyt/m/tsiXUtU2vc4HPotnNxD+/avc6Cph6WFabxxtItX6yd8VWURiUIJCQm0tbVFfUgFAgHT0tKSDuw9+7GId/EZY9YCdwGrznH/pZGuJ+oM9cD2f4aCFZB7Eemv/heLPLP43k238uHvPcePdtZSUZLldJUiMsVmz57N0aNHaWlpGdfzm5qavH6/P2eKy5qMALDX5/N95uwHIh5Q1todxpj2SO932vjj3dBzAm74CTZrHj17t/Pd5B9TkrWBT7xjDpv/dITG9n6Ks5KcrlREplBsbCzz5s0b9/OXLFmyx1pbMYUlhZ0rjkEZY8qttTucrsP1mg/Ai9+HS26B4ks52BPHV4f+igUjB+DlH/LXV8zFYwz/83yd05WKiFwwVwQUoDmpsVgLT30J4lJg7b8C8OTuEzxhr2S45D3w7NeY5e3j/ctnseWVRnqHfGNsUETE3RwPqPGMnowxG4wxlcaYyvHOt0473ceh9k+w5ouQnM2If4Qn9zRyeVkOcdd+FUb64NB2/mbNPHqGfGx95W0XIRYRiQqOBxRQaoxZb4xZH/r8LR1+1trN1toKa21Fbm6uAyW6QNOe4Mc5lwPwmd/+Hc0p3+QDy2fBrJWQUgDVz3BxcQar5mby4+fr8Aeiu7tHRGa2iAdUKIgqQh+x1j5irX2E4DRfRqTriRonQwGVv5Sdx3ayq/V5YhKPkp93DIyB+WvhyO/A7+PTa+bR0N7Ps/snfPkVERHXiHhAhQIpMxRKZ96/2VpbZq3dFemaokLTHsgqxRebyKZXNuHxZRNjU3iibmvw8QVrYbALjr7CtUvyKcpI5Ec7a52tWUTkArhhik/Go2kP5C/jscOPcaTrCH1N72N17vv5fePvOdZ7DErfDSYGqp/BG+Phk1eU8FJtO3uPdTlduYjIpCigosFQD7TX0Ju3iO+9/j1yvIsw/cv5h8s+icGw5cAWSMyA4svg8NMA3HBpMUlxMdz/nEZRIhKdFFDR4OQ+AO73NdM+2E7/ifdz1YI8FuYUc/Wcq3nk8CP0j/TDgmuCI62eJtITY7mhopgndh+nuWfQ4f+AiMjEKaCiQdMehgz85ORzrM5by8nWPD64YhYANy++mZ7hHn5d++tgQAFUB7v2P3lFCb6A5acv1DtVuYjIpCmgokHTGxxNzmbQP0SgbxFxXg/XLMkH4JK8S1ictZiH9j+EzVsKqbNOTfOV5CTzFwtzefz1Y05WLyIyKQqoaNC0h8bcUgB213p518JcUhNiATDGcPPim6nurOaput+G2s3/AP7gShKXzMnkaMcAA8N+p6oXEZkUBZTb+X3QvJ/G1OAixG2dqaem90Z9sPSDLM1eyl2v3EXXvDUw1AVHXwZgfl4K1kJNa2/ESxcRuRAKKLdrqwbfII3xiXhJJN6TwtrF+W96SownhjuuuIOuoS6+1bkbPN5Tx6HKclMAqG5WQIlIdFFAuV1oiaNGfPiHs3jPonyS4996lZRFWYu4demtPFb7JK8ULob6FwAoyUnCY+BIS19EyxYRuVAKKLdregNi4qgdaGN4MIurFrz9WoSfX/l5ilKK+FqCj97ju/AN9xEX42FOVhJHWjSCEpHoooByu6Y9+PMW0dR/gsBwNgvyUt72qYneRL6y+ivU+fu4vDiPS36+mhUPrmA49/tUN/dEsGgRkQungHIza6FpDyfzFuK3PuxI1qljSm/niqIr+M6VX+cL7Z38XeYlXDfvOnrMAep6q7S6uYhEFQWUm/U0QX8rDenBrr0UTz6ZyXFjvuzd8z/EZ+IK+Vx3P3dcfgdxnkRM2gsc6xiY6opFRMJGAeVmow0SCcFRU0n6nPG/ds7l0PgSSTHxXFXwPrypb/D6cV3EUESihwLKzdoOA9Bo/GBjWJRbPP7Xzrkchrrh5D7+etknMB4/v6l9YooKFREJPwWUm3U2QFwKR3qb8Q9nsSAvbfyvnRu88i4NL3DJrMWYwVJ2df6GgA1MTa0iImGmgHKzzkZIL6a2qwE7ksX883TwvUXGHEibDfXPA1DouZoB28Jzx56bomJFRMJLAeVmXQ3Y9GJODhwjMJxN2UQCCoKjqIYXwFouzr4K/KlsObhlamoVEQkzRwLKGFN+1u0NoX93OVGPa3U20JFewHBgAG8gh8L0hIm9fs7l0HsS2mtYkJfBUEcFfzr6J5r6mqamXhGRMIp4QBlj1gI/POv2DmvtZqA0dFsGu2Cwi8bEVAAKkmZjjJnYNuZeEfzY8AJlucn4ehdhsRzqOBTmYkVEwi/iAWWt3QG0n3FXKTAaSjWh29IZbAlvjA2e91SWMYEW81E5F0FiJtS/EFzVfDgruM0etZuLiPu9ddXRCAuNnEaVAzpIAtAVDJGawAjWGpbmz5v4Njye4DRfwwsUpicS70nDSzxHe46GuVgRkfBzTZNE6LjUM9baXU7X4gqhEdTBgW6sL42L8rImt53iy6D9CJ6BNkpzUom1uQooEYkKrgkoYK219u5zPRBqoKg0xlS2tLREui5ndNaDN4HavmYCw1nMz0ue3HaKLwt+bHyZ+XkpjAxlaopPRKKCKwLKGLNhNJzO1SRhrd1sra2w1lbk5r795Samla5GSJ9Ny+BxGMlhbvYkA6rwYvDEQuNLlOWm0N+fztHeo1irhWNFxN2c6OJbD1SEPo4G0l3GmCPGmI5I1+NanQ30p89mMNBJemwBsTGT/FLFJgZDqvFlyvKSCQxnM+QfonWgNazlioiEmxNdfI9YazOttY+Ebu8I3S4LfdwR6ZpcqbORo6nZABSlzL6wbRVfBsd3MT87jkCok+9or45DiYi7uWKKT84y3Af9rdTHB6f1FmTNvbDtFb8DfIPMGzkCI2o1F5HooIByo67g6OaQP3hzWd4Fnho2+x0AxJ+opCi1EDDq5BMR11NAuVGoxfzw8DDWH8/yWQUXtr20WcHFYxtfYn5uJjGBDAWUiLieAsqNOusBqB3uJTCSyfy81AvfZvFlwUaJnCRGBjNp0BSfiLicAsqNuhrB46V5pIM4skmOD8OCH8WXQc8JVqT24BvOoqFbASUi7qaAcqPOBkifTV+glcy4/PBsM3TC7lL/AexwFh1DbQz4BsKzbRGRKaCAcqPORrrSi7BmgMLkwvBsM28JxKVQ2LObwEiwff1Yz7HwbFtEZAoooNyoq5HahGA7eGlmcXi2GeOFolUknKgkNSYPUKu5iLibAsptfEPQc4L9BC9OuCyvJHzbLr4MTu5lUWowoHSyroi4mQLKbULnQB0MnQNVMbssfNsufgfYAO9ObodAglrNRcTVFFBu09kAwBGfDwJxzMsM4+K4heUAXBxTg384k5pQO7uIiBspoNwmdKHCxpF+4sjG4wnjlyg5GzJLKBk6QGA4i3q1mouIiymg3KazAYyH9kAX6bFhajE/U2E5WZ17sSPZNA+cIGAD4d+HiEgYKKDcprMRf8osAt4OZiXPCv/2i1bh7TlGmj8Jvx2hub85/PsQEQkDBZTbdDXSkpiPiRmgJOMCL7NxLkXB41AVccEuDDVKiIhbKaDcpvsYB7zpACzJLQn/9metBOPhypgeQK3mIuJeCig3sRa6j7OfeCDM50CNikuG3MWs9jdgrYfaUNegiIjbKKDcpK8V/MMc8ge/LMFrN02BonLm9B3A+lKo6Tg+NfsQEblAjgSUMab8rNvrjTFrjTG3OVGPa3QH18ar8fvwEEt2QvbU7KeonLjhTmJ9iRzvOTk1+xARuUARDyhjzFrgh2fcLgew1u4AOs8OrxmlOziaabJDpHnzMMZMzX5CJ+ym+6F1oHVq9iEicoEiHlChIGo/464bgc7Q5zXA2kjX5BqhEdRA7AB5SVPQYj4qfynExDMHH72+jqnbj4jIBXDDMagM3hxYUzSvFQW6jxEwXgKx3ZSkT0GL+aiYWJi1gvmBHoZtN76Ab+r2JSIySW4IKBnVfZzm+FyMt5+F2XOmdl9Fq1gw0grG0j7YPvbzRUQizA0B1QlkhT7PANrOfoIxZoMxptIYU9nS0hLB0iKs6xhV3kwAilOLpnZfheUU+IYAaOhqmtp9iYhMghsCagtQGvq8FNhx9hOstZuttRXW2orc3DCu7u023cfYRxIAhSlT1GI+qmgVOf7gahL7m3VlXRFxHye6+NYDFaGPWGt3he5fC3SO3p5xrMV2H+eQ9QJQlDLFI6isUrI8iQDUdJyY2n2JiEyCN9I7tNY+Ajxy1n2bI12H6/S3YfxDHPfGEGO8ZCdOca+Ix0N29iLgBI2a4hMRF3LDFJ/AqRbzNm+A3IQCPGbqvzSJs1aQ7g/Q3KcVzUXEfRRQbhE6Sbc7vo+yzHmR2Wf+UnL9PnoHtdyRiLiPAsotuo7S5fEwEt/JqvxLIrPPguXk+P34/NO4M1JEopYCyi26j7MrPgGAi/Mujsw+cxeR4wswYrrx+XVlXRFxFwWUS9juYzwXn47Bw7KcZZHZaXwK6Z5kBrzDHO8ciMw+RUTGSQHlEkNtjbyeEEd+QhmJ3sSI7TcjMR+/gQPNWtVcRNxFAeUSw11HqYmHZdkrI7rfvMzgOdKHThyJ6H5FRMaigHIDa6n1tTHisayZvSqiuy4qWApAe/PMPD9aRNxLAeUG/e28ERf8UqwpvjSiu84vqgBgoOtgRPcrIjIWBZQbdB/jtYR4kv3J5CfnR3TXuXkrAPANNUZ0vyIiY1FAuUCg6yi74+Mo9JZEfN9JcSnEW7C2FWttxPcvIvJ2FFAuUH18L81eL6XpkW2QADDGkEE8fm8fnX3DEd+/iMjbUUC5wEvNewAoL77Kkf1nxmbQFWM53nDYkf2LiJyLAsoF9vQ3khiwvGvexY7sPyd5Fi0xMfQ27HZk/yIi56KAcoEDgU5KB2MozEh2ZP+FOWW0emMINO1xZP8iIueigHJYS38L9V4fc/2pGGMcqWFW+mx6PR5i2qsc2b+IyLkooBx2z6v/lxiggghdYuMcchJzAIgZrHasBhGRsymgHPR68+v8quYJbu3qpjB9gWN15CbmAmBNG/iGHKtDRORMCiiH+AN+vvHyN8j0prOhs5uUglLHahkdQbXHGIaa1cknIu6ggHLItuptVLVV8ZH4K0iyltzZzo2gRgOqxRtDe/0+x+oQETmTd6IvMMaUAOVAFpAB1ACd1trfTbYIY8x6oBMotdZunux2okX3cDff3vVtyvPKWX48FoD8uQsdqyczIZMYE0NrTAwDx9UoISLuMO4RlDHmS8aYp4G7gDLAAF2hz681xjxtjLnXGHPxRAowxpQDNdbaHUBN6Pa0tuXAFjqGOviny/4J09lIj0kmJinTsXo8xkNmfDb1McnYFi0aKyLuMOYIyhgzD/gc8LC19j/HeG46sMEYU2Gt/e8J1HEXcA3BEdSOCbwuKm2v287FuRezKGsRHX1H6YwrJNXhmvKTcznW3k5id43DlYiIBJ13BBUKp6uttf9orX19rI1Za7tCIfasMeYz4ynAWruL4MjpCNA+ntdEs/rueg52HOTakmsZHPGT7WtiKKXI6bLIScyh3esle6AeAgGnyxEROX9AWWtrJzgSmvDrjDEZBI8/3Qf80BjzlnY2Y8wGY0ylMaaypaVlouW4ytN1TwNwzdxrONLcw2zTiidzrsNVBQOq22uJt4PQfdTpckREJt7FZ4xJC3MNG4BvWGvvBj4OrD/7CdbazdbaCmttRW5ubph3H1nb67azMnclBckFNBxtIMkMkZxf5nRZ5Cfn0+8ZYhgINB9yuhwRkUm1mZed2QhhjJlnjHlPOIoJHX/qDMe23OjU9N7cawFoPxpcuSGraL6TZQFQkFQAQLM3hr7jajUXEedNOKCsta8Bl4bazbHW1gKZxphvTKaA0MhpgzFmvTFmw3RuMx+d3ru2JBhQA83BhoTYbOeWORqVnxS8km91TCoDx/c7XI2IyOSm+LYAR4COM6b7dhCcqpsUa+3d1tpHpnM4ATxd/zQrcldQkBwcrdDZEPyYUexcUSGjl5rfG5ONadVqEiLivMlM8a0CKq21XYAJtZavBf4jrJVNMw3dDRxoP3Bqem/EHyCx/xj93nSId7rJ/MwRVBrJ3UccrkZEZHIB9XFCo6VQSGUBmWOdIzXTPV0fmt4LBVR9Wz+zaWYwebaTZZ2SEpdCcmwyJ+MTSfJ1QP+07/gXEZeb1DEoa+2mM27XAq9OdAWJmeaPjX9kWfYyZqXMAqC6uZfZpsUVLeaj8pPy6U4ILr1Eqzr5RMRZYVksNtQ4URuObU1HARvgUMchVuSuOHXfkeZuZptWklzQYj4qLymP/jh/8IaWPBIRh4VtNfPQdJ+cw4m+E/T7+pmfebqd/OTxBuLNCHHZ7hpBDXh6GbSxDJ884HQ5IjLDjbnU0XiXLArH66ar6o7g+U4LMk5fUqM/1GJOhosCKjmffn8nh+0shk4ooETEWWMudURwXb0fjOdkXGNMmjHmSwTX75vwEknT1eHOYNt2WUZwOi8QsKdbzF12DMoS4HVPATHtOgYlIs4aczXzUEj9L2PMZ40x/whYYBfQFnpKNsHrQpURPD/q7tBrJKS6s5qC5AJS44Lt5Mc6B8jznwz+eZDu/DlQo0bPz6qKyeSv+l6BkQGITXS4KhGZqcZ9wUJr7Q8JLuaaDlQQDKUsgs0RNaFGCTmHI51HmJ9x+vhTdUsvxaaF4YQc4uKSHKzszUbPhTqakIbps9B6GGatGONVIiJTY8JX1A01Qzw7BbVMS76Aj5rOGi6fdfmp+w6c6GGZy1rM4XRA9aYkQx/QpoASEedMqovPGPOZ0NVzPzMFq5tPK409jQwHht/UwfdSbRvzvG14s9wVUOnx6cTHxDOSHPq7pU0rSoiIcyazFt9/APMJXu79BqDWGPPpcBc2XVR3Bjv4Rqf4fP4Ar9a2UkCLqxokAIwx5CflY+L7OGZzCLSoUUJEnDPhKT7gFWvto6M3Qhcc/EdjzEettY+FrbJporqjGoNhXnpwxfJ9x7tJHm7Fm+CDjDkOV/dW+cn5NHV1ciQwi5zmw8Q7XZCIzFgXfKKutbbTWvuPBLv55CyHOw9TnFpMojfYDfdiTRvFJnRVYBedAzUqLymP/kAbtbaAmI5qsNbpkkRkhppMQNUYY14xxrz7rONPbW/7ihmsurP6TR18L9a0UZ7eHbzhwoDKT8qna7iVI3YW3pFe6G12uiQRmaEmE1A3AluBzwN1obDaDpQaY1IBjDEfDWONUWvIP0RDd8OpBgmfP8ArdR1cntYGHq8rrgN1tvykfHzWx/HE3OAdbdXOFiQiM9ZkAuoI8Atr7Q3W2iyCl97YAVwL1BtjDgN3hbHGqFXXVYff+k8tcbTveDe9Qz4WmwbIuQi87jvCM3rhwpHs0Ixtmy5eKCLOmMzlNn5I8BLvJaHbr1lr/9Nae20osG5EK5sDp5c4Gp3ie7EmOAua018N+Usdq+t8CpKCq0nEZicySCxWV9cVEYdMpouP860aYa3dZYz58kS2Z4wpB0pDr39kMjW5UXVHNV6Pl7lpwWNNL9a0sTInQEzPMShY5nB15zY6gkpJHaA2UMC8k4dIcLgmEZmZwna5jTNNYtmjz4WCqTQUVtNCdWc1JWklxMbE4vMHqKzr4IP5oSvVunQElZWQhdd4iY3rptbOItCiEZSIOGNKAmoijDHrCR7Xwlp7t7V2l8MlhU11Z/Wp409VJ7rpGfKxOrkp+GD+cgcre3se4yEvKQ+/p5MaO4uE3kbwjzhdlojMQI4HFHApkG2MKTfG3OZ0MeHSP9LPsd5jpzr4Ro8/zffXQlIOpOQ5Wd555ScHW82bY4vxWB901DtdkojMQG4IKIC20ZFTaET1JsaYDcaYSmNMZUtLS+Srm4TarmCfSGl6KQAv1rRTmptMYseB4PEnY5ws77zykvI42X8Sf1bocvTq5BMRB7ghoI4AocvLUkNwRPUm1trN1toKa21Fbm5uRIubrNruYECVpJUEz3+qbefyknRo3g/57myQGJWflM/JvpMkFiwEUCefiDjCDQG1g1AHX+jjKw7WEjZ1XXV4jIc5aXNOHX96T14P+AajIqAG/YPkzkqnzaYycOKg0yWJyAzkeEBZa2uAztGpvenSZl7fXU9hciFxMXGnjj+tSjgefNClLeajRlvNM9P6qbGzGGlWQIlI5E3qPKhws9ZudrqGcKvrrqMkvQSAl2raKc1JJqOrMrjEUc5CZ4sbQ1FKEQCx8R3UBmaxtHOvwxWJyEzk+AhqOgrYAPXd9ZSkleAPWF6ubeey0mw4uc+1SxydafTSIM2D9ZyInU3ScBsMdjlclYjMNAqoKdDc38yAb4B56fOoOh46/6k0C07ude0JumdKjk1mVvIsarpqGM4Y7eTTorEiElkKqCkw2mJeklZy6vjT5bM80O3eJY7OVppRypHOI8TlB080ViefiESaAmoK1HXXATA3bS4v1rRRmpNMXn9oBOLyDr5R89PnU9tVS0bRAvzW0HdcjRIiElkKqClQ11VHkjeJ7IRcXq5r57LR6T2ImoAqyyhjODBMeuYwjTaPgRP7nS5JRGYYBdQUqO+uZ27aXA409dAz6GN1aXYwoJJzITXf6fLGpWz02FNcE9W2kBitJiEiEaaAmgKjLeajx58uK8mCxpehwJ0LxJ7L6BJNLYMNHI0pJq2/Hvw+h6sSkZlEARVmg75BjvceZ17aPF6saWNeTjIFQzXQeggWfcDp8sYtJS6F/KR8jnQdYSC9DK8dgU4tGisikaOACrOGngYsljmpc3mptj3YXr73MTAeWPxhp8ubkPkZ86nprMGTdxEAtkWNEiISOQqoMKvrqgOgqS2VnkEfa8pyYO+jMO9dkBIdC92OKs0opaarhuSixQD0HqtyuCIRmUkUUGE22mL+8HMDlOYk896sE9BRC8s+5mxhkzA/Yz5D/iFScwzNNoM+BZSIRJACKszquupIi83h8MkRvrB2Ad6qx8ATC4s/6HRpEzbaKGHimqkOFOJpPeRwRSIykyigwqyuu46Bviwuyk/lQ8sLYN/jMH8tJGY6XdqElWYEA6p5sJ7GmGJSe2vBWoerEpGZQgEVRtZaDrfX0teXxd9fswDP0ZeDyxtF4fQeQFpcGnlJedR01dCXVkpioBd6TzpdlojMEAqoMGrub2Uw0Etewmzeu7Qg2BzhTYSLrnO6tEkrSy+jurMakxu6um7LAYcrEpGZQgEVRv/zSvBiwH95cTnGPwxV22DheyE+xdnCLkBZRhm1XbWnOvl6jqpRQkQiQwEVJkM+P1t37wLg+osWw5ZboK8Fym91uLILU5ZRxqB/kIS8ZHpsIr1H9zldkojMEK4KKGPMbU7XMFlbXmmkJ9BAvCeBwic2wuHt8MF7YP7VTpd2QUbX5DPxzRyxhbrshohEjCsu+Q5gjFkLXOp0HWOyFpr2gH8keGVcbwJDIyNsf3YneYU1zA9ATO0f4Pr/gvJbnK72gp1ak2+oARtTzLxuXf5dRCLDNQHlen5f8JjSc/cEA+oM8cD9BlZ7ilnR1QPr7oWLP+FElWGXHp9OflI++1r3UZ4yj/SePwQv/56Q7nRpIjLNuSKgjDHl1todxpjPOV3LOdX+GX71d9BRB9kLglN3aYXgG2JwoI+vPXkAcofwmV+z4t13wvLpEU6jVs9aze8bf8/KnE9AD9iWQ5hi9w92RSS6ueUYVJbTBbyt5v3w8E3g8cKNP4W/fRkqPhXszltyPT/qvpSHBt5B6sp5ACwve6/DBYffmqI1dA9305mbDEB3oxolRGTqOT6CGh09jfGcDcAGgDlz5kSkLgB6W+ChGyA2EW79JaTPftPDrzV08J1nD7N2cR4dvj+Sn5RPXlJe5OqLkNWzVuMxHk7EtzBkvXQf3Ycm+ERkqrlhBFVqjFlvjFkf+rz87CdYazdbayustRW5uRFaEXxkMDhy6m2BT/z8LeHU2N7PZx+sJD8tgbs+toI3Wt9gRe6KyNQWYRkJGSzLXsaR/teoswUEmrUmn4hMPccDylr7iLX2EYLTfBkOl3Pak38PR1+Gj/wAila96aGugRH+5sevMOwLcP8nL8V4+zjWe4zlOdFzxdyJurLoSg52VLHfW0hSd7XT5YjIDOB4QI0KjZLKrLW7nK6Fhhdh90Nw1UZYuu5ND434A/ztz3ZR19bHfbdUMD8vhT0twa6+6R5QARvg9cwMsoaPw3C/0yWJyDTnmoByDWvh6X+BlAK46h/Oeshy++N72Vndyjc+uoLLy7IBeKP1DWJMDEuylzhRcUQsy15GWlwah1ItMQTwn9SSRyIytRRQZzvwZHBq793/DHHJb3roB3+sYUtlI//Pe+azftXpY1J7WvawIHMBSbFJka42YmI8MVxeeDn13iYscOLAS06XJCLTnALqTP4R2HEH5FwEF9/8pod+/cYJ7vrtAT58cSF/f83CU/cHbIC9rXun9fTeqCsLr6Tb38Vrsal01To/Eysi05sC6ky7HoS2arjmXyHmdAf+aw0d/P3W16mYm8ldH1uBMebUY3XddfSM9MyMgCq6EoCnkguIa9W5UCIytRRQo4Z64Q//AXOvhIXvO3V3W+8Q//tnuyhIS2DzrRUkxMa86WVvtLwBMG1bzM+Ul5THwsyFvJ4WT9FQDUPDw06XJCLTmAJq1Gs/hb5muPqrEBoh+QOWL255nba+Ye79q3KykuPe8rI9LXtIiU1hXvq8SFfsiKuKruJwTC/9MSPs3/e60+WIyDSmgAII+OGle6H4Mphz2am7v/u7w/z5cCtfu34pSwvfunaCL+DjxRMvsixnGR4zM97K6+dfj58AT6Ykc2y/GiVEZOrMjN+qYzn4m+BCsJf/7am7/nSohW8/e5iPlhdx46XF53zZ49WP09DTwA0X3RChQp1Xml7KJbkreTQ1heGjrzldjohMYwoogBe+Dxlz6Cl9FyP+EU50DfDFLa+zIC+FO9cte1NTxKi+kT6+99r3KM8rZ+2ctQ4U7ZyPLlxPXVwsnb799A35nC5HRKYpBdSxXQQanufe+RVcueWdrPrpKq577BqG8+7hmsv3E+u153zZ/Xvvp22wjY0VG88ZYNPZtXOvJQkP+9LaebmmzelyRGSamvEB1f/Cd9lYUMD32yp5b8l7WZL4MQa6F1CSncKDB7/HTb++iX1tb26pbupr4sF9D3LdvOtYnjv928vPlhSbxPvSFvGnZC+V+193uhwRmaYcv9yGk040vc7fdbxAdWIcGys2kuu/hv/91Gt88or13HH9Up5teJZ/f/HfufnXN/ORBR9hWfYy5qTN4ReHfkHABvhC+Rec/i845uNl1/PYa1W8cfxRYPpdA0tEnDdjAypgA3z591/kuDeG76/+V+bkvo/rvv1nLi7O4J/fvxiAq+dczaUFl/Ktym/xy+pf8sihR069/lPLPkVRSpFT5Ttu6YIPsPDFr9EY+wbtfcPnbMEXEbkQMzagnjj8OK8Nt/G1uDlcsfAj3Hr/ywD8102XEOc9PfOZFpfGHVfcwb+s/hea+puo766npb+Fa0uudap0VzCJGVw/EsemlD4e3fMyn129xumSRGSamZHHoLqGuvjWK3ezcnCID1+2kUd3HePPh1v58vsuYnbmuRd8jfHEUJRSxBWFV/Dh+R8m0ZsY4ard58NZS4kLWH5Z88jYTxYRmaAZGVD/9dp/0TnSz//nS6Yt7wr+7ckqKuZmcvNlc50uLapkFJZzXV8fDUN/pne41+lyRGSamXEBVdVWxdaDW7ixu4fFqzbwr0/uZ2DYz398bAUez8xqF79gBSu4sbsX6xnmZ/sed7oaEZlmZlRAWWv5xkvfIMN4+bveYf6QsJYn3zjB/3nPfObnpThdXvQpWsWy4WGyBpPZenAr1p77nDERkcmYUQH1ctPLvN7yOn/b1k7C4o/yT081cFF+Kp97V5nTpUWnlFzIXcQHeqB5qI7XmrX0kYiEjysCyhizIfTvrqncz/177yc7JpEPd3eweeA9NHUPctf6FW/q2pOJMSVr+Gx/HQQSePjAw06XIyLTiOO/mY0xa4Ed1trNQGnodthVtVXx/PHnuaV3iOHcVWx6I55PXTGPi4szpmJ3M0fJGjIDA6R3lvFM/TO0DWjpIxEJD8cDCigFRkOpJnQ77O7fez8pMQnccLKeb3f/BbMzE9n43oVjv1DOb27wKrtXdcXisz4er1azhIiEh+MBZa3dHBo9AZQDleHeR0N3A8/UP8MN/niIzeXHnSv5+keWkxQ3Y89TDp+UPGzORVzvaSSdxfzi4C/wB/xOVyUi04DjATXKGFMOPGOt3RXubf9434+JwcNfNezjB/3v4fpL5vLOhbnh3s2MZUrWcAkH6D1ZwfG+4/z52J+dLklEpgHXBBSw1lp797keCDVQVBpjKltaWia00daBVn5Z/Uuuj80l1e9le8L7+MqHloSlYAkpWUNCYIA5HbFkxeeqWUJEwsIVAWWM2TAaTudqkghNA1ZYaytycyc28nlo/0OMBEa4peYNHvVdxT9+9AoykrSwaViVBNfhu9xzkAWJa3nu+HPUd9c7XJSIRDvHAyoUSHcZY44YYzrCue3+kX62HNzClbFFlI0McOyiv2btkvxw7kIAUvIg5yLWJh6ivm45XuNly8EtTlclIlHO8YCy1u6w1mZaa8tCH3eEa9uPVz9O93A3n2g4xAvmYj63/v3h2rScrWQNF9v91JywLM9cw7bqbQz4BpyuSkSimOMBNVV8AR8/qfoJJeTyzsFWkt75f0hPjHW6rOmrZA2x/n6uTj9O09FV9Az38FTtU05XJSJRbNoG1DP1z3Cs9xi3NB2lMWERK//iY06XNL2FjkN9vuQkh+pzKEwq5eEDD2t9PhGZtGkZUNZa7t/zAGm+ZNYPnCTrg18Fo5XKp1RKHuQuZmX/CxSkJWK7rmR/+35ebnrZ6cpEJEpNy4B6pekVDnTs56872unNXkny0uucLmlmWL4eT+ML/MOl8Rw6spD0uCx+tOdHTlclIlFqWgbUN1/+HvG+OP667yRp131Fo6dIWXEjAB+J2Ul2UjJJA+/mhRMvsK9tn8OFiUg0mnYB9VT1n6jq3MWnu3rwFl4KZVc7XdLMkVEMJVcRu3cLn1kzj0PVy0nypmgUJSKTMq0CqndwhNv/+J8kjcTzNz0niXnPP2v0FGkrPwHtNdw6p5m0uBQyfX/Bjvod1HXVOV2ZiESZaRNQPn+AWx5+gGFvHRt72omfexWUvtvpsmaeJdeDN5Hk/b/gU1fO4+ChlXg9sTyw7wGnKxORKDMtAspay78+sZeDQ1spDMTxkd5e+OA9Gj05IT4VFn8I9j7Kpy6bRVJMBrlcxa+O/IqmvianqxORKDItAupHO2v5edWviEk4yd+3Hsf7zi9Bznyny5q5Vv4lDHaRcfR3/NXlczl8eBVg+PaubztdmYhEkagPqO37mvj3p3aTWbSDi3yWa5OK4covOF3WzFb6F5BSALsf5jNrSokN5DDH836erHmSV5pecbo6EYkSUR1Quxs7+cLDr1E471kGaePLLS14PvRd8Gq1ckd5YmDljXBoO7kDNXziHXPYV1VBXmIBX3/p64wERpyuUESiQNQGVHP3IJ/+n0rSs2rojvsjt3R1c+nyW2DOZU6XJgBXfCF4POo3X+Jz75xHUmwiPcc+RHVnNT+r+pnT1YlIFIjagNpa2UhrfwcJeT+nbNjHF1IWwXv/3emyZFRyNlz9Faj7M7Maf8NDn13NcM8iYgaX8r3Xv6+GCREZU9QG1JNvnKC09DG6Rzr5+lA88Tc+BN54p8uSM636JMy6GJ6+nWU5Hh76zGpM2zoGfT6+9IfbNdUnIucVlQF16GQPTcOP0hK7l//VO8ySv3wk+Be7uIsnBj7wTeg5AX+8iyWFaWz59AfwdnyU11tf4v/93e1a7VxE3lZUBtR3fvdV/Pm/45r+QT79gR+qpdzNZldA+a3w4r1wtJKF+an84uYv4u1+L78/9hvu+PM3na5QRFwq6gKqpbuBPw4/w9o+H3d/8CG8897ldEkylqvvgLRCePDDUPsn5uel8Ohf3oG3bzWP1f4P33pRq0yIyFtFXUA1j/RweU8MVy77Kd7iS50uR8YjORv+ZjukF8NP18OBX1Oam8KjH9+Ed3ApDxz8Fjdv20j3YI/TlYqIi7gioIwx640xa40xt4313FQby5+O38HVq5ZHojQJl7RC+NRvoGA5bLkFdt5DabqXx9b/gBz/e9nd+TTv+vkH2br3d05XKiIu4XhAGWPKAay1O4DO0dtvp983i9ULCslM1sm4UScpC279JSy4BnZ8Ff7vMubt+QG/u/Gf+GzZN/H5Y/i3V7/A1Q/dyM/3b6V7uNvpikXEQcbpLipjzF3AM9baHcaYtUC5tfbut3t+/KwF9mdP/p71q2ZHrkgJv4aX4Ll74OBvwMRA/hK68lbylY4udgZqGI7rwWu8rMovZ37mAsoyyihJKyErIYv0+HTS49OJ9cQ6/b8QiRrGmFettRVO1zERXqcLADKA9jNun7df3ADXLs2fynokEuZcBnN+Ds37Yc8jcKyS9IO/4ttD3VigKi6OJ1OS2D3wZx47/iIDnrcO9r3WEmsh1oLXBqcDzOi/0N9d51rPXmvci0QHNwTUmIwxG4ANAJlF80hL0F/O00beYrj6X4KfBwLQUYvpPs5F3Sfp2nuA5R1teIaH6KWbdtPLgBmhz4zQb3yMEMBnAowYix+LBQKhjwCYMz4P0VlXItHDDQHVCWSFPs8A2s5+grV2M7AZoKKiQr9jpiuPB7LLILsML3DFSqcLEpk+/vtz0Td34HiTBLAFKA19XgrscLAWERFxCccDylq7CyDUINE5eltERGY2N0zxjU7hiYiInOL4CEpERORcFFAiIuJKCigREXElBZSIiLiSAkpERFzJ8bX4JsoY0wMcdLoOl8gBWp0uwiX0Xpym9+I0vRenXWStTXW6iIlwRZv5BB2MtgUPp4oxplLvRZDei9P0Xpym9+I0Y0yl0zVMlKb4RETElRRQIiLiStEYUFp14jS9F6fpvThN78Vpei9Oi7r3IuqaJGYqY8x6giu/v+0FHY0x5VrLUGaq8fyMhJ532/keF/dw9QjKGLPeGLPWGHPbZB6fLowx5QDW2h1A5+jts56zFvhhpGtzwji+LzaE/t0V6doibRzvxdrQv2n9XoznZyT0vLXApZGszQnj+L64K/RxQ2QrmxjXBtRY33Dj/YacJm4k+JchQA2w9uwnhN6H9rPvn27G8X2xFtgRWoC4NHR7Whrnz8g1ocfLZ/rPyEwxzt+NG4wxRwi+V67l2oBi7G+4mfQNmcGbwyfboTrcYKyve+kZ99Vw+lpj09F53wtr7S5r7ZdDN0un+fRvBmP8jISmwGfC9ebG87vx49baMre/H24+DyqD83/DjfW4TE8ZnOfrftalW8oJXhBzuspgHD8DoWmez0WiIJfLGvsp00IGY39flBtjYIzjdU5z8whKTuvk9A9XBtDmWCVRIjSt8cw0HzWMS+gX0OeMMRlO1zKFOjnPz8gMGj2Ni7X27tD7ke3maXA3B1Qn5/+lPNbj08kWTk9VlQI7AKb5L5y308n4vu5r3fyXYZh0MsYv5TOOP9QArj4gfoHG+hkpDTUOrA99Pp2Px3Vy/u+L0feB0GOunQZ3c0CN9Q13zseno9FRQOgvnc4zRgXPjj4n9A1XccY33nQ1ZlgbYzaMhpOb/zoMg7Hei7W8+ReVqw+IX4ixfkastY9Yax8h+H5kOFJk5Iz1fVHD6d+XZYBrl0By9XlQoRbIGoIHeDeH7nvVWrvq7R6X6e983xehX1C/IDgHn0XwYPC0/eNljPciA7iB4HtxjbVWx6FmiHH+7mwPPe7amQZXB5SIiMxcbp7iExGRGUwBJSIirqSAEhERV1JAiYiIKymgRETElRRQIiLiSgooERFxJQWUiIi4kgJKRERcSQElEgahhVmPGGN+ccbtDIfLEolqCiiR8FgLrALuG72MtrW209GKRKKc1uITCaPQqCnLWjttVw4XiRQFlEiYjE7paeQkEh6a4hMJA2NMKZwOp9HbIjJ5XqcLEIl2oauzVgDtxpgdBI9HdTKNLxAoEgkaQYlcgDOm9TYTvHppLXDpdL5Iokik6BiUiIi4kkZQIiLiSgooERFxJQWUiIi4kgJKRERcSQElIiKupIASERFXUkCJiIgrKaBERMSVFFAiIuJK/z9lB5dk/fdSWAAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -15431,7 +15166,7 @@ Wall time: 954 ms
 
 
 <div class="jp-RenderedImage jp-OutputArea-output ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABAfklEQVR4nO3daXSc133n+e+tFVUoAFUo7PtCUuIicRFlyYrs2DFjSfZMW7ZpxZE6fezElmNnnM7MUdvJHPtFT9ydkaLJ8fEko0i2x57EWax4UWdxIktyYlmxZImURIk7SAAksRFbFQqoQq3PnRdPFQCSIDbW9gD/zzk8ZFU99TwXJQg/3Pv8771Ka40QQghRbmylboAQQgixHAkoIYQQZUkCSgghRFmSgBJCCFGWHKVugBBCiPU7evRog8Ph+AawB2t3NgzgeDqd/tRtt902vvQFCSghhLAgh8Pxjaampp319fUhm81m2XJswzDUxMTErrGxsW8A/2Hpa1ZOXSGE2Mr21NfXR6wcTgA2m03X19fPYPYEr3ytBO0RQghx42xWD6ec7NdxTR5JQAkhhCiIkydPuu67776ejb5fAkoIIURB7Nq1K/nP//zP/Rt9vxRJCCGExf2X7x1rPzs2683nOXc0VcX++PDeSysd8/jjj9fdeeedsVdeecX7yCOPTD7zzDNVjz32WNOnP/3pyfPnz7vuvffe2S984QutP//5z/tyxweDwcz58+ddvb29yU9+8pOhlc4vASWEEGLdvvSlLzXee++9s3fffXdscnLS/vjjj9c98sgjk5///Oc7lwZPTU1NBuCZZ56pCgaDmU9+8pOh++67r+crX/nK5dWuIQElhBAWt1pPpxB+8pOfVD/44IMhgB07diSefPLJ+kceeWRyz549seWOv/vuu2Nf/vKXm7Zv35543/veF1nLNSSghBBCrNvevXtjZ8+ede/atSt59uxZ92233RZd6fjx8XH7PffcE7n55psTd99997IhdjUpkhBCCLFuTzzxxPCRI0e8zzzzTNWRI0e8X/nKVy4/88wzVcePH/e+9NJLXoCXXnrJe/z4ce/JkyddAE8++WT97/7u77bdd999PbljVqJkPyghhLCeY8eODe7du3ey1O1Yq89+9rOtTzzxxPD1Hh87dqxu7969XUvfI0N8QgghCu6hhx4Kfetb3wps37490dfX537ooYdWrOADCSghhBBFcPfdd8dy957kHpQQQghLk4ASQghRliSghBBClCUJKCGEEGVJiiSEEEIUxDPPPFMF8Oyzz1YvLSlfK+lBCSGEyLuXXnrJe+TIEe/9998/e+zYsYXJuushPSghhLC6Z36nnfGTeV3NnIZdMe7/s+uu8ZdbufwLX/jC2JEjR7y9vb3JQCCQfvrpp2u/9rWvDeXKyicnJ+1dXV3JXbt2JdfbBOlBCSGEWLf7779/9tKlS+77779/9sEHHwx9/etfr7v//vtnDxw4EF26jNFLL73k7enpiW/kGtKDEkIIq1uhp1NIS1cu37t3bwwgGAxmlh5z//33zz799NO13/rWtwKr7f90NelBCSGEyLvPfvazrY8//ngdQE1NTXpqasq+3nNID0oIIcS6LV2p/Ec/+lF1rhDiueeeq66pqUl//vOfnzh79qz7mWeeqZqZmXE88sgj667ik9XMhRDCgqy2mvlqllvNXIb4hBBClCUJKCGEEGVJAkoIIURZkoASQghRliSghBBClCXLlZnX1dXprq6uUjdDCCFK6rHHHuPkyZOdaz0+kUik9+/ff6yQbco3ywVUV1cXR44cKXUzhBCipE6dOsXOnTvXfPzx48fXvRbejaqurt63Z8+e6K/8yq9EvvKVr1xe7/stF1BCCCGs4S/+4i/O33///bMbfb8ElBBCWNyjrz7K6enTKx4zF52rcAw6blrrObcFtsX+8Jf+cMOrmdfV1WVCoZDj5MmTro2sZA5SJCGEEGID1rKa+dTUlL2hoSHz4IMPrvle2VLSgxJCCIv74ju+uOoxx48fj+/Zs+dMPq+72mrmjzzyyCSYi8XKauZCCCHKwuOPP163dF+ojZCAEkIIsW4rrWb+7LPPVn/iE58IAXzrW98KAKy39wQWXM384MGDWsrMhRBb3QbKzGN79uw5VcAm3RBZzVxsyItDL3I2dLbUzRBCbDESUGJF8+l5fu9ff49P/MsnOBc6V+rmCCG2EAkosaI3Lr9BykiRSCf47Auf5XJ03ZPBhRAFYrVbNNdjGIYCjKufl4ASK3pl7BUcNgffvOebzCZn+dwLn2M2ueGJ4UKIPKmoqGBqasryIWUYhpqYmKgBjl/9msyDEit6ZeQV9tbvZV/DPv7kPX/C7zz/O3zhxS/wxKEnSt00Iba0trY2hoaGmJiYWNPxY2NjjkwmU1fgZm2EARxPp9OfuvoFCShxXaF4iNPTp/ncvs8BcFfLXXz61k/zxLEnmJqfIugJlriFQmxdTqeT7u7uNR+/a9eut7XWBwvYpLyTIT5xXa+OvYpGc2fznQvPvbPlnQC8OfFmiVolhNgqJKDEdb0y+gqVzkr21O1ZeG5XcBdOm5M3x98sXcOEEFuCDPGJa0TiKR7959P8ZO5nNHv38FLfNG0BL20BDxVON7uDu3lj/I1SN1MIsclJQIlr/NuZCf769TfwbbvM8XPv4BOvvbbwWkOVm8auVoaNH5PIJHDb3SVsqRBiM5OAEtc4MTKDu+o8AN956DewpRsZCsW4ND3Pz/omeGOgFk97ihOTJzjQeKDErRVCbFYSUOIaJ0ci1AQu4PM08I7Wm1FKcXtXLQC3tNbwm39p7mH2xvgbElBCiIKRIglxBa01J0bCpFxnuaP5DpRSV7y+s7kanfERcLZKoYQQoqCKHlBKqcNKqeeWPPYrpQ5kn3+02O0RV7ocSRBOXyTFLHc033HN643VbgJeJ5V6G29OvGn5WexCiPJV9IDSWn/vqqceAA7mnldKPVzsNolFJ0dnsLnHAbOk/GpKKXY2VxOfayecCDMQGSh2E4UQW0TJh/i01k9prZ/KPuwB+kvZnq3uxHAEm9PcV6zV17rsMTubqxkZawKQYT4hRMGUPKBylFI9wLTW+vllXntYKXVEKXVkretOiY05ORqhuipCbUUtXufyuzXvbK4mMR+kylkj86GEEAVTNgEFHNZaf2a5F7K9rINa64P19fXFbteWcmIkgsc7c93eE8DO5ipA0erZKT0oIUTBlEVAKaUOa60fy/5b6pZLJBJPcXE6hmGfos3Xdt3jtjX4cNgUHqOXwcgg0/HpIrZSCLFVlKKK7xBwUCl1eMnjR5VSR5VSR4HaYrdJmE6NRACDucwkrVXX70G5HXa2NfiIRdoBeGvirSK1UAixlRR9om72HlPgqse9xW6HuNaJkQjKMYOhMysO8QHsaq7mpX4/qkVxavoU72l/T3EaKYTYMspiiE+UhxMjEQI1c8D1K/hydjZXMz4Dbb4OzkyfKUbzhBBbjASUWHByNEJzXRRgxXtQYAYUQIO7m9PTpwveNiHE1iMBJQBIpDP0XZ6lumoWm7LR5Gta8Xizkg/cup3huWEiyUgxmimE2EIkoAQAfZfnSBsahytEo7cRp8254vFBn5uGKjfzc2aQyTCfECLfLBtQ5yfmuPerLzIcni91UzaFkyNmDyjOxKr3n3J2NlczNmEWXUpACSHyzbIB1Xd5jtNjs3z3tUulbsqmcGJkhkqXnan4GG1VK99/ytnZXM3AZRvBijpOTZ8qcAuFEFuNZQMqbRgA/OD1IQxDVtS+USdHI9zUXMHE/Hp6UFWkMpr2ym3SgxJC5J11AypjhtJQaJ5XB2UlgxthGJqTIxG6GhPA6iXmObuylXw+WwfnZ86TyqQK1kYhxNZj2YBKZcwelFLw/aNDJW6NtV2cjhFNZgj6syXm1xviMww49wIc/wEA3XWVuBw2jHgzaSPNufC5YjVZCLEFWDag0tlhvbu31fGjt0eJJdMlbpF1ncgWSHi8M8AyPai5cXjxcfjaPvjOR+B7n4Sf/QkOu42bGquYmq4DkPlQQoi8sm5AZXtQv3Z7O9FkhmdPjJW4RdZ1YmQGh02Rtk3isrmo89Qtvjh7GZ64C37yh+DvgI9+E/Ychhf+K7zy5+xsruL8qAePw8OZkNyHEkLkT9HX4suXVPYe1F29dbQFPHz/6DAf3r+26jNxpZOjEbY1+BiNjtDia8Gmsr+3aA1//3lIzMKn/xVaswvN7/oQpOPwL1/kQzu/xNPRXdxRvY1TU1LJJ4TIH+v2oLJVfE674iMH2vj385OMyJyoDTkxEmF3Sw3Dc8NX3n86+m3oexYO/dfFcAKwO+Hwt2D7+7nr1H/jgDpLrbObM6EzGNooevuFEJuTZQMq14Ny2m18ZH8rWsMP3xgucausZ3w2zsRsgl0t1QzNDS3ef5o6D8/+79DzHnjHw9e+0eEyQ8rp5aP2n2FPtRJNRRmek/8GQoj8sGxA5crMHTZFV10lBzsDfP/1IbSWOVHrkVtBortBMZucNReJzaThBw+bPaUP/T9gu863iduHuulePuB4jeiMFEoIIfLLugGVHeKz2xQAH72tjf6JKMeGZkrZLMvJVfBVV80CmBsVHv8+DB+BD/xfULPKnKjdHyFAhODIRezKLgElhMgbywZUKqNx2hVKmQH1wVubcTtsMidqnU6ORmiv9RBOXgayJeavPgXB7bDno6ufYNshEvZK3jH7MzqqO2VFCSFE3lg2oNIZA8eSoafqCifv393E3x8bIZHOlLBl1nJyJMLu5pqFe0ets5Nm7+kdn77+0N5SzgomWg9xj+1Vmt3dUmouhMgb6waUoXHY1RXPffRAKzPzKX5yarxErbKWuUSagcmoWSAxO0SVs4qaN/4GXD7Y++trPo/j1o9So2I0zGUYi44xk5BhViHEjbNsQKUyBk77lc1/1/Z6GqrcfP91GeZbi9Oj5v2n3S3VjEXHaPE2mPef9n4cKqrXfJ6GvfcyoyvZMXEekK03hBD5YdmASmc0DtuVPSi7TfHh/a3825kJJucSJWqZdeQKJHa31DAaHaU5lYRMAm7/9LrOY3O6ec3zS7xn+k0AGeYTQuSFZQMqZVzbgwKzmi9taP7HmyMlaJW1nByJUFvporHazWh0lKbpi9D9bmi4ed3nuthyL+3pKEGHT3pQQoi8KHpAKaUOK6WeW+a5Q0qpZWaELi+dufYeFMCOxipuaa3hGZm0u6oTozPsbqkmlo4RSUZojoXX3XvKcW17D9PaxzbDztnQ2fw2VAixJRU9oLTW31v6WCl1OPv889nHh9ZynrRhXDPEl/PuHXWcGo0sbMkhrmUYmrOX57i5qYqxqLnQbrOjCm76wIbOt7M1wFFjB9uis5wLnyNlyN5QQogbUw5DfLcD/dl/9wMHVjh2QTqjlx3iA+ip85E2NBenY/lp4SY0MZcgmTboCFYyGrkEQHPrHWDf2PrBNzVVc9zoZs/sBCkjxcDMQD6bK4TYgsohoPxXPQ6u5U3LlZnn9NRXAtA/Eb2Rdm1ql7Lh3RbwMDr0MgBNvb+64fP53A7GfDdzczIJSCWfEOLGlUNAhYHalQ5QSj2slDqilDoyMTEBmGXmjutMJO2p9wHQPzGX14ZuJkMhc+X39oCX0dEj2LWmfscHb+ic0do9dKVSuJTchxJC3LhyCKjXWOxF9QDPXX2A1voprfVBrfXB+vp6IDfEt3wPqsbjpM7nkh7UCpb2oMZC/TQqB3aP/4bOWVXfRogAvapCelBCiBtWiiq+Q8DBJcUR3wN6ss/7c8USqzGLJK7f/J46H/2T0oO6nqHQPPVVbipio4ym52iqqL/hc7YFvBzLdLEjEedM6IysLC+EuCGlqOJ7XmsdWFrNp7V+LPv8Y2s9T+o6ZeY5vQ2V0oNawaVQjPaAB/qeY9ThoLl2+w2fsy3g4bju5ubIFNPxaSbnJ/PQUiHEVlUOQ3wbkr7ORN2cnjofU9EkMzEpd17OpVCMtoCXTN9zXHbYaa7dccPnbAt4edvo5qakuYqHrCghhLgR1g2ojF7YC2o5uUq+8zLMd410xmA0HKfT72DqwouklaLZ13LD522v9fC20cMOqeQTQuSBZQPKXCx2pYAyK/nOj0tAXW0sEidtaPbr04xqs7fTVNl0w+et97mZcQSx22tpVi4JKCHEDbFsQKUNvWKRRHvAg9Ou6J+U+1BXy5WY75h9mVFXBQDNlc03fF6lFG0BD/3O7dyUysgQnxDihlg3oFYpknDYbXTUemUu1DJyJeYNl3/GWF0PkJ+AAvM+1HHdzU1zIQYjgyQysqq8EGJjLBtQqYyBc5UdX3vqfVLJt4xLoXn8ag7X9FlGqxupclbhc/nycu72Wg+vzHewLZnE0AaDM4N5Oa8QYuuxbECttNRRTk99JRemYmQMmY+z1FAoxnt95vp7o04nTb4bv/+U0xbw8kq8g56kWT3ZP9O/yjuEEGJ5lg2o5XbUvVpvnY9kxmAoJIvGLjU0Pc8d7guAYiwTz9vwHphLJ40ToNURwAacC5/L27mFEFuLZQNquR11c7TWpIwUvQ2yaOxyLoVi7OEc1G1ndH48rwHVFvAAEPPvosNQ9IelByWE2BjrBpRh4LhOD+pP3/xTPvI/PkJ7rRuA81IosSCZNhiLzNOdOE2sZR/hRDgvJeY57bVeAIYqttM7H+O89KCEEBtkyYDSWpNaYbHYE1MnGIwM8u9jPybgdUqp+RIj4Xma9DSVqWnG6nqB/FXwAQS8TrwuOwO6hZ5UkouzF0lmknk7vxBi67BkQOWKHq43D2pkbgSAbx7/Jt31Xpmsu8RQaJ69tvMAjNWYwZTPHpRSivaAl5PJBnqTKTLa4ELkQt7OL4TYOiwZUOlcQC3Tg9JaMzo3Sld1FxciF/D6j0sPaolLoRh7befRNiej7vxN0l2qLeDhjblatqXMSr7zM+fzen4hxNZgyYBKZQyAZYf4puPTxDNxHrjpAbprurmk/5GJ2TizcVk0FsxJuvts56FxD6PzE9iUjXrvjW+1sVR7rZczM3Y6nH5swPmwBJQQYv0sGVArDfHlhvfafG186pZPMZ26gN13Sir5soano9xqG0C13cZodJR6Tz1OmzOv12gLeJhLpHEGemjTDgkoIcSGWDKgUhkzoJbrQY1EzYBq8bVwX/d9NHiacdf9K+cnZovaxnJlTJ6lknloOcBYdCzvw3tgTtYFiHi76E0mpNRcCLEhlgyotGEO8S1XZp7rQbX4WnDanPzmnt/E7rnEa6NvF7WN5ap25oT5j1azB1WIgGqvNedCTbja6J2f40JkkFRGhliFEOtjzYDK5Ib4lulBzY1Q5aqiylUFwDtb3gHAuemB4jWwTMVTGXoSp0naK0nXdpsB5StcD+qCaqYnmSKtM1ycvZj36wghNjdLBtRikcQyPajoCC2Vi5vv5UqoR+ZGi9O4MjaUreCbCexmJHaZtJGmq7or79ep8TiprnBwJtW4WMkn96GEEOtkyYBaqcx8ZG6EliW7w3qdXlyqilByHGPsBLzwh3Dp1aK1tZwMTYbZqS6SbtrPYGQQgK6aroJcqy3g5a1YLV2pDAoJKCHE+jlK3YCNyPWgrq7i01ozMjfCHc13LH2SRuWm1vkKtj//rvnc6JvwH79fpNaWj9jFY7hVGk/X7QvbYBSiBwXmfaj+iSiemjZalVvmQgkh1s2aPajr3IOaScwQS8euGOLj/E/YPnuRkMPg/P4/gFsegAsvw1a8aT92HIDq7oMMRgapcdcQqAgU5FJtAS+XQjF0cBvb0ob0oIQQ62bNgFqo4rsyoHIl5q2+1sUnL75MU8bggsPNT4MPwM0fhFQURt4oWnvLhTt8lnnc2AKdXIhcoLO6s2DXag94iKcM4tXd9MRmGYwMkjK24C8FQogNK4uAUkodVkodUko9vJbjF+dBXdn8XIn5FZVpQ6/R7KlD2ZOcmZiArneZzw+8mIeWW0tttJ8xVwfYbAzODBZseA8WK/km3e30xqOkjTSXZi8V7HpCiM2n5AGllDoE9Gutnwf6lVIHVnvP9Yb4cgG10IMyMjB0lJbADgD6pi5CZRAadm/JgGpJXSBU2UssFWN8frygAZXbdmPY1kpv0lzNXCbsCiHWo+QBBRwB/i4bTD1a69dXe0PqOhN1R6IjeB1eql3V5hOTZyE5S3OzmXmXImaA0f0uuPQLSCfy9kWUu7mZKRqZJhHYUfAKPljcuLAv00hHKg0gc6GEEOtS8oDSWoeBJ4G/A25b7hil1MNKqSNKqSMTExMLPairlzoanhumxdeCUtnnh14DoLnzlwEIp8aJJtLQ/W5Ix2HoSCG+pLI0NXAMAHvjzQWv4AOodDuorXRxer6GKpuTWpuLixEJKCHE2pU8oLJDfM9rrXuBsFLq8NXHaK2f0lof1FofrK+vJ32dMvPRudEr5kAx9BpU+Klt3o9DObE5wwxMRqHzLkDB4M8K+JWVl+gls4LP134LFyIXUCjaq9oLes22gIeLoQTU9tCuHXIPSgixLiUPKODAkmG9PwJqV3tDyli+BzUyd+UqEgwdgbbbsdns1HuaUI6wuf27JwDNt26p+1B6/BQx7aaxfTsDkQFafC1UOCoKes32gJfh0DwEt9GRTMgQnxBiXcohoJ7KDuEdAh7QWj+12hsWelBL7kFFkhFmU7OLPah4BMZPQdvtALRVtWBzhRe33eh6l9nDSs3n96spU55wH+dppdZXwYXIhYIO7+W0BTwMhebRtb20R8OMRceIp+MFv64QYnMoeUBprcPZIbzn1xJOsHwV32h2rb2FgBp5HdDQdhCA1qpmHK6Zxd11u38ZMkmzWGILqI31M+rqAmBwZrCgc6By2mq9JDMGkcpO2pNmQcrw3HDBryuE2BxKHlAbkaviWzoPKveDb6HEPFsgQatZd9FS2YK2RTg/ETaf73wnKDsMbIH7UPMh/Jkpwr5eJuYniKVjBa3gy8lV8o06WulIm5V8ch9KCLFWlgyohR7UkntQo1GzB7Wwv9HQEai7CTx+ILuqudIMhEYwDA3uKmjZvyUKJfT4KQCSgR1ciFwAClvBl9Oenaw7YDQtlppLJZ8QYo2sGVC5IgnblT2oCnsFtRW1oLXZg8ref4LFob+kmmIskr0P0nGnueSRkSle40tgftjcpNDRtIuBGXNfrGLdgwI4F/VSY3NRpZxSKCGEWDNrBlTm2rX4RufMzfeUUhAagNgUtC1Oq8r1rJRzSaFE3XbzPtTMUPEaXwKx4RNEtRt/czcXIheosFfQWNlY8OtWOO3UV7kZCsdR/k46kFJzIcTarTuglFL7lFIfUUo9opT6VPbf+wrQtutabj+o3CRdYHEC7pIeVG7jQpszRP/knPlkba/59/QmX2l7/DR9upW2Wh+DkUE6qjuwqeL8btIW8HApFINAF+2ptAzxCSHWbE0/pZRSXUqpP1dKPQt8BugFZgCV/fdvK6V+rJR6QinVVbDWZi3sqLtkiG80Oro4B2roCDi9UL9z4XWX3UWdpw6XO7LYgwpmA2pqcweUd6aPPqON9oC3aCXmOe0BL0OheTOg5mcZjY7KquZCiDVZdcNCpdR/wZw8+0Wt9cwqx9YADyulQlrrb+SpjddIZzQ2BbZsmXnaSBNOhKnz1JkHTPVB3Q6wX/nltVS2MOeJMDiVDaiqZjPIpjfxIqaxabzJSS44OvC6YWh2iHu67ina5dsCHn709iiGv4OOeJRMVQWjc6N0VHcUrQ1CCGtasQeVDafvaa3/YLVwAtBaz2it/xh4QSn1SL4aebWUYVwzSRegxl1jPjE9ALXd17yvqbIJ5QwzmJsLpRTU9mzugJo4DUDEt41Lc5fI6Exxe1C1XtKGJuRulUVjhRDrsmJAaa3/WGs9sN6Taq0HtNaPb7xZK0tnNM4lk3TDiTAAfrcfMmmYuQSBawOqubKZJFMMhWILw4TUdm/uIb5ciXntjoXtLrprrv1sCiVXyTdMPR1pc2hP7kMJIdZiI0USXQVox7qkM1f2oGYSZufO7/ab4WSkl+1BNfuayZAio+YYCWeXOKrthdCgGWybkB4/xZz2UFnfxVsTb+G0OdmR3R+rGHJzofrT9QQzBh4llXxCiLXZSClXQCn1qdwDpdRHlVK/ksc2rSpl6CsWig3Hw0B2iC+U7fBdpwcFZqn54FTMfDLYC0bKDLZNKDV+hnO6mbZaL8cmjrEzuBOX3VW06zf7K1AKBiIK5Q3SbquQIT4hxJqsO6C01m8A23KhpLX+PvB+pdRv5btx15POGNiXGeKrcdeY959g2R5Urgzd5gxxIVcosVBqvknvQ02ep1+30Fzj5MTUCfbW7y3q5d0OO03VFQuVfB0ZQ3pQQog12cgQ37OABo4umf/0R8BjeWzXitIZfcVeUFcM8YUGwO6GqpZr3pfrQbkrIua+ULBYar4ZAyo1jys6zIDRRMY5TCKTKHpAwVVzoeLzDM0Okdnkq3cIIW7cRob4eoEns1V9Klta/vXsn6K4ZogvEcahHPicPrMHFegE27VfWrWr2twSvmqOC7khPl8jOCs3Z6FE9msa0M1cTp4BKElALewL5e+kIxoiZaS4HLtc9HYIIaxlIwH1fuCLSqnq7HDfIeBVrfXv57dp13d1kUQ4EabaXW0uczQ9YJaOL0MpRYuvBZc7vDgXaqHUfDMG1DkAJis6OD19nEZv48KKGsXUFvAwOjNP2t9JR3bbDbkPJYRYzUbuQfVrrT+rtY5kH38fmClmoUQqo6/YC2omMWMO72ltVuQtUyCR0+prRTumuTQdI5NdMongJp0LNdUHgA50c2ziWEl6T2DuC2VomHI00y6rmgsh1igvC7Jprb8OrHu+1EalDeOKvaBmktmAmhuHVHTZAomcFl8LMWOCVMbY/KXmU+cZJ0igzsFIdKR0AZWdC3WJBhozGVzKLoUSQohV5W3F0I1M6N2odEZfsVBsOBFetcQ8p9XXSsKIgW1+cZgv2GvOnZrZXL/VG5N99BlNuCrNMNjbUJqA6qg150L1zddgU3ba7JXSgxJCrGrVpY42MjFXKdVd0KWOMsYVC8XOxLM9qBVKzHNyO+7aXKHFuVC5e1ZTm2iYT2v05DkGjCaS9n6cNic7a3eu/r4CaK7x4LLbGAwloKaNVq0YiY6UpC1CCOtYdakj4FeVUn+0lqBSSlUrpf5P4KMFXerIWOxBaa0JJ8KLJeYo8F9/IdJcQLkrwlyY3MRzoWLT2BNhBnQz46mz7AruKuoE3aXsNkVH0Gv2WANdtCaTDM8Ol6QtQgjrWHU1c63115VS3ZhbauwH+oEwcB7wA8Hs373Z5x4r9HBfOmNQ6TabPp+eJ2kkqXZXw4VTUNMGDvd135ubrFtbM7fYg/I1gMu3uSr5shV8fbqBC7Ov8PGbP17S5nQFvQxOxqC3k7aLZ5m1O5lJzCwu8CuEEFdZNaBg4f7S74M5fAf0ZP/MYBZH9GdLzositWSx2Gsm6a4wvAfmahNVziq83si1peabaS5UtoJv2OcmaSRLViCR0xWs5KVzkxi3ddFyOgxV9QzPDUtACSGua00BtVQ2rAaAF/LVCKXUAczAQ2v9vdWOzywZ4rtiJfPpAbj5g6ter7WqlchciIEps9TcblNmocTosY1/EeVm6hxpHGRq40BpJugu1VlXSTxlMFPRQmvarJYcmRthV3BXSdslhChfG6riy271/kfZv6vz0I4/yAZTrVJq+Vm2SyzdD2phHT7lhNjkqj0oMDcuTDJJMmMwFjF/gFPbA6ELkNkku71O9jGsmrB5L9FU2URjZWNJm9MdrARgSDcuBNTwnNyHEkJc30bW4vtzYBvmdu8PAAM3slCsUuph4DWlVI/W+imt9aqVCunlhvjis+aLK5SY57RWtRJJjwP6ykIJnYHw5ih/1lPnOJNpYFad5bbG20rdHDqDZqn52VSQGkNTZXMxNDtU4lYJIcrZRnpQz2mtfz/75/2YxRHblVIf2WAbejELLaaVUk8qpfxXH6CUelgpdUQpdWRiYuKKpY4WAioaMg9eQw+q1ddK0oij7FEGpjbhorFGBj09wFF7LXEjzO2Nt5e6RbT4zVLzsxEnuHy02iqkByWEWNENT9TVWoez6/AFb+A057XWYeAo8PAy13hKa31Qa32wvr7+isViF+5BzWUXH11LDypbau6qCC8uGuvvNP8OX7iBL6NMzFzClklwzGPeYry9qfQBZbcp2ms9ZuVkoIuWjCEBJYRY0UYCql8p9ZpS6sNX3X+a2mAbXlvybz9mCfuK0hljYbuNcCKM1+HFGboI3iBUrH5LLFdqXh+IMpgb4vM1gt21OYb4siXmlzwx6ioaaK9qL3GDTN11lWapeaCL1kSckbkRtNalbpYQokxtJKB+DXga+HVgMBtW3yVbhQewnoVjs8URfqXUoezjp1Z7z9KljhYWig0NrKn3BIs9qOqq2cUelM0GNe2bI6Amz6GBWe8EdzTfbq7yXga6gpVcmI6i/Z20RkPEM3Gm4hv9vUYIsdmtu8wcczLuc9lVJshO3j2EuavuH2BO5AVY87iS1jq32eHzazk+tWSx2IV1+C6dgo4713S9SmclfrcflwpzaiqKYWhstuwKFJshoKbOccpVhXZEy2J4LydXah7xtNKWmAeqGJ4bps5TV+qmCSHK0Ea22/g6EMgtfaS1fkNr/cda6/drrYPAZ4BQfpt5pfSS7TbMHlQNRIbMjQrXqNXXimGbJpE2uDybLTXfRAH1fIX5Q7+cAipXaj6immlJmzvqypJHQojr2VCRRDaUBq/z2uvAF2+kUatJG4sBFU6EzTlQ2lgsdFiDFl8LUWMCwLwvAmbARScgGct7m4tJT/XxisuF11ZbNvefYLHU/Hy6bnGyriwaK4S4jrxtt7FUIZc9yt1SXzpRtyb35Dp6UG2+NkLJy4DBhVypeS7gZiy8V1FqHj0zzDlPmp6qW8vm/hMslpqfnK/Bq6HW5pa5UEKI6ypIQBVSrujLYVdkjAyzyVn8uY0GV1jF/GotvhZSRhKXK7q4aGzu/VYe5ps6z6DTzrwjxYGGg6VuzRVypebnp1NQ3UorTik1F0Jcl/UCKtuHctpsRJIRNBp/Mg7KBtWtaz5PrpKvKRhbLDVfCCgLz4WaOseRigoA3td1V4kbc63uukqzcjLQRUs6LQElhLgu6wXUkh5UbhWJmvisGU5255rP01plBlSgZm5xVfPKBrC7Ld6DOsdrFW5IV7OvqbfUrblGZ7CSwakoOtBJazzKaHSUjJEpdbOEEGXIcgHFQkDZFleRiIbWNbwH5oKxAB7vDBemYuaEUZsN/NaeC6Un+3jV48WTuQmbrfz+83ZlS83nvO20xmZIG2km5idK3SwhRBkqv59gq1gc4lvsQfnnxtcdUBWOCuo8ddicIeZTGSZmE+YLFi81H5k+y7Rd0Vxxc6mbsqyubCXfqK2JtmwlnxRKCCGWY72AWq4HFbm8rhLznBZfCwkmARhYeh8qZNF7UFpzfM4M12015bnPUld2LtSgUU9rSrbdEEJcn/UCKvu3064W94IyMuvuQYFZKGFuu8GSRWM7zH2lktE8tLbIYtOcUGlsWrG3YWepW7OshVLzeC3N6TQKc+NCIYS4mvUCKtuFcthszCRmsGOjytAbCqiu6i7G50dx2FOLhRILq5pbcC7UVB8n3C4q4n621ZfnVuq5UvNTYScul496WwVDczLEJ4S4lvUCKvu3I9uDqrG7UbChgNoV3IWhDZrrp6/sQYEl70MZk32cdLvIxNvoqqssdXOuq7uukgvT8xDook0rGeITQizLegGVTajcEF+1coCyr2sOVM6uoHmfpqpmbEkPyrpzoS5cfoM5m41YcgdN1RWlbs51LZaad9GaTEpACSGWZbmAyvWhckN8fkNDTSvY178we4O3gXpPPapiiMHJqDl86GsER4Ule1Anpk8D0ODeYa7OXqZypeaxynZaYhEuRy+TyqRK3SwhRJmxXEAtnagbToTxp1MbquDL2RXcRZRBoskMk3NJUMqy+0KdiI3iNKDXX34TdJfKlZpftjfRloyj0bJorBDiGtYLqOzfTrvZg6pJzm/o/lPO7uBuppNDoBJLFo214FwoI8MJI0Zdwkt3sKrUrVlRrtT8om6gPVtqfmnWgkUpQoiCsl5A5XpQNsVMIow/MXdDAbUruAuNxl4xeuWisRYLqPT0AKdcDlzxOjrLuEACFkvNzySCtKcloIQQy7NgQJkJpUkRzyTwZ4wbDigAh3foyh6UxeZC9Q/9nLjNRnK+c2EIrVzlSs3fnqumPmNQoeyymoQQ4hrWC6js3/NGBMhN0t34Pah6bz0N3gZ81WNXriYBlpoLdeLyEQAm53cuDKGVs+66Ss5Np1A1bbQpl/SghBDXsF5AZRMqlp4FuOEeFJi9KOUeXjIXKjdZ1zrDfCfCfVQaBrOZLppryrfEPGfpquZtaUMCSghxDesFVLYPNZ8xe1B+raCq+YbOuTu4m4QaY3B6yhxCtOBcqOPxCXpSDtoDVQu7DZezXKn5fGU7bfEYw3PDC8O3QggBFgyo3BjfXCq7krmnbkNzoJYy70NpYlwkFEuBryE7F8oaAZXMJDmj4zQkq+ks8/tPObn7ZJPOFtpjM8yn55mKT5W4VUKIcmK5gMr9jh1JhQAIVrfd8DlzhRI2z7B5H0qp7Krmgzd87mLoG3+btFIQrS/rJY6WWig1Vy1SySeEWFZZBZRS6tHVjskNA80kp7Fpjb+m+4avW+epo76iEXvFEGcvm/e2CHTD9OANn7sYTg29BEAk1mWJAglYLDU/nW6UuVBCiGWVTUAppQ4BPasdl+tBzcQnCGQMbLVdebn+LfW7cXpGOD5sDh1S2wOhgcWqjDJ2duItvIbBSLLXMkN8uVLzN+fqaElnUEhACSGuVBYBpZTqAfrXcmwuL8LREYKZje0DtZzddbvBNcFbI5fNJ2p7IDkH0fLfjrwvMsj2ZIoB3WKZHhSYw3znQilc/g6alEvmQgkhrlAWAQX0aK2vG1BKqYeVUkeUUkfmouZcpVBsgqCRMdfNy4Pcfai+8EnSGQNqs0OH02vKzZLRWnM2MUVHxkXa5qY14Cl1k9asqy5bal63g/Z0RnpQQogrlDyglFKHtNbPr3SM1voprfVBrfVBr9ccwppOhAhmDLOnkwf76vdhw4ZRcY7zE9HF85Z5QI3HxomQIWAEaQt4cFqgxDynK+g1VzWv6qZ9PioBJYS4Qjn8NJtWSh1SSh0GepRSB1Y6WAN2G0ynowS1Daqa8tIIn8vHTYFbcFT2mfehatrNfaamB/Jy/kI5O3kCAJ1sptNCw3vAQsXhZVc7bck40/FpoinrLC8lhCiskgeU1vr1bA+qFvCvfjw47EniGATdAbMkPE/e23E3tophjg5dAocLatrKvgfVN/IKACNzXWW/Bt/VcvfLBmmlLVtqLvehhBA5JQ+onOwwXq/W+vUVj0PjdJlLEgUrG/LahrtbfwmlNEfHXzWfqO0p+4A6O3GcxnSak/NdlutB5UrNjycbaE+ZGxZKQAkhcsomoNZMg8tploIHq/NTwZezK7gLp6pkOHEMw9CLpeZlrG/uItuTaQZ0s+V6ULlS85MzHtptZtvlPpQQIsdyAaWBoMPcfbW2dltez2232dlWtR9dcYbBqahZyTcfgth0Xq+TLykjRX8qQiceUjjotsgqEkt1BSsZnI5RXdtLDTYJKCHEAusFlAa/fRSAYN2uvJ//XW13Y3NG+Mn5txYr+cq0FzU4M0gaTY1RT1WFw1JzoHIWS823057OMDQnQ3xCCJP1AgqNx2FOng007c37+f/DjvcA8LPhf19Sal6eAdU3cRyA+Hwr+9r92Gz5Kxgplh2NPuIpg2lPJ23xGJci1ligVwhReNYLKA1O2wz+jIHzBrfZWE5nTSuOTCN9kdch0GU+WaYBdXb0VRxaczbUwf52f6mbsyEHOgIAnEk3055OMxodI22kS9wqIUQ5sGRAZWxzBJUzryXmS7VV7GOWM8SVgqqWsq3k65s6TXcqxVmjg30d/lI3Z0N6631UVTh4dTZIeypNWmcYjY6WullCiDJguYACTdwWJ+goXMXabQ13gi3Fc/2/KOtS87PRYbYlMwzqJva2+UvdnA2x2RT72v28cLmStnQGkFJzIYTJcgGltSZizxCsCBTsGvf23oXWdn7c/6JZyVeGRRKRZIQxY56mTCVtwSqCPnepm7RhBzoCHB9P0OZpBOCC3IcSQmDBgHLoFNN2O0FvY8Gusbe1ESPWyVtTr5oBNXcZEnMFu95G9IX6ALDFg+yz6P2nnAOdAbQGl6cTn4Zz4XOlbpIQogxYLqDsOkHUZsv7JN2lPC47frWb6fQgU1XZ1SrKrBfVN/E2AOFom2ULJHJyAXtRtdGbTHE+fL60DRJClAXLBZRNJwGore0t6HV2+g8C8Asj23Mqs/tQZ8eOUpUxGE51s6+jcMOdxVDjcbK9wcdb8/VsSyQ4Fzq7sHOyEGLrsl5AYQZUIXtQAHe03oLOePi3XM+pzErNz0yfYUcyyYCti13N1aVuzg3b3+HnxVCAbakU4WSEqfhUqZskhCgxywWUwpwjE/QEC3qdW9tqSUd7eWX8KNpbV1Y9qIyRoW9+nB3JDDXNvbgclvvPeI0DHQHenG+kN2n+AiLDfEIIC/5kywZURWEDaldLNZnodkLJcQZrO8oqoC7MXmCeDDUJH7d2FPZzKJYDnQGmqKHVZg5XSqGEEMJyAaUxAKj11Bb0OtUVTpqctwDwss8HocGCXm89Tk+eAiAx385+i99/ytmWnbA769hGjSEBJYSwYEBllMKtnbjthZ/3c2tTL7Z0kJdtaZgZKptS89MjL+PQmuHEzZav4MvJTdg9muykNxnn/PTZUjdJCFFilguoNFChqopyrd2t1cRne3k1MUEaDeMni3Ld1ZweP8b2ZIqLFbtpC3hK3Zy82d8R4N9mW9iWTHEu1CeVfEJscdYLKKVw2go7vJezp6WGTHQ7MSPBcbcLxt4uynVXorXmTHSY3mQGf/tuVIHWIyyFAx1+3sr0sC2ZYjYzz3hsvNRNEkKUkOUCKqUULntxCgN2t1STjvUAiper/GURUOOxcaZ1isq4n32dm6NAImd/R4BJamjVPkAq+YTY6iwXUGkUHltNUa4V9Llp9gWpUl287Kspi4A6PXEMgHi83fJLHF2txuNkW4MPbZhz3PrCfSVukRCilCwXUIbSeO3+ol1vd3aY7y2VZG78JBiZol17Oacv/gyAkcQubm0rTlAX04EOPyfnu6jNZDg/dbrUzRFClJDlAgqg0uEv2rX2tFYzNdlJBs1rTl3y+VCnJ47RkUoR8x+kqsJZ0rYUwv6OAK8mOs1CicnjpW6OEKKESh5QSim/UuqAUuqwUurRtbynssg9qHSsE7dy8XJFBYy9VbRrL+d0dITOpKKzs7BrEZbKgY4Ax41uc9HYuWGp5BNiCyt5QAEPAAe11t8DUEo9vNobfM7iTU7d01oN2kFLxW5e9npKeh9qNjnLkE7gjfstu4PuarY3+Ii762jNuInplOyuK8QWVvKA0lo/pbV+KvuwB1h1DK2qiAHVVF1BsNKFO7OTQaeDsdHXi3btq50eeRXYnAUSOTabYl+HH1u6CZAVJYTYykoeUDlKqR5gWmv9/DKvPayUOqKUOgJQXcSAUkqxu7WG0GQ3AC/PlK6y7MyFfwVgKnUrOxqLM1m5FPZ3BBiZ7QTg3OSJErdGCFEqZRNQwGGt9WeWeyHbyzqotT6ItuF1eovasFtbaxgcrSJo9/CySsBcaSaQnpp4i2A6g6vxLuy2zTNB92r7O/ycTu+gPp3m3FjpeqxCiNIqi4BSSh3WWj+W/feBlY+24bAX94fzvXuaSBvQ5djGK54KjNFjRb1+zunoMG1JG7u6Wkpy/WI50G4WStycTHE8JKXmQmxVJQ8opdQh4FGl1FGl1FFgxXWMdKoGp624zd7dUs32Bh9TM7sJ2e2cufjTol4fIJGO068TeOOBTXv/KafG66S6vpVdCTsDyTCT85OlbpIQogRKHlBa6+e11r1a69uyf665B3XF8Yan6D0opRQfPtDK8Us9ALw8Xvxhp2NnfkhaKeLzPZtmBfOVHOgI4J43e4pHx46WuDVCiFIoeUBthMNe/GZ/aF8rOl1NR8bJy7Hhol//1b5/wKY1E7Z7aKiuKPr1i+1AZ4DTcwfwGAZHBn5c6uYIIUrAmgFVggKBVr+HO3tqqY8Fed2eIT4fKur1Xwudojtpo6fj5qJet1T2d/j5WWY/+xIJjlx+rdTNEUKUgATUOnxkfxuxmR6SSvF6398X7bqx8AXeUikqok3c3rk5dtBdzfaGKmLuenakfZxLhgjFi/sLgRCi9CwZUM4SDPEB3HdLE5fjd+AxDF7o/1HRrvvmsf+PtFJMx2/jw/vbinbdUrLbFHf2BJmf2wbA0UsvlrhFQohis2RAFbtIIqeqwsktO/dxIKZ4PnyaTJFWNv/5hX/FrjUHb/4INd7Nt0Ds9Xziri7eiLyDCsPgyLl/LHVzhBBFZs2AKnKZ+VIf3t+Kb7aTaWXw+tBLhb9gOsHR+ChNcQ+ffteuwl+vjPzStiCJhnewO5HhyGTp9+ISQhSXJQPKWaIeFMC7d9QznXoPFYbBsyf+suDXmz79LKdcDuodO+muqyz49cqJUopP/fI2/LFazmbmmInPlLpJQogismRAlaLMPMdpt9F16/t5ZyzF8xOvF3yY79nXvkNGKX7l1gcKep1y9T/d2kImfStaKV4/8/1SN0cIUUTWDKgSr0P3oQOdNM41MaVTvHG5cJN2tWFwdvZtHBo+vv99BbtOOXPabezf9xu4DM2Lp/+p1M0RQhSRJQOqVFV8Obe21ZDR78JtGPz45F8X7DqvH32ZExUGvfYmPE5Pwa5T7g6/+x30JhRvzMrWG0JsJZYMqFJV8eUopWje+yHuno/z45GXMLRRkOsMvPQNTrucvGf7oYKc3yqqK5x0O7sZcGQ4NVCahXqFEMVnyYAq9mKxy7n3jj3smKtiyojz5vibeT9//6UhXKkX0Erxzu6tHVAA99/5OQyl+JsXvlzqpgghiqT0P+k3oNQ9KID2Wi+V9nfiMjT/fPYHeT//2R/93/yoykWts4Zb62/N+/mt5p277+WmVAW/4Byh8ESpmyOEKAIJqBvQcMv93BON8cOBf2I6Pp2384ZmItRPPM2/ez18fPdDOG1bZ3LuSv7n3gcZcdp5+h+kFyXEVmDJgCqHIT6Au37pvXw4DCkjzbdPfDtv533jn57kuWqNQ9n52I6P5e28Vvfgu/8X/BnFq3M/JZWMl7o5QogCK4+f9OtULj2omkoXs02/xgeiUb5z/Dt56UUlkyma+/5fflBVxT1d91LnqctDSzcHp93JewPv4jWPnef/8aulbo4QosAsGVClLjNf6j2/8WV+fdZGWqf44nNfu+HzvfHcX/GmL8K8DR7c+WAeWri5fPbQl1AoXhn6K7RRmOpJIUR5KJ+f9OtQ6om6S9ncXnYd+jIfjEZ5dfIZvnv01IbP9YtTA9S/9ih/WR1gd3C3FEcso7mqmf3Obl7wZXj5X75Z6uYIIQrIkgFlL6OAAnDsf4hPEwCV5r+++Kf89Oz6qsy01nz9p+eY+evfYqQixCWX4qGdDxWotdb3W3c/wozdztun/zs/fF624RBis7JcQCnMibJlxe6g533/Bx+IxnAF/p3ffvoZjl5Y2wZ7sWSaz//NG8z++I94j/0oT3Tvobailnu67ilwo63r7o53cXf9QZ6orUS9+tv89x/8gnRGhvuE2GysF1DlFk45N32A/62im6ZMCnfr1/nEd/6BU6ORFd8yMBnlw3/2c+In/onfc36PL28/wFvxy3zx9i/isruK1HDrUUrx2KGv0e5t4k+aYNvbX+BT336V2Xiq1E0TQuSR0lqXug3r4mnZoedHzpa6Gcu7fIKLf/Vh/pPfyZz2wcQj/PqBW2moclNfVUFDtZt6n5uGajcv9U3yv373dT6mfsIf2P+KP21u5ZuOOP/5wH/mU7d8qtRfiSX0z/Tz0N9/jPb5OX516FZ+6P8MT37iLtprvaVumhBlRyl1VGt9sNTtWA/LBZS3dYeODZdpQAGEL3Hmbz/GJ92z2Awfoxc/QybReM1hN6mLfLXy2+xMn+Zvu/bx39Q0D+x4gC/d+aXy7SWWoZ9e+jc+/5PPc+f8PL8x6ebb+rf53H/6j9zWGSh104QoKxJQG22EUoeBMNCjtX5qpWMrW3foaDkHFEBiljf+7kF+O9VPzGbjblXNhwLvoosmHBMn8YZPUT13imf9Af6uqZsT86P8ctsv89X3fhWHzVHq1lvO02ee5vFXHyWVSfDxyCyNU7cy2HA/2w+8l/fvaaW+yl3qJgpRchJQG2mAGU5orb+nlHoY6NdaP3+9431tN+m5oTNFa9+GGRmmj3yD7577IX+bGGLapvAaBhUa3DYnMzZFTKfZ5t/G4R2HObzjMG67/CDdqInYBH929Kv8sP/vcRsGexMJdsQhM9+B07ODbR27eOee22lo7gG3D5xekJ6q2EIkoDbSAKUeBb6rtX5dKXUIOKC1fux6x1e13aRnrRBQS8TTcX504jv0RQZJOlzEMwkq7BV8sOeD7G/YL0N6eXRm+gx/d/I7HBt5hbPzY1xd2+cxDBwanGjs2qwSUlqx/H8B+e8iNo/nPn3CcgFVDuNJ/qseB68+INuzehgg0NpdhCblV4Wjgo/slcKHYrip9ia+dPcfAhBLxTg1dZKJmUH6h8/QN9LPXCqE0kkgidZpwAAMNMaSONJX/S2EKIVyCKgwULvSAdn7Uk8BHDx4UH5qiDXxOr3c1nQQmg7CTaVujRCl9Y3PWG9EoBzmQb3GYi+qB3iudE0RQghRLkoeUFrr7wE92ftP/pUKJIQQQmwd5TDEx5KiCAknIYQQQBn0oIQQQojlSEAJIYQoSxJQQgghypIElBBCiLIkASWEEKIslXypo/VSSs0C1lrrqHDqgMlSN6JMyGexSD6LRfJZLLpJa11V6kasR1mUma/TGautJ1UoSqkj8lmY5LNYJJ/FIvksFimljpS6DeslQ3xCCCHKkgSUEEKIsmTFgFpxQ8MtRj6LRfJZLJLPYpF8Foss91lYrkhCCCHE1mDFHpQQQogtoKwDSil1WCl1KLth4bpf30zW+Flsia1KVvoslFJ+pdSB7DGPlqJ9xbSG74tD2T9b/rNYctyW/yyUUiGl1HNKqS8Uu23rUbYBpZQ6DJDbfiO7HceaX99M1vK1Zrct2fTW8Fk8ABzMfR6b+ZeXNfw/cgA4kH39gFKqp/itLI61/jzIPr9pPwdY82fxMa31ry7ZSaIslW1AAbcD/dl/9wMH1vn6ZrKVvtbVrPhZaK2fyu7ADOYPon42r9U+i9e11o8ppfxAv9Z6y34WANmA3syfQc5afl74rfALSzkHlP+qx8F1vr6Z+K96vJm/1tX4r3q87GeR/Z9vepNvgOm/6vH1vi8OAucL25SS81/1eLnPomeTh3SO/6rHy30WtcC0UurJwjdn48o5oMKYH+JGX99Mwmydr3U1Ydb2WRzWWn+mwG0ptTBr+CyyId2bG/rZpMKs8FkopQ5t8l9WlgqzyvdFdqQhDITL+fuinAPqNRZ/E+gBri4AWO31zWQrfa2rWfWzUEodzo2tZ+/DbFYrfhZKqUeX3IMLs7l/yVnt+2I6WzRwGOjZ4t8XD1vl6y/bgMre5O7J3uDzL7nh99xKr29Gq30W2X8fAg6W829D+bDaZ5F9/lGl1FGl1FE28Q/lNXxfPAn0L3ndchM112oNPy9ezz5Xy7VDYJvKGr4vns4+Przk+LIkE3WFEEKUpbLtQQkhhNjaJKCEEEKUJQkoIYQQZUkCSgghRFmSgBJCCFGWJKCEEEKUJQkoIYQQZUkCSgghRFmSgBJCCFGWJKCEyAOlVI9S6vySJZc29f5LQhSDBJQQ+fFF4FeB17M7th7cIls7CFEwshafEHmglPJrrcPZzQEPbubFi4UoFgkoIfIkt4WB1vr1UrdFiM1AhviEyIPs1gX9uXDa7NueCFEMElBC3KDspoA9wNeVUv7sPahwaVslhPVJQAlxA7KVev3ZHXz7gQHgvNyDEuLGyT0oIYQQZUl6UEIIIcqSBJQQQoiyJAElhBCiLElACSGEKEsSUEIIIcqSBJQQQoiyJAElhBCiLElACSGEKEsSUEIIIcrS/w+EO5pJIyl+PAAAAABJRU5ErkJggg==
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAagAAAEnCAYAAAD8VNfNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABBLElEQVR4nO3deXCc13nn++/pFd3oBtDY95WkxEWiCFGWrMjbhPF6M6ZtWXHkyZST2HLs3NT43lLkzJSTqtxoJiNFSansZBTJ9rVvvCRWZFsTO45lUU4sK5YsgZIocQexkMRGYunG0o1e33P/eLsBkMTO7n67gedTxcLSb7/vYRPsH855n3OO0lojhBBCFBqb1Q0QQgghliMBJYQQoiBJQAkhhChIElBCCCEKksPqBgghhNi4o0eP1jocjq8A+yjuzoYBHE8mk5+89dZbLy99QAJKCCGKkMPh+Ep9ff3umpqaoM1mK9pybMMw1Pj4+J6xsbGvAP9x6WPFnLpCCLGd7aupqZkp5nACsNlsuqamZhqzJ3jlYxa0RwghxPWzFXo4nTx50vW+972vc63j0n+Pa/JIAkoIIURO7NmzJ/6Nb3zj/GafLwElhBAiJ06ePOk6ffq0e7PPlyIJIYQocn/41LGWs2Oz3myec1e9P/IXd++/uNoxjzzySPUdd9wReemll7z333//xNe+9rXAk08+GbjnnnuCfX19rnvvvTf4wAMPNP3iF7/onZiYsD/66KPVBw8ejPT09HgrKipS999//8Rq55eAEkIIsWFf+MIX6g4ePBi56667IhMTE/ZHHnmk+v7775/4kz/5k6Z/+Zd/6c8cV15engJ44YUXvBUVFanDhw/PPv744zVLj1mJBJQQQhS5tXo6uXD06NHSe++9Nwiwa9eu2OOPP15z//33T+zbty+y3PGHDx+efeSRR9xPP/20/y//8i+H1nMNCSghhBAbduutt4bPnj3r3rNnT/zs2bPuW2+9Nbza8S+88IL3/e9//8yePXvi672GFEkIIYTYsAcffPBST0+P9+mnn/b39PR4H3zwwUtPP/20//jx494XXnjBC2YoHT9+3Hvy5EnXXXfdFfnoRz/a9b73va/zM5/5TNPExIR9rWso2Q9KCCGKz7Fjxwb379+/apFBIfnCF75Q97nPfW6iuro6dfLkSdeXvvSlmscee2w48/ixY8eq9+/f3770OTLEJ4QQIucOHjwY+cEPflAWCASSwWDQ8fGPfzy41nMkoIQQQuTc4cOHZzf6HLkHJYQQoiBJQAkhhChIElBCCCEKktyDEkIIkRNPP/20H+CZZ54pW1qxt17SgxJCCJF1L7zwgveZZ54pO3z48OyxY8cW5kZthPSghBBCZN1dd90VueuuuyIAFy9edGc+3wgJKCGEKHZP/34Ll09mdTVzavdEOPw3K67x9/TTT/sffvjh+gceeGCsp6fH29XVFQ8EAsknn3yy8otf/OJQdXV1CswJul/60pc2tSeUDPEJIYTYsMOHD89OT087Dh8+PHvvvfcGn3zyycDhw4dnu7u7w0uH8x588MFLjz/+eM16lja6mvSghBCi2K3S08ml8vLyZObz9vb2GEBVVdXC9hpgDvW1t7fHHn300eoHH3zw0kbOLz0oIYQQm5LZ62k5P/7xj/2ZXtP09LSjq6tr3auYZ0gPSgghxIYtXbn8xz/+sf/YsWPekydPup588slAIBBIffGLXxz6+te/Hvja177mAPjt3/7tNdfeu5qsZi6EEEWo2FYzX8tyq5nLEJ8QQoiCJAElhBCiIElACSGEKEgSUEIIIQqSBJQQQoiCVHRl5tXV1bq9vd3qZgghhKUefvhhTp482bbe42OxWPLAgQPHctmmq33mM59peuyxx4YfeeSR6vvvv3/DFYdFF1Dt7e309PRY3QwhhLDUqVOn2L1797qPP378+IYnyl6vb33rWzU//OEPA5tdi6/oAkoIIURx+Lu/+7u+w4cPz272+RJQQghR5B56+SFOT51e9Zi58FyJY9Bxw3rPuSOwI/Jnv/Jn17WaeU9Pjxegp6fHu9F1+ECKJIQQQmzCelYzf/DBBy8dPnx4dnJy0pHZXXcjpAclhBBF7vNv+fyaxxw/fjy6b9++M9m87mqrmX/ta18LgLkGX1VVVfLcuXNuYEPDfdKDEkIIsSmrrWa+c+fO2K//+q/PAPT395fccccdsqOuEEKI3FtrNfNvf/vb5x955JHqqqqqVGdnZ3QzW74X3WrmBw8e1FJmLoTY7jZRZh7Zt2/fqRw26brIauZiU54fep6zwbNWN0MIsc1IQIlVzSfn+dy/fo5P/PgTnAues7o5QohtRAJKrOq1S6+RMBLEkjE+89xnuBTe8FQGIUSOFNstmpUYhqEA4+rvS0CJVb009hIOm4OvvuerzMZn+exzn2U2vumJ4UKILCkpKWFycrLoQ8owDDU+Pl4OHL/6ManiE6t6aeQl9tfs55baW/ird/4Vv3/k93ng+Qd47NBjVjdNiG2tubmZoaEhxsfH13X82NiYI5VKVee4WZthAMeTyeQnr35AAkqsKBgNcnrqNJ+95bMA3Nl4J5+6+VM8duwxJucnqfJUWdxCIbYvp9NJR0fHuo/fs2fPm1rrgzlsUtbJEJ9Y0ctjL6PR3NFwx8L33tr4VgBeH3/dolYJIbYLCSixopdGX6LUWcq+6n0L39tTtQenzcnrl1+3rmFCiG1BhvjENWaiCR76l9P8dO7nNHj38ULvFM0BL80BDyVON3ur9vLa5desbqYQYouTgBLX+Lcz43z71dfw7bjE8XNv4ROvvLLwWK3fTV17E8PGT4ilYrjtbgtbKoTYyiSgxDVOjEzj9vcB8M2P/xa2ZB1DwQgXp+b5ee84rw1U4mlJcGLiBN113Ra3VgixVVkSUEqpbq31q0u+vi/9aZfWeu1140VOnRyZoTxwHp+nlrc03YhSitvaKwG4qamc3/mGuYfZa5dfk4ASQuRM3osklFKHgC9f9fURrfUTQGf6a2ERrTUnRkIkXGe5veF2lFJXPL67oQyd8hFwNkmhhBAip/IeUFrrI8DUkm91AplQ6k9/LSxyaSZGKHmBBLPc3nD7NY/XlbkJeJ2U6h28Pv560c9iF0IULsvLzLXWT6R7TwDdgOylYaGTo9PY3JcBs6T8akopdjeUEZ1rIRQLMTAzkO8mCiG2CcsDKkMp1Q08u/TelMi/E8Mz2JxBAJp8Tcses7uhjJGxegAZ5hNC5EzBBBRwSGv98HIPKKXuU0r1KKV61rvulNick6MzlPlnqCypxOv0LnvM7oYyYvNV+J3lMh9KCJEzBRFQSqn7MuG0XJFEehjwoNb6YE1NTf4buI2cGJnB451esfcEsLvBDyiaPLulByWEyBkrqvjuBg6mP2YC6SGlVJ9SKpjv9ohFM9EEF6YiGPZJmn3NKx63o9aHw6bwGF0MzgwyFZ1a8VghhNgsK6r4ntJaB7TWT6W/PpL+uiv98Ui+2yRMp0ZmAIO51ARN/pV7UG6HnR21PiIzLQC8Mf5GnloohNhOCmKITxSGEyMzKMc0hk6tOsQHsKehjAtjFSgUp6ZO5amFQojtRAJKLDgxMkOgfA5YuYIvY3dDGZenodnXypmpM/lonhBim5GAEgtOjs7QUB0GWPUeFJgBBVDr7uD01Omct00Isf1IQAkAYskUvZdmKfPPYlM26n31qx5vVvKBW7cwPDfMTHwmH80UQmwjElACgN5LcyQNjcMVpM5bh9PmXPX4Kp+bWr+b+TkzyGSYTwiRbUUbUH3jc7z30ecZDs1b3ZQt4eSI2QOKMr7m/aeM3Q1ljI2bq5xLQAkhsq1oA6r30hynx2b5zisXrW7KlnBiZJpSl53J6BjN/tXvP2Xsbihj4JKNqpJqqeQTQmRd0QZU0jAA+N6rQxiGrKh9vU6OznBDQwnj8xvpQflJpDQtpTukByWEyLriDaiUGUpDwXleHpSVDK6HYWhOjszQXhcD1i4xz9iTruTz2Vrpm+4jkUrkrI1CiO2naAMqkTJ7UErBd48OWdya4nZhKkI4nqKqIl1ivtIQn2HAuefg+PcA6KguxeWwYUQbSBpJzoXO5avJQohtoGgDKpke1rtrRzU/enOUSDxpcYuK14l0gYTHOw0s04OauwzPPwJfvAW++WF46rfh53+Fw27jhjo/k1PVADIfSgiRVcUbUOke1G/c1kI4nuKZE2MWt6h4nRiZxmFTJG0TuGwuqj3Viw/OXoLH7oSf/hlUtMJHvgr77obn/hRe+lt2N/jpG/XgcXg4E5T7UEKI7HFY3YDNSqTvQd3ZVU1zwMN3jw7zoQPrqz4TVzo5OsOOWh+j4REafY3YVPr3Fq3hn/4AYrPwqX+Fpm7z+3s+CMko/PjzfHD3F3gyvIfby3ZwalIq+YQQ2VO8Pah0FZ/TrvhwdzP/3jfBiMyJ2pQTIzPsbSxneG74yvtPR78Ovc/AoT9dDCcAuxPu/hrsfDd3nvrvdKuzVDo7OBM8g6GNvLdfCLE1FW1AZXpQTruNDx9oQmv4/mvDFreq+FyejTI+G2NPYxlDc0OL958m++CZ/wad74S33HftEx0uM6ScXj5i/zn2RBPhRJjhOfk3EEJkR9EGVKbM3GFTtFeXcrAtwHdfHUJrmRO1EZkVJDpqFbPxWXOR2FQSvnef2VP64P8C2wo/Jm4f6ob38n7HK4SnpVBCCJFdxRtQ6SE+u00B8JFbm+kfD3NsaNrKZhWdTAVfmX8WwNyo8Ph3YbgH3v+XUL7GnKi9HybADFUjF7AruwSUECJrijagEimN065QygyoD9zcgNthkzlRG3RydIaWSg+h+CUgXWL+8hNQtRP2fWTtE+w4RMxeyltmf05rWZusKCGEyJqiDahkysCxZOiprMTJu/fW80/HRoglUxa2rLicHJlhb0P5wr2jptkJs/f0lk+tPLS3lLOE8aZDvMf2Mg3uDik1F0JkTfEGlKFx2NUV3/tIdxPT8wl+euqyRa0qLnOxJAMTYbNAYnYIv9NP+Wt/Dy4f7P/NdZ/HcfNHKFcRaudSjIXHmI7JMKsQ4voVbUAlUgZO+5XNf9vOGmr9br77qgzzrcfpUfP+097GMsbCYzR6a837T/s/BiVl6z5P7f73Mq1L2TXeB8jWG0KI7LAkoJRS3Vd9fbdS6pBS6oH1niOZ0jhsV/ag7DbFhw408W9nxpmYi2WptVtXpkBib2M5o+FRGhJxSMXgtk9t6Dw2p5tXPL/CO6deB5BhPiFEVuQ9oJRSh4AvL/m6G0BrfQQIXR1eK0kY1/agwKzmSxqa//36SJZavHWdHJmhstRFXZmb0fAo9VMXoOPtUHvjhs91ofG9tCTDVDl80oMSQmRF3gMqHURL98f4DSCU/rwfOLSe8yRT196DAthV5+empnKelkm7azoxOs3exjIiyQgz8RkaIqEN954yXDveyZT2scOwczZ4NrsNFUJsS4VwD6qCKwOraj1PShrGNUN8GW/fVc2p0ZmFLTnEtQxDc/bSHDfW+xkLmwvtNjj8cMP7N3W+3U0Bjhq72BGe5VzoHAlD9oYSQlyfQgioTUmm9LJDfACd1T6ShubCVCTPrSoe43Mx4kmD1qpSRmcuAtDQdDvYN7d+8A31ZRw3Otg3O07CSDAwPZDN5gohtqFCCKgQUJn+vAKYXM+Tliszz+isKQWgfzx83Y3bqi6mw7s54GF06EUA6rt+bdPn87kdjPlu5MZ4HJBKPiHE9SuEgPoO0Jn+vBM4cvUBSqn7lFI9Sqme8fFxwCwzd6wwkbSzxgdA//hcLtq7JQwFzZXfWwJeRkd7sGtNza4PXNc5w5X7aE8kcCm5DyWEuH5WVPHdDRxMf0Rr/Wr6+4eAUObrpbTWT2itD2qtD9bU1ACZIb7le1DlHifVPpf0oFaxtAc1FuynTjmweyqu65z+mmaCBOhSJdKDEkJct7xvWKi1fgp46qrvPbHR85hFEivna2e1j/4J6UGtZCg4T43fTUlklNHkHPX+9us+Z3PAy7FUO7tiIX4ePIPWemGtRCGE2KhCGOLblMQKZeYZXbWl0oNaxcVghJaAB3qfZdThoKFy53Wfszng4bju4MaZSaaiU0zMT2ShpUKI7apoAyq5wkTdjM5qH5PhONMRKXdezsVghOaAl1Tvs1xy2Gmo3HXd52wOeHnT6OCGuLmKh6woIYS4HsUbUCm9sBfUcjKVfH0yzHeNZMpgNBSlrcLB5PnnSSpFg6/xus/bUunhTaOTXVLJJ4TIgqINKHOx2NUCyqzk67ssAXW1sZkoSUNzQJ9mVJu9nfrS+us+b43PzbSjCru9kgblkoASQlyXog2opKFXLZJoCXhw2hX9E3If6mqZEvNdsy8y6ioBoKG04brPq5SiOeCh37mTGxIpGeITQlyX4g2oNYokHHYbrZVemQu1jEyJee2lnzNWbU5By0ZAgXkf6rju4Ia5IIMzg8RSsqq8EGJzijagEikD5xo7vnbW+KSSbxkXg/NUqDlcU2cZLavD7/Tjc/mycu6WSg8vzbeyIx7H0AaD04NZOa8QYvsp2oBabamjjM6aUs5PRkgZOk+tKg5DwQjv8pnr7406ndT7rv/+U0ZzwMtL0VY642b1ZP90f9bOLYTYXoo2oJbbUfdqXdU+4imDoaAsGrvU0NQ8t7vPA4qxVDRrw3tgLp10mQBNjgA24FzoXNbOLYTYXoo2oJbbUTdDa03CSNBVK4vGLudiMMI+zkH1TkbnL2c1oJoDHgAiFXtoNRT9IelBCSE2p3gDyjBwrNCD+uvX/5oP/+8P01LpBqBPCiUWxJMGYzPzdMROE2m8hVAslJUS84yWSi8AQyU76ZqP0Cc9KCHEJhVlQGmtSayyWOyJyRMMzgzy72M/IeB1Sqn5EiOheer1FKWJKcaqu4DsVfABBLxOvC47A7qRzkScC7MXiKfiWTu/EGL7KMqAyhQ9rDQPamRuBICvHv8qHTVemay7xFBwnv22PgDGys1gymYPSilFS8DLyXgtXfEEKW1wfuZ81s4vhNg+ijKgkpmAWqYHpbVmdG6U9rJ2zs+cx1txXHpQS1wMRthv60PbnIy6szdJd6nmgIfX5irZkTAr+fqm+7J6fiHE9lCUAZVIGQDLDvFNRaeIpqLcc8M9dJR3cFH/kPHZKLNRWTQWzEm6t9j6oG4fo/Pj2JSNGm9NVq/RUunlzLSdVmcFNqAvJAElhNi4ogyo1Yb4MsN7zb5mPnnTJ5lKnMfuOyWVfGnDU2Futg2gmm9lNDxKjacGp82Z1Ws0BzzMxZI4A500a4cElBBiU4oyoBIpM6CW60GNhM2AavQ18r6O91HracBd/a/0jc/mtY2Fypg4Synz0NjNWHgs68N7YE7WBZjxttMVj0mpuRBiU4oyoJKGOcS3XJl5pgfV6GvEaXPyO/t+B7vnIq+MvpnXNhaqyukT5idNZg8qFwHVUmnOhRp3NdM1P8f5mUESKRliFUJsTHEGVCozxLdMD2puBL/Lj9/lB+CtjW8B4NzUQP4aWKCiiRSdsdPE7aUkKzvMgPLlrgd1XjXQGU+Q1CkuzF7I+nWEEFtbUQbUYpHEMj2o8AiNpYub72VKqEfmRvPTuAI2lK7gmw7sZSRyiaSRpL2sPevXKfc4KStxcCZRt1jJJ/ehhBAbVJQBtVqZ+cjcCI1Ldof1Or24lJ9g/DLG2Al47s/g4st5a2shGZoIsVtdIFl/gMGZQQDay9tzcq3mgJc3IpW0J1IoJKCEEBvnsLoBm5HpQV1dxae1ZmRuhNsbbl/6TeqUm0rnS9j+9jvm90Zfh//03Ty1tnBELhzDrZJ42m9b2AYjFz0oMO9D9Y+H8ZQ306TcMhdKCLFhxdmDWuEe1HRsmkgycsUQH30/ZefsBYIOg74D/xVuugfOvwjb8ab92HEAyjoOMjgzSLm7nEBJICeXag54uRiMoKt2sCNpSA9KCLFhBRFQSqm7lVKHlFL3ref4xSq+KwMqU2Le5Gta/OaFF6lPGZx3uPlZ1T1w4wcgEYaR17LU+uLhDp1lHje2QBvnZ87TVtaWs2u1BDxEEwbRsg46I7MMzgySMLbhLwVCiE2zPKCUUt1Av9b6CNCf/npVi/Ogrmx+psT8isq0oVdo8FSj7HHOjI9D+9vM7w88n5X2F5PKcD9jrlaw2RicHszZ8B4sVvJNuFvoioZJGkkuzl7M2fWEEFuP5QGV9lD6Y6fW+tW1Dl5piC8TUAs9KCMFQ0dpDOwCoHfyApRWQe3ebRlQjYnzBEu7iCQiXJ6/nNOAymy7MWxroiturmYuE3aFEBtheUClA6lfKdUHTK3nOYkVJuqOhEfwOryUucrMb0ychfgsDQ1mp+zijBlgdLwNLv4SkrGs/B2Kwdz0JHVMEQvsynkFHyxuXNibqqM1kQSQuVBCiA2xPKCUUhVACHgc+LJSqnOZY+5TSvUopXrGx8cXelBXL3U0PDdMo68RpdLfH3oFgIa2dwAQSlwmHEtCx9shGYWhnhz9rQrP5MAxAOx1N+a8gg+g1O2gstTF6fly/DYnlTYXF2YkoIQQ62d5QAH3AX+utX4Y+Chw99UHaK2f0Fof1FofrKmpIblCmfno3OgVc6AYegVKKqhsOIBDObE5QwxMhKHtTkDB4M9z97cqMOGLZgWfr+Umzs+cR6Fo8bfk9JrNAQ8XgjGo7KRFO+QelBBiQwohoBakCyVCax2XMJbvQY3MXbmKBEM90HwbNpudGk89yhEyt3/3BKDh5m11H0pfPkVEu6lr2cnAzACNvkZKHCU5vWZLwMtwcB6qdtAaj8kQnxBiQywPqHTP6b50qfl9Wusn1nrOQg9qyT2omfgMs4nZxR5UdAYun4Lm2wBo9jdic4UWt91of5vZw0rMZ/cvVKA8oV76aKLSV8L5mfM5Hd7LaA54GArOoyu7aAmHGAuPEU1Gc35dIcTWYHlAgRlSWuun1hNOsHwV32h6rb2FgBp5FdDQfBCAJn8DDtf04u66He+AVNwsltgGKiP9jLraARicHszpHKiM5kov8ZTBTGkbLXGzIGV4bjjn1xVCbA0FEVAblaniWzoPKvPGt1Bini6QoOlWABpLG9G2GfrGQ+b3294Kyg4D2+A+1HyQitQkIV8X4/PjRJKRnFbwZWQq+UYdTbQmzUo+uQ8lhFivogyohR7UkntQo2GzB7Wwv9FQD1TfAJ4KIL2qudIMBEcwDA1uPzQe2BaFEvryKQDigV2cnzkP5LaCL6MlPVl3wKhfLDWXSj4hxDoVZ0BliiRsV/agSuwlVJZUgtZmDyp9/wkWh/7iapKxmfR9kNY7zCWPjFT+Gm+B+WFzk0JH/R4Gps19sfJ1DwrgXNhLuc2FXzmlUEIIsW7FGVCpa9fiG50zN99TSkFwACKT0HzrwuOZnpVyLimUqN5p3oeaHspf4y0QGT5BWLupaOjg/Mx5Suwl1JXW5fy6JU47NX43Q6EoqqKNVqTUXAixfhsOKKVUu1Lqw0qpTyql7k9//h9y0biVLLcfVGaSLrA4AXdJDyqzcaHNGaR/Ys78ZmWX+XFqi6+0ffk0vbqJ5kofgzODtJa1YlP5+d2kOeDhYjACgXZaEkkZ4hNCrNu636WUUn+olPoJ5rp5XYACptOfv1sp9ROl1GNKqVty0tIlFnbUXTLENxoeXZwDNdQDTi/U7F543GV3Ue2pxuWeWexBVaUDanJrB5R3updeo5mWgDdvJeYZLQEvQ8F5M6DmZxkNj8qq5kKIdVlzw0KlVAfwaeAftNZ/scax5Zhzmg5qrb+SpTZeI5nS2BTY0mXmSSNJKBai2lNtHjDZC9W7wH7lX6+xtJE5zwyDk+mA8jeYQTa1hRcxjUzhjU9w3tGK1w1Ds0O8p/09ebt8c8DDj94cxahopTUaJuUvYXRulNay1ry1QQhRnFbtQaXD6Ve11n+ktX59rZNprafTIfacUuqTWWrjNRKGcc0kXYByd7n5jakBqOy45nn1pfUoZ4jBzFwopaCyc2sH1PhpAGZ8O7g4d5GUTuW3B1XpJWlogu4mWTRWCLEhqwaU1npgMz2hzT5vvZIpjXPJJN1QLARAhbsCUkmYvgiBawOqobSBOJMMBSMLw4RUdmztIb5MiXnlroXtLjrKr31tciVTyTdMDa1Jc2hP7kMJIdZjM0USZbloyEYkU1f2oKZj00A6oKYvgpFctgfV4GsgRYKUmmMklF7iqLILgoNmsG1B+vIp5rSH0pp23hh/A6fNya70/lj5kJkL1Z+soSpl4FFSySeEWJ/NlHJ1LS2EUEp15LuKL2HoKxaKDUVDQHqIL2jO81mpBwVmqfngZMT8ZlUXGAkz2LagxOUznNMNNFd6OTZ+jN1Vu3HZXXm7fkNFCUrBwIxCeatosZXIEJ8QYl02HFBa69eA25RS7emvB4CAUurPs9y2FSVTBvZlhvjK3eXm/SdYtgeVKUO3OYOczxRKLJSab9H7UBN99OtGGsqdnJg8wf6a/Xm9vNthp76sZKGSrzVlSA9KCLEumxni+w7QBwSXDPcdwdzXKS+SKX3FXlBXDPEFB8DuBn/jNc/L9KDcJTPmvlCwWGq+FQMqMY8rPMyAUU/KOUwsFct7QMFVc6Gi8wzNDpHa4qt3CCGu32aG+G4FerTW04BKl5YfAv5nVlu2imuG+GIhHMqBz+kze1CBNrBd+1crc5WZW8L75zifGeLz1YGzdGsWSqT/TgO6gUvxMwCWBNTCvlAVbbSGgySMBJcil/LeDiFEcdlMQH2UdG8pHVKVQGCtOVLZdHWRRCgWosxdZi5zNDVglo4vQylFo68Rlzu0OBdqodR8KwbUOQAmSlo5PXWcOm/dwooa+dQc8DA6PU+yoo3W9LYbch9KCLGWTd2D0lo/suTrAeBoPlaQyEik9BV7QU3Hps3hPa3NirxlCiQymnxNaMcUF6cipNJLJlG1RedCTfYCoAMdHBs/ZknvCcx9oQwNk44GWmRVcyHEOmVlQbZ04cRANs61HknDuGIvqOl4OqDmLkMivGyBREajr5GIMU4iZWz9UvPJPi5TRaDawUh4xLqASs+FukgtdakULmWXQgkhxJqytmJoergvL5IpfcVCsaFYaM0S84wmXxMxIwK2+cVhvqouc+7U9Nb6rd6Y6KXXqMdVaobB/lprAqq10pwL1Ttfjk3ZabaXSg9KCLGmNZc62sySRZt93nolUsYVC8VOR9M9qFVKzDMyO+7aXMHFuVCZe1aTW2iYT2v0xDkGjHri9n6cNie7K3ev/bwcaCj34LLbGAzGoLyZJq0YCY9Y0hYhRPFYc6kjzHX1/nY9k3GVUmVKqT/EXL8vd0sdGYs9KK01oVhoscQcBRUrL0SaCSh3SYjzE1t4LlRkCnssxIBu4HLiLHuq9uR1gu5Sdpuitcpr9lgD7TTF4wzPDlvSFiFE8VhzNfN0SP2eUupTSqk/AjTwKjCZPqQKqMDcdqMPeDj9nJxJpgxK3WbT55PzxI04Ze4yOH8KypvB4V7xuZnJupXlc4s9KF8tuHxbq5IvXcHXq2s5P/sSH7vxY5Y2p73Ky+BEBLraaL5wllm7k+nY9OICv0IIcZU1AypDa/1l4MvpeU8HMUOpErM4oj9dKLEpSqluoDN9nafWOj6xZLHYaybprjK8B+ZqE36nH6935tpS8600FypdwTfscxM34pYVSGS0V5XywrkJjFvbaTwdAn8Nw3PDElBCiBVtpsx8Wmv9nNb6u1rrL6c/bjqc0j6dDqbOdFitKrVkiO+KlcynBlYtkMho8jdhcwW5MLm01Lxry/WgkjhIVUYBayboLtVWXUo0YTBd0khT0qyWHJmT+1BCiJVtqoovvd37Y+mP17W6uVLqbsyhQbTWD2utX13rOUv3g1pYh085ITKxZg8KzI0L40wQTxmMzZhv4FR2QvA8pLbIbq8TvQyremzei9SX1lNXWmdpczqqSgEY0nULATU8J/ehhBAr28xafP8T2IG53fs9wIBS6nevow23AVVKqW6l1APreUJyuSG+6Kz54Dp7UDPJy4C+slBCpyC0Ncqf9eQ5zqRqmVVnubXuVqubQ1uVWWp+NlFFuaHx21wMzQ5Z3CohRCHbTA/qlfQOu3+ktX43ZnHETqXUh6+jHZOZnlO6R3UFpdR9SqkepVTP+Pj4FUsdLQRUOGgevI4eVJOvibgRRdnDDExuwUVjjRR6aoCj9kqiRojb6m6zukU0Vpil5mdnnODy0WQrkR6UEGJV1z1RV2sd0lr/EWY132b0AZlU6MfsUV19jSe01ge11gdramquWCx24R7UXHrx0fX0oNKl5q6S0OKisRVt5sfQ+U3+NQrI9EVsqRjHPGYNzG311geU3aZoqfSYlZOBdhpThgSUEGJVmwmofqXUK0qpd111/2lyxWes7gjpCr70x1fWekIyZSxstxGKhfA6vDiDF8BbBSVr3xLLlJrXBMIMZob4fHVgd22NIb50iflFT4Tqklpa/C0WN8jUUV1qlpoH2mmKRRmZG0FrbXWzhBAFajMB9RvAk8BngMF0WD2DWYHnB9jIcJ/Wuh8IZYb21lNmvnSpo4WFYoPrq+CDxR5UmX92sQdls0F5y9YIqIlzaGDWO87tDbeZq7wXgPaqUs5PhdEVbTSFg0RTUSajm/29Rgix1a17HtQSfcCzme01lFIHMPeDejfw35RSmXec7633hFrrJzbSgMSSxWIX1uG7eApa71jX80udpVS4K3CpEKcmwxiGxmZLr0CxFQJq8hynXH60I1wQw3sZmVLzGU8TzbF5wM/w3DDVnmqrmyaEKECbmQf1Zcwt3tvTX7+mtf4LrfW7tdaVmD2sHK8ksbjdhtmDKoeZIXOjwnVq8jVh2KaIJQ0uzaZLzbdQQB0pMd/0CymgMqXmI6qBxqS5o64seSSEWMmmiiTSoTS4wmOvAp+/nkatJWksBlQoFjLnQGljsdBhHRp9jYSNcQDzvgiYARceh3gk623OJz3Zy0suF15bZcHcf4LFUvO+ZPXiZF1ZNFYIsYKsbbexVBZWllj53OmPSyfqlme+uYEeVLOvmWD8EmBwPlNqngm46SLeqygxj54e5pwnSaf/5oK5/wSLpeYn58vxaqi0uWUulBBiRTkJqFzKFH057IqUkWI2PktFZqPBVVYxv1qjr5GEEcflCi8uGpt5fjEP8032Mei0M+9I0F170OrWXCFTat43lYCyJppwSqm5EGJFxRdQ6T6U02ZjJj6DRlMRj4KyQVnTus+TqeSrr4oslpovBFQRz4WaPEdPSQkAv9p+p8WNuVZHdalZORlopzGZlIASQqyo+AJqSQ8qs4pEeXTWDCe7c93nafKbARUon1tc1by0FuzuIu9BneOVEjcky7ilvsvq1lyjraqUwckwOtBGUzTMaHiUlJGyullCiAJUdAHFQkDZFleRCAc3NLwH5oKxAB7vNOcnI+aEUZsNKop7LpSe6OVljxdP6gZstsL7521Pl5rPeVtoikyTNJKMz49b3SwhRAEqvHewNSwO8S32oCrmLm84oEocJVR7qrE5g8wnUozPxswHirzUfGTqLFN2RUPJjVY3ZVnt6Uq+UVs9zelKPimUEEIsp/gCarke1MylDZWYZzT6GokxAcDA0vtQwSK9B6U1x+fMcN1RvsfixiyvPT0XatCooSkh224IIVZWfAGV/ui0q8W9oIzUhntQYBZKmNtusGTR2FZzX6l4OAutzbPIFCdUEptW7K/dbXVrlrVQah6tpCGZRCEbFwohlld8AZXuQjlsNqZj09ix4Tf0pgKqvaydy/OjOOyJxUKJhVXNi3Au1GQvJ9wuSqIV7KgpzK3UM6Xmp0JOXC4fNbYShuZkiE8Ica3iC6j0R0e6B1Vud6NgUwG1p2oPhjZoqJm6sgcFRXkfypjo5aTbRSraTHt1qdXNWVFHdSnnp+Yh0E6zVjLEJ4RYVvEFVDqhMkN8ZcoByr6hOVAZe6rM+zT+8rElPajinQt1/tJrzNlsROK7qC8rsbo5K1osNW+nKR6XgBJCLKvoAirTh8oM8VUYGsqbwL7xhdlrvbXUeGpQJUMMToTN4UNfHThKirIHdWLqNAC17l3m6uwFKlNqHiltoTEyw6XwJRKphNXNEkIUmKILqKUTdUOxEBXJxKYq+DL2VO0hzCDheIqJuTgoVbT7Qp2IjOI0oKui8CboLpUpNb9kr6c5HkWjZdFYIcQ1ii+g0h+ddrMHVR6f39T9p4y9VXuZig+Bii1ZNLYI50IZKU4YEapjXjqq/Fa3ZlWZUvMLupaWdKn5xdkiLEoRQuRU8QVUpgdlU0zHQlTE5q4roPZU7UGjsZeMXrlobJEFVHJqgFMuB65oNW0FXCABi6XmZ2JVtCQloIQQyyvCgDITSpMgmopRkTKuO6AAHN6hK3tQRTYXqn/oF0RtNuLzbQtDaIUqU2r+5lwZNSmDEmWX1SSEENcovoBKf5w3ZoDMJN3N34Oq8dZQ663FVzZ25WoSUFRzoU5c6gFgYn73whBaIeuoLuXcVAJV3kyzckkPSghxjeILqHRCRZKzANfdgwKzF6Xcw0vmQmUm6xbPMN+JUC+lhsFsqp2G8sItMc9Yuqp5c9KQgBJCXKP4Airdh5pPmT2oCq3A33Bd59xbtZeYGmNwatIcQizCuVDHo+N0Jhy0BPwLuw0Xskyp+XxpC83RCMNzwwvDt0IIAQUWUEqpB9Y8KP0eNpdIr2Tuqd7UHKilzPtQmggXCEYS4KtNz4UqjoCKp+Kc0VFq42W0Ffj9p4zMfbIJZyMtkWnmk/NMRictbpUQopAUTEAppQ4Bt611XOZ37JlEEICqsubrvnamUMLmGTbvQymVXtV88LrPnQ+9l98kqRSEawp6iaOlFkrNVaNU8gkhllUwAbVemWGg6fgUNq2pKO+47nNWe6qpKanDXjLE2UvmvS0CHTA1eN3nzodTQy8AMBNpL4oCCVgsNT+drJO5UEKIZRVEQCmlurXWR9ZzbKYHNR0dJ5AysFW2Z6UNN9XsxekZ4fiwOXRIZScEBxarMgrY2fE38BoGI/Guohniy5Savz5XTWMyhUICSghxpYIIKKByvQdm8iIUHqEqtbl9oJazt3ovuMZ5Y+RSukWdEJ+DcOFvR947M8jOeIIB3Vg0PSgwh/nOBRO4KlqpVy6ZCyWEuILlAbWe3pNS6j6lVI9SqmcubM5VCkbGqTJS5rp5WZC5D9UbOkkyZUBleuhwqj8r588VrTVnY5O0plwkbW6aAh6rm7Ru7dXpUvPqXbQkU9KDEkJcwfKAAjqVUncrpe5Of9599QFa6ye01ge11ge9XnMIayoWpCplmD2dLLil5hZs2DBKztE3Hl48b4EH1OXIZWZIETCqaA54cBZBiXlGe5XXXNXc30HLfFgCSghxBcvfzbTWT2mtn8Ic5qtY83jAboOpZJgqbQN/fVba4XP5uCFwE47SXvM+VHmLuc/U1EBWzp8rZydOAKDjDbQV0fAesFBxeMnVQnM8ylR0inCieJaXEkLkluUBlZHuJXVprV9d/Thw2ONEMahyB8yS8Cx5V+td2EqGOTp0ERwuKG8u+B5U78hLAIzMtRf8GnxXy9wvG6SJ5nSpudyHEkJkFExArZdG43SZSxJVldZm9dx3Nf0KSmmOXn7Z/EZlZ8EH1Nnx49Qlk5ycby+6HlSm1Px4vJaWhLlhoQSUECKj6AIKDS6nWQpeVZadCr6MPVV7cKpShmPHMAy9WGpewHrnLrAznmRANxRdDypTan5y2kOLzWy73IcSQmQUXUBpoMph7r5aWbkjq+e22+zs8B9Al5xhcDJsVvLNByEyldXrZEvCSNCfmKENDwkcdBTJKhJLtVeVMjgVoayyi3JsElBCiAXFF1AaKuyjAFRV78n6+d/WfBc25ww/7XtjsZKvQHtRg9ODJNGUGzX4SxxFNQcqY7HUfCctyRRDczLEJ4QwFV9AofE4zMmzgfr9WT//f9z1TgB+PvzvS0rNCzOgesePAxCdb+KWlgpstuwVjOTLrjof0YTBlKeN5miEizPFsUCvECL3ii+gNDht01SkDJzXuc3GctrKm3Ck6uideRUC7eY3CzSgzo6+jENrzgZbOdBSYXVzNqW7NQDAmWQDLckko+ExkkbS4lYJIQpBUQZUyjZHlXJmtcR8qeaSW5jlDFGlwN9YsJV8vZOn6UgkOGu0cktrhdXN2ZSuGh/+Egcvz1bRkkiS1ClGw6NWN0sIUQCKLqBAE7VFqXLkrmLt1to7wJbg2f5fFnSp+dnwMDviKQZ1PfubK6xuzqbYbIpbWip47lIpzckUIKXmQghT0QWU1poZe4qqkkDOrvHerjvR2s5P+p83K/kKsEhiJj7DmDFPfaqU5io/VT631U3atO7WAMcvx2j21AFwXu5DCSEowoBy6ARTdjtV3rqcXWN/Ux1GpI03Jl82A2ruEsTmcna9zegN9gJgi1ZxS5Hef8robgugNbg8bfg0nAuds7pJQogCUHQBZdcxwjZb1ifpLuVx2alQe5lKDjLpT69WUWC9qN7xNwEIhZuLtkAiIxOwF1QzXfEEfaE+axskhCgIRRdQNh0HoLKyK6fX2V1xEIBfGumeU4Hdhzo7dhR/ymA40cEtrbkb7syHco+TnbU+3pivYUcsxrng2YWdk4UQ21fxBRRmQOWyBwVwe9NN6JSHf8v0nAqs1PzM1Bl2xeMM2NrZ01BmdXOu24HWCp4PBtiRSBCKzzAZnbS6SUIIixVdQCnMOTJVnqqcXufm5kqS4S5eunwU7a0uqB5UykjRO3+ZXfEU5Q1duBxF9894je7WAK/P19EVN38BkWE+IUQRvrOlA6oktwG1p7GMVHgnwfhlBitbCyqgzs+eZ54U5TEfN7fm9nXIl+62AJOU02QzhyulUEIIUXQBpTEAqPRU5vQ6ZSVO6p03AfCizwfBwZxebyNOT5wCIDbfwoEiv/+UsSM9YXfWsYNyQwJKCFGEAZVSCrd24rbnft7PzfVd2JJVvGhLwvRQwZSanx55EYfWDMduLPoKvozMhN2j8Ta64lH6ps5a3SQhhMWKLqCSQIny5+Vae5vKiM528XJsnCQaLp/My3XXcvryMXbGE1wo2UtzwGN1c7LmQGuAf5ttZEc8wblgr1TyCbHNFV9AKYXTltvhvYx9jeWkwjuJGDGOu10w9mZerrsarTVnwsN0xVNUtOxF5Wg9Qit0t1bwRqqTHfEEs6l5LkcuW90kIYSFii6gEkrhsuenMGBvYxnJSCegeNFfURABdTlymSmdoDRawS1tW6NAIuNAa4AJymnSPkAq+YTY7oouoJIoPLbyvFyryuemwVeFX7Xzoq+8IALq9PgxAKLRlqJf4uhq5R4nO2p9aMOc49Yb6rW4RUIIKxVdQBlK47VX5O16e9PDfG+oOHOXT4KRytu1l3P6ws8BGInt4ebm/AR1PnW3VnByvp3KVIq+ydNWN0cIYaGCCCil1H3pPw+t5/hSR0WOW7RoX1MZkxNtpNC84tSWz4c6PX6M1kSCSMVB/CVOS9uSCwdaA7wcazMLJSaOW90cIYSFLA8opdQh4IjW+gmgM/31qkrz3INKRtpwKxcvlpTA2Bt5u/ZyTodHaIsr2tpyuxahVbpbAxw3OsxFY+eGpZJPiG3M8oACOoFMKPWnv16Vz5m/yan7mspAO2gs2cuLXo+l96Fm47MM6RjeaEXR7qC7lp21PqLuappSbiI6IbvrCrGNWR5QWusn0r0ngG6gZ63n+PMYUPVlJVSVunCndjPodDA2+mrern210yMvA1uzQCLDZlPc0lqBLVkPyIoSQmxnlgdUhlKqG3hWa31NAqTvT/UopXoAyvIYUEop9jaVE5zoAODFaesqy86c/1cAJhM3s6suP5OVrXCgNcDIbBsA5yZOWNwaIYRVCiaggENa64eXeyDdyzqotT6ItuF1evPasJubyhkc9VNl9/CiisGcNRNIT42/QVUyhavuTuy2rTNB92oHWis4ndxFTTLJuTHreqxCCGsVREAppe7LhNPaRRI2HPb8vjm/d189SQPaHTt4yVOCMXosr9fPOB0epjluY097oyXXz5fuFrNQ4sZ4guNBKTUXYruyPKDSgfSQUqpPKRVc63idKMdpy2+z9zaWsbPWx+T0XoJ2O2cu/Cyv1weIJaP06xjeaGDL3n/KKPc6KatpYk/MzkA8xMT8hNVNEkJYwPKA0lof0VoHtNZd6Y9HVj3e8OS9B6WU4kPdTRy/aBYYvng5/8NOx858n6RSROc7t8wK5qvpbg3gnjd7ikfHjlrcGiGEFSwPqM1w2PPf7A/e0oROltGacvJiZDjv13+59wfYtGbc9h5qy0ryfv18624LcHquG49h0DPwE6ubI4SwQHEGlAUFAk0VHu7orKQmUsWr9hTR+TVHI7PqleApOuI2OltvzOt1rXKgtYKfpw5wSyxGz6VXrG6OEMICElAb8OEDzUSmO4krxau9/5S360ZC53lDJSgJ13Nb29bYQXctO2v9RNw17Er6OBcPEozm9xcCIYT1ijKgnBYM8QG876Z6LkVvx2MYPNf/o7xd9/Vj/x9JpZiK3sqHDjTn7bpWstsUd3RWMT+3A4CjF5+3uEVCiHwryoDKd5FEhr/EyU27b6E7ojgSOk0qTyub/+L8v2LXmoM3fphy79ZbIHYln7iznddm3kKJYdBz7odWN0cIkWfFGVB5LjNf6kMHmvDNtjGlDF4deiH3F0zGOBodpT7q4VNv25P76xWQX9lRRaz2LeyNpeiZsH4vLiFEfhVlQDkt6kEBvH1XDVOJd1JiGDxz4hs5v97U6Wc45XJQ49hNR3Vpzq9XSJRSfPIdO6iIVHI2Ncd0dNrqJgkh8qgoA8qKMvMMp91G+83v5q2RBEfGX835MN8zr3yTlFL8h5vvyel1CtX/cXMjqeTNaKV49cx3rW6OECKPijOgLF6H7oPdbdTN1TOpE7x2KXeTdrVhcHb2TRwaPnbgV3N2nULmtNs4cMtv4TI0z5/+Z6ubI4TIo6IMKKuq+DJubi4npd+G2zD4yclv5+w6rx59kRMlBl32ejxOT86uU+jufvtb6IopXpuVrTeE2E6KMqCsquLLUErRsP+D3DUf5ScjL2BoIyfXGXjhK5x2OXnnzjU3Gd7SykqcdDg7GHCkODVgzUK9Qoj8K8qAyvdisct57+372DXnZ9KI8vrl17N+/v6LQ7gSz6GV4q0d2zugAA7f8VkMpfj75/7Y6qYIIfLE+nf6TbC6BwXQUuml1P5WXIbmX85+L+vnP/ujL/Ejv4tKZzk319yc9fMXm7fufS83JEr4JecIhsatbo4QIg8koK5D7U2HeU84wvcH/pmp6FTWzhucnqFm/En+3evhY3s/jtO2fSbnrubXu+5lxGnnyR9IL0qI7aAoA6oQhvgA7vyVd/GhECSMJF8/8fWsnfe1f36cZ8s0DmXno7s+mrXzFrt73/5/UpFSvDz3MxLxqNXNEULkWGG8029QofSgyktdzNb/Bu8Ph/nm8W9mpRcVjydo6P1/+Z7fz3va30u1pzoLLd0anHYn7wq8jVc8do788FGrmyOEyLGiDCiry8yXeudv/TG/OWsjqRN8/tkvXvf5Xnv2W7zum2HeBvfuvjcLLdxaPnPoCygULw19C23kpnpSCFEYCuedfgOsnqi7lM3tZc+hP+YD4TAvTzzNd46e2vS5fnlqgJpXHuIbZQH2Vu2V4ohlNPgbOODs4Dlfihd//FWrmyOEyKGiDCh7AQUUgOPAx/kUAVBJ/vT5v+ZnZzdWZaa15ss/O8f0t3+XkZIgF12Kj+/+eI5aW/x+9677mbbbefP0/+D7R2QbDiG2qqILKIU5Ubag2B10/ur/w/vDEVyBf+f3nnyao+fXt8FeJJ7kD/7+NWZ/8ue8036Uxzr2UVlSyXva35PjRhevu1rfxl01B3msshT18u/xP773S5IpGe4TYqspvoAqtHDKuOH9/N8lHdSnEribvswnvvkDTo3OrPqUgYkwH/qbXxA98c98zvkUf7yzmzeil/j8bZ/HZXflqeHFRynFw4e+SIu3nr+qhx1vPsAnv/4ys9GE1U0TQmSR0lpb3YYN8TTu0vMjZ61uxvIuneDCtz7Ef65wMqd9MH4/v9l9M7V+NzX+Emr8bmr9bmrL3LzQO8H/9Z1X+aj6Kf/V/i3+uqGJrzqi/Jfu/8Inb/qk1X+TotA/3c/H/+mjtMzP8WtDN/P9ik/z+CfupKXSa3XThCg4SqmjWuuDVrdjIwoioJRSdwMhoFtr/fBqx3qbdunIcIEGFEDoImf+4aP8tnsWm+Fj9MKnScXqrjnsBnWBR0u/zu7kaf6h/Rb+u5rinl338IU7vlC4vcQC9LOL/8Yf/PQPuGN+nt+acPN1/Xt89j//J25tC1jdNCEKigTUZhqgVDfQqbV+Sil1H9CjtV5xD4vSpl06XMgBBRCb5bV/vJffS/QTsdm4S5XxwcDbaKcex/hJvKFTlM2d4pmKAP9Y38GJ+VHe0fwOHn3XozhsDqtbX3SePPMkj7z8EIlUjI/NzFI3eTODtYfZ2f0u3r2viRq/2+omCmE5CajNNECph4BntdZHlFKHWKMX5Wu+Qc8NnclfAzfLSDHV8xW+c+77/ENsiCmbwmsYlGhw25xM2xQRnWRHxQ7u3nU3d++6G7dd3kg3azwyzt8cfZTv9/8TbsNgfyzGriik5ltxenaxo3UPb913G7UNneD2gdML0lMV24gE1GYaoNTjwONa61fTAfVrWuvPr3S8v/kGPVsMAbVENBnlRye+Se/MIHGHi2gqRom9hA90foADtQdkSC+Lzkyd4R9PfpNjIy9xdn6Mq2v7PIaBQ4MTjV2bVUJKK5b/F5B/F7F1PPupE0UXUEUxnpQe+rsPINDUYXFrNq7EUcKH90vhQz7cUHkDX7jrzwCIJCKcmjzJ+PQg/cNn6B3pZy4RROk4EEfrJGAABhpjSRzpqz4KIaxQCAEVAirTn1cAk1cfoLV+AngC4ODBg/KuIdbF6/Rya/1BqD8IN1jdGiGs9ZVPF9+IQCHMg/oO0Jn+vBM4YmFbhBBCFAjLAypTsZe+/xRarYJPCCHE9lEIQ3yZITwhhBBigeU9KCGEEGI5ElBCCCEKkgSUEEKIgiQBJYQQoiBJQAkhhChIli91tFFKqVmguNY6yp1qYMLqRhQIeS0WyWuxSF6LRTdorf1WN2IjCqLMfIPOFNt6UrmilOqR18Ikr8UieS0WyWuxSCnVY3UbNkqG+IQQQhQkCSghhBAFqRgDSladWCSvxSJ5LRbJa7FIXotFRfdaFF2RxHallLobc+X3FTd0VEp1y1qGYrtaz/+R9HEPrPa4KBwF3YNSSt2tlDqklHpgM49vFUqpbgCt9REglPn6qmMOAV/Od9ussI6fi/vSfx7Kd9vybR2vxaH0ny39Wqzn/0j6uEPAbflsmxXW8XPxUPrjfflt2cYUbECt9QO33h/ILeI3MH8zBOgHDl19QPp1mMpjmyyxjp+LQ8CR9ALEnemvt6R1/h/5tfTj3dv9/8h2sc73xvuUUn2Yr1XBKtiAYu0fuO30A1nBleFTZVE7CsFa/+6dS77Xz+JeY1vRqq+F1vpVrfXn0192bvHh3wrW+D+SHgLfDvvNree98aNa665Cfz0KeR5UBav/wK31uNiaKljl3/2qrVu6MTfE3KoqWMf/gfQwz6fz0aACV7n2IVtCBWv/XHQrpWCN+3VWK+QelFgUYvE/VwUwaVlLikR6WOPZLd5rWJf0G9CnlVIVVrclh0Ks8n9kG/We1kVr/XD69agq5GHwQg6oEKu/Ka/1+FbyHRaHqjqBIwBb/A1nJSHW9+9+qJB/M8ySEGu8KS+5/9APFPQN8eu01v+RznThwN3pz7fy/bgQq/9cZF4H0o8V7DB4IQfUWj9wyz6+FWV6AenfdEJLegXPZY5J/8AdXPKDt1WtGdZKqfsy4VTIvx1mwVqvxSGufKMq6Bvi12Ot/yNa66e01k9hvh4VljQyf9b6uehn8f2yCyjYJZAKeh5UugSyH/MG7xPp7x3VWt+60uNi61vt5yL9BvWPmGPwlZg3g7fsLy9rvBYVwD2Yr8Wvaa3lPtQ2sc73zqn04wU70lDQASWEEGL7KuQhPiGEENuYBJQQQoiCJAElhBCiIElACSGEKEgSUEIIIQqSBJQQQoiCJAElhBCiIElACSGEKEgSUEIIIQqSBJQQWZBemLVPKfWPS76usLhZQhQ1CSghsuMQcCvweGYbba11yNIWCVHkZC0+IbIo3Wuq1Fpv2ZXDhcgXCSghsiQzpCc9JyGyQ4b4hMgCpVQnLIZT5mshxOY5rG6AEMUuvTvrQWBKKXUE835UiC28QaAQ+SA9KCGuw5JhvScwdy8dAG7bypskCpEvcg9KCCFEQZIelBBCiIIkASWEEKIgSUAJIYQoSBJQQgghCpIElBBCiIIkASWEEKIgSUAJIYQoSBJQQgghCpIElBBCiIL0/wPhZxQry66XLQAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -15440,34 +15175,6 @@ Wall time: 954 ms
 
 </div>
 
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span> 
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span> 
-</pre></div>
-
-     </div>
-</div>
-</div>
 </div>
 
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">

--- a/nb/demo.ipynb
+++ b/nb/demo.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,29 +70,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PDF at one point for one distribution: 0.3520653267642995\n",
-      "PDF at three points for one distribution: [0.35206533 0.24197072 0.1295176 ]\n",
-      "PDF at one point for three distributions: [0.35206533 0.35206533 0.1295176 ]\n",
-      "PDF at one different point for three distributions: [0.35206533 0.39894228 0.35206533]\n",
-      "PDF at four different points for three distributions:\n",
-      " [[0.35206533 0.35206533 0.1295176 ]\n",
-      " [0.24197072 0.39894228 0.24197072]\n",
-      " [0.1295176  0.35206533 0.35206533]\n",
-      " [0.05399097 0.24197072 0.39894228]]\n",
-      "PDF at four different points for three distributions: broadcast reversed\n",
-      " [[0.35206533 0.24197072 0.1295176  0.05399097]\n",
-      " [0.35206533 0.39894228 0.35206533 0.24197072]\n",
-      " [0.1295176  0.24197072 0.35206533 0.39894228]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# evaluate a single distribution's PDF at one value\n",
     "print(\"PDF at one point for one distribution:\", \n",
@@ -133,20 +113,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This is the generic normal distribution class:  <class 'scipy.stats._continuous_distns.norm_gen'>\n",
-      "This is an instance of the generic normal distribution class <scipy.stats._continuous_distns.norm_gen object at 0x7fd6b870c160>\n",
-      "This is a frozen normal distribution, with specific paramters <scipy.stats._distn_infrastructure.rv_frozen object at 0x7fd6b870c5b0> {'loc': 0, 'scale': 1}\n",
-      "The frozen object know what generic distribution it comes from <scipy.stats._continuous_distns.norm_gen object at 0x7fd66abc9040>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"This is the generic normal distribution class: \", \n",
     "      sps._continuous_distns.norm_gen)\n",
@@ -181,24 +150,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PDF =  0.3520653267642995\n",
-      "CDF =  0.6914624612740131\n",
-      "PPF =  0.2533471031357997\n",
-      "SF  =  0.2742531177500736\n",
-      "ISF =  0.0\n",
-      "RVS =  -0.1331918386344051\n",
-      "stats =  (array(0.), array(1.))\n",
-      "M2  =  1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"PDF = \", norm_sp.pdf(0.5))  \n",
     "print(\"CDF = \", norm_sp.cdf(0.5))\n",
@@ -230,658 +184,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "odict_keys(['alpha', 'anglit', 'arcsine', 'argus', 'beta', 'betaprime', 'bradford', 'burr', 'burr12', 'cauchy', 'chi', 'chi2', 'cosine', 'crystalball', 'dgamma', 'dweibull', 'erlang', 'expon', 'exponnorm', 'exponpow', 'exponweib', 'f', 'fatiguelife', 'fisk', 'foldcauchy', 'foldnorm', 'gamma', 'gausshyper', 'genexpon', 'genextreme', 'gengamma', 'genhalflogistic', 'genhyperbolic', 'geninvgauss', 'genlogistic', 'gennorm', 'genpareto', 'gilbrat', 'gompertz', 'gumbel_l', 'gumbel_r', 'halfcauchy', 'halfgennorm', 'halflogistic', 'halfnorm', 'hypsecant', 'invgamma', 'invgauss', 'invweibull', 'johnsonsb', 'johnsonsu', 'kappa3', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'laplace', 'laplace_asymmetric', 'levy', 'levy_l', 'levy_stable', 'loggamma', 'logistic', 'loglaplace', 'lognorm', 'loguniform', 'lomax', 'maxwell', 'mielke', 'moyal', 'nakagami', 'ncf', 'nct', 'ncx2', 'norm', 'norminvgauss', 'pareto', 'pearson3', 'powerlaw', 'powerlognorm', 'powernorm', 'rayleigh', 'rdist', 'recipinvgauss', 'reciprocal', 'rice', 'semicircular', 'skewcauchy', 'skewnorm', 'studentized_range', 't', 'trapezoid', 'trapz', 'triang', 'truncexpon', 'truncnorm', 'tukeylambda', 'uniform', 'vonmises', 'vonmises_line', 'wald', 'weibull_max', 'weibull_min', 'wrapcauchy', 'spline', 'hist', 'interp', 'interp_irregular', 'quant', 'quant_piecewise', 'mixmod', 'sparse'])"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qp.stats.keys()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Help on class lognorm in module qp.factory:\n",
-      "\n",
-      "class lognorm(qp.pdf_gen.Pdf_gen_wrap, scipy.stats._continuous_distns.lognorm_gen)\n",
-      " |  lognorm(*args, **kwargs)\n",
-      " |  \n",
-      " |  Mixin class to extend `scipy.stats.rv_continuous` with\n",
-      " |  information needed for `qp` for analytic distributions.\n",
-      " |  \n",
-      " |  Method resolution order:\n",
-      " |      lognorm\n",
-      " |      qp.pdf_gen.Pdf_gen_wrap\n",
-      " |      qp.pdf_gen.Pdf_gen\n",
-      " |      scipy.stats._continuous_distns.lognorm_gen\n",
-      " |      scipy.stats._distn_infrastructure.rv_continuous\n",
-      " |      scipy.stats._distn_infrastructure.rv_generic\n",
-      " |      builtins.object\n",
-      " |  \n",
-      " |  Methods defined here:\n",
-      " |  \n",
-      " |  freeze = _my_freeze(self, *args, **kwds)\n",
-      " |  \n",
-      " |  moment = _moment_fix(self, n, *args, **kwds)\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Data and other attributes defined here:\n",
-      " |  \n",
-      " |  name = 'lognorm'\n",
-      " |  \n",
-      " |  version = 0\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Methods inherited from qp.pdf_gen.Pdf_gen_wrap:\n",
-      " |  \n",
-      " |  __init__(self, *args, **kwargs)\n",
-      " |      C'tor\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Class methods inherited from qp.pdf_gen.Pdf_gen_wrap:\n",
-      " |  \n",
-      " |  add_mappings() from builtins.type\n",
-      " |      Add this classes mappings to the conversion dictionary\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Class methods inherited from qp.pdf_gen.Pdf_gen:\n",
-      " |  \n",
-      " |  add_method_dicts() from builtins.type\n",
-      " |      Add empty method dicts\n",
-      " |  \n",
-      " |  create(**kwds) from builtins.type\n",
-      " |      Create and return a `scipy.stats.rv_frozen` object using the\n",
-      " |      keyword arguemntets provided\n",
-      " |  \n",
-      " |  create_gen(**kwds) from builtins.type\n",
-      " |      Create and return a `scipy.stats.rv_continuous` object using the\n",
-      " |      keyword arguemntets provided\n",
-      " |  \n",
-      " |  creation_method(method=None) from builtins.type\n",
-      " |      Return the method used to create a PDF of this type\n",
-      " |  \n",
-      " |  extraction_method(method=None) from builtins.type\n",
-      " |      Return the method used to extract data to create a PDF of this type\n",
-      " |  \n",
-      " |  plot(pdf, **kwargs) from builtins.type\n",
-      " |      Plot the pdf as a curve\n",
-      " |  \n",
-      " |  plot_native(pdf, **kwargs) from builtins.type\n",
-      " |      Plot the PDF in a way that is particular to this type of distibution\n",
-      " |      \n",
-      " |      This defaults to plotting it as a curve, but this can be overwritten\n",
-      " |  \n",
-      " |  print_method_maps(stream=<ipykernel.iostream.OutStream object at 0x7fd762d39790>) from builtins.type\n",
-      " |      Print the maps showing the methods\n",
-      " |  \n",
-      " |  reader_method(version=None) from builtins.type\n",
-      " |      Return the method used to convert data read from a file PDF of this type\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Readonly properties inherited from qp.pdf_gen.Pdf_gen:\n",
-      " |  \n",
-      " |  metadata\n",
-      " |      Return the metadata for this set of PDFs\n",
-      " |  \n",
-      " |  objdata\n",
-      " |      Return the object data for this set of PDFs\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Data descriptors inherited from qp.pdf_gen.Pdf_gen:\n",
-      " |  \n",
-      " |  __dict__\n",
-      " |      dictionary for instance variables (if defined)\n",
-      " |  \n",
-      " |  __weakref__\n",
-      " |      list of weak references to the object (if defined)\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Methods inherited from scipy.stats._continuous_distns.lognorm_gen:\n",
-      " |  \n",
-      " |  fit = wrapper(self, *args, **kwds)\n",
-      " |      # if fit method is overridden only for MLE and doesn't specify what to do\n",
-      " |      # if method == 'mm', this decorator calls generic implementation\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Methods inherited from scipy.stats._distn_infrastructure.rv_continuous:\n",
-      " |  \n",
-      " |  __getstate__(self)\n",
-      " |  \n",
-      " |  cdf(self, x, *args, **kwds)\n",
-      " |      Cumulative distribution function of the given RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      x : array_like\n",
-      " |          quantiles\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      cdf : ndarray\n",
-      " |          Cumulative distribution function evaluated at `x`\n",
-      " |  \n",
-      " |  expect(self, func=None, args=(), loc=0, scale=1, lb=None, ub=None, conditional=False, **kwds)\n",
-      " |      Calculate expected value of a function with respect to the\n",
-      " |      distribution by numerical integration.\n",
-      " |      \n",
-      " |      The expected value of a function ``f(x)`` with respect to a\n",
-      " |      distribution ``dist`` is defined as::\n",
-      " |      \n",
-      " |                  ub\n",
-      " |          E[f(x)] = Integral(f(x) * dist.pdf(x)),\n",
-      " |                  lb\n",
-      " |      \n",
-      " |      where ``ub`` and ``lb`` are arguments and ``x`` has the ``dist.pdf(x)``\n",
-      " |      distribution. If the bounds ``lb`` and ``ub`` correspond to the\n",
-      " |      support of the distribution, e.g. ``[-inf, inf]`` in the default\n",
-      " |      case, then the integral is the unrestricted expectation of ``f(x)``.\n",
-      " |      Also, the function ``f(x)`` may be defined such that ``f(x)`` is ``0``\n",
-      " |      outside a finite interval in which case the expectation is\n",
-      " |      calculated within the finite range ``[lb, ub]``.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      func : callable, optional\n",
-      " |          Function for which integral is calculated. Takes only one argument.\n",
-      " |          The default is the identity mapping f(x) = x.\n",
-      " |      args : tuple, optional\n",
-      " |          Shape parameters of the distribution.\n",
-      " |      loc : float, optional\n",
-      " |          Location parameter (default=0).\n",
-      " |      scale : float, optional\n",
-      " |          Scale parameter (default=1).\n",
-      " |      lb, ub : scalar, optional\n",
-      " |          Lower and upper bound for integration. Default is set to the\n",
-      " |          support of the distribution.\n",
-      " |      conditional : bool, optional\n",
-      " |          If True, the integral is corrected by the conditional probability\n",
-      " |          of the integration interval.  The return value is the expectation\n",
-      " |          of the function, conditional on being in the given interval.\n",
-      " |          Default is False.\n",
-      " |      \n",
-      " |      Additional keyword arguments are passed to the integration routine.\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      expect : float\n",
-      " |          The calculated expected value.\n",
-      " |      \n",
-      " |      Notes\n",
-      " |      -----\n",
-      " |      The integration behavior of this function is inherited from\n",
-      " |      `scipy.integrate.quad`. Neither this function nor\n",
-      " |      `scipy.integrate.quad` can verify whether the integral exists or is\n",
-      " |      finite. For example ``cauchy(0).mean()`` returns ``np.nan`` and\n",
-      " |      ``cauchy(0).expect()`` returns ``0.0``.\n",
-      " |      \n",
-      " |      The function is not vectorized.\n",
-      " |      \n",
-      " |      Examples\n",
-      " |      --------\n",
-      " |      \n",
-      " |      To understand the effect of the bounds of integration consider\n",
-      " |      \n",
-      " |      >>> from scipy.stats import expon\n",
-      " |      >>> expon(1).expect(lambda x: 1, lb=0.0, ub=2.0)\n",
-      " |      0.6321205588285578\n",
-      " |      \n",
-      " |      This is close to\n",
-      " |      \n",
-      " |      >>> expon(1).cdf(2.0) - expon(1).cdf(0.0)\n",
-      " |      0.6321205588285577\n",
-      " |      \n",
-      " |      If ``conditional=True``\n",
-      " |      \n",
-      " |      >>> expon(1).expect(lambda x: 1, lb=0.0, ub=2.0, conditional=True)\n",
-      " |      1.0000000000000002\n",
-      " |      \n",
-      " |      The slight deviation from 1 is due to numerical integration.\n",
-      " |  \n",
-      " |  fit_loc_scale(self, data, *args)\n",
-      " |      Estimate loc and scale parameters from data using 1st and 2nd moments.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      data : array_like\n",
-      " |          Data to fit.\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information).\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      Lhat : float\n",
-      " |          Estimated location parameter for the data.\n",
-      " |      Shat : float\n",
-      " |          Estimated scale parameter for the data.\n",
-      " |  \n",
-      " |  isf(self, q, *args, **kwds)\n",
-      " |      Inverse survival function (inverse of `sf`) at q of the given RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      q : array_like\n",
-      " |          upper tail probability\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      x : ndarray or scalar\n",
-      " |          Quantile corresponding to the upper tail probability q.\n",
-      " |  \n",
-      " |  logcdf(self, x, *args, **kwds)\n",
-      " |      Log of the cumulative distribution function at x of the given RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      x : array_like\n",
-      " |          quantiles\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      logcdf : array_like\n",
-      " |          Log of the cumulative distribution function evaluated at x\n",
-      " |  \n",
-      " |  logpdf(self, x, *args, **kwds)\n",
-      " |      Log of the probability density function at x of the given RV.\n",
-      " |      \n",
-      " |      This uses a more numerically accurate calculation if available.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      x : array_like\n",
-      " |          quantiles\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      logpdf : array_like\n",
-      " |          Log of the probability density function evaluated at x\n",
-      " |  \n",
-      " |  logsf(self, x, *args, **kwds)\n",
-      " |      Log of the survival function of the given RV.\n",
-      " |      \n",
-      " |      Returns the log of the \"survival function,\" defined as (1 - `cdf`),\n",
-      " |      evaluated at `x`.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      x : array_like\n",
-      " |          quantiles\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      logsf : ndarray\n",
-      " |          Log of the survival function evaluated at `x`.\n",
-      " |  \n",
-      " |  nnlf(self, theta, x)\n",
-      " |      Negative loglikelihood function.\n",
-      " |      \n",
-      " |      Notes\n",
-      " |      -----\n",
-      " |      This is ``-sum(log pdf(x, theta), axis=0)`` where `theta` are the\n",
-      " |      parameters (including loc and scale).\n",
-      " |  \n",
-      " |  pdf(self, x, *args, **kwds)\n",
-      " |      Probability density function at x of the given RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      x : array_like\n",
-      " |          quantiles\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      pdf : ndarray\n",
-      " |          Probability density function evaluated at x\n",
-      " |  \n",
-      " |  ppf(self, q, *args, **kwds)\n",
-      " |      Percent point function (inverse of `cdf`) at q of the given RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      q : array_like\n",
-      " |          lower tail probability\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      x : array_like\n",
-      " |          quantile corresponding to the lower tail probability q.\n",
-      " |  \n",
-      " |  sf(self, x, *args, **kwds)\n",
-      " |      Survival function (1 - `cdf`) at x of the given RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      x : array_like\n",
-      " |          quantiles\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      sf : array_like\n",
-      " |          Survival function evaluated at x\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Methods inherited from scipy.stats._distn_infrastructure.rv_generic:\n",
-      " |  \n",
-      " |  __call__(self, *args, **kwds)\n",
-      " |      Freeze the distribution for the given arguments.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution.  Should include all\n",
-      " |          the non-optional arguments, may include ``loc`` and ``scale``.\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      rv_frozen : rv_frozen instance\n",
-      " |          The frozen distribution.\n",
-      " |  \n",
-      " |  __setstate__(self, state)\n",
-      " |  \n",
-      " |  entropy(self, *args, **kwds)\n",
-      " |      Differential entropy of the RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information).\n",
-      " |      loc : array_like, optional\n",
-      " |          Location parameter (default=0).\n",
-      " |      scale : array_like, optional  (continuous distributions only).\n",
-      " |          Scale parameter (default=1).\n",
-      " |      \n",
-      " |      Notes\n",
-      " |      -----\n",
-      " |      Entropy is defined base `e`:\n",
-      " |      \n",
-      " |      >>> drv = rv_discrete(values=((0, 1), (0.5, 0.5)))\n",
-      " |      >>> np.allclose(drv.entropy(), np.log(2.0))\n",
-      " |      True\n",
-      " |  \n",
-      " |  interval(self, alpha, *args, **kwds)\n",
-      " |      Confidence interval with equal areas around the median.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      alpha : array_like of float\n",
-      " |          Probability that an rv will be drawn from the returned range.\n",
-      " |          Each value should be in the range [0, 1].\n",
-      " |      arg1, arg2, ... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information).\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter, Default is 0.\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter, Default is 1.\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      a, b : ndarray of float\n",
-      " |          end-points of range that contain ``100 * alpha %`` of the rv's\n",
-      " |          possible values.\n",
-      " |  \n",
-      " |  mean(self, *args, **kwds)\n",
-      " |      Mean of the distribution.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      mean : float\n",
-      " |          the mean of the distribution\n",
-      " |  \n",
-      " |  median(self, *args, **kwds)\n",
-      " |      Median of the distribution.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          Location parameter, Default is 0.\n",
-      " |      scale : array_like, optional\n",
-      " |          Scale parameter, Default is 1.\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      median : float\n",
-      " |          The median of the distribution.\n",
-      " |      \n",
-      " |      See Also\n",
-      " |      --------\n",
-      " |      rv_discrete.ppf\n",
-      " |          Inverse of the CDF\n",
-      " |  \n",
-      " |  rvs(self, *args, **kwds)\n",
-      " |      Random variates of given type.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information).\n",
-      " |      loc : array_like, optional\n",
-      " |          Location parameter (default=0).\n",
-      " |      scale : array_like, optional\n",
-      " |          Scale parameter (default=1).\n",
-      " |      size : int or tuple of ints, optional\n",
-      " |          Defining number of random variates (default is 1).\n",
-      " |      random_state : {None, int, `numpy.random.Generator`,\n",
-      " |                      `numpy.random.RandomState`}, optional\n",
-      " |      \n",
-      " |          If `seed` is None (or `np.random`), the `numpy.random.RandomState`\n",
-      " |          singleton is used.\n",
-      " |          If `seed` is an int, a new ``RandomState`` instance is used,\n",
-      " |          seeded with `seed`.\n",
-      " |          If `seed` is already a ``Generator`` or ``RandomState`` instance\n",
-      " |          then that instance is used.\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      rvs : ndarray or scalar\n",
-      " |          Random variates of given `size`.\n",
-      " |  \n",
-      " |  stats(self, *args, **kwds)\n",
-      " |      Some statistics of the given RV.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional (continuous RVs only)\n",
-      " |          scale parameter (default=1)\n",
-      " |      moments : str, optional\n",
-      " |          composed of letters ['mvsk'] defining which moments to compute:\n",
-      " |          'm' = mean,\n",
-      " |          'v' = variance,\n",
-      " |          's' = (Fisher's) skew,\n",
-      " |          'k' = (Fisher's) kurtosis.\n",
-      " |          (default is 'mv')\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      stats : sequence\n",
-      " |          of requested moments.\n",
-      " |  \n",
-      " |  std(self, *args, **kwds)\n",
-      " |      Standard deviation of the distribution.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      std : float\n",
-      " |          standard deviation of the distribution\n",
-      " |  \n",
-      " |  support(self, *args, **kwargs)\n",
-      " |      Support of the distribution.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, ... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information).\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter, Default is 0.\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter, Default is 1.\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      a, b : array_like\n",
-      " |          end-points of the distribution's support.\n",
-      " |  \n",
-      " |  var(self, *args, **kwds)\n",
-      " |      Variance of the distribution.\n",
-      " |      \n",
-      " |      Parameters\n",
-      " |      ----------\n",
-      " |      arg1, arg2, arg3,... : array_like\n",
-      " |          The shape parameter(s) for the distribution (see docstring of the\n",
-      " |          instance object for more information)\n",
-      " |      loc : array_like, optional\n",
-      " |          location parameter (default=0)\n",
-      " |      scale : array_like, optional\n",
-      " |          scale parameter (default=1)\n",
-      " |      \n",
-      " |      Returns\n",
-      " |      -------\n",
-      " |      var : float\n",
-      " |          the variance of the distribution\n",
-      " |  \n",
-      " |  ----------------------------------------------------------------------\n",
-      " |  Data descriptors inherited from scipy.stats._distn_infrastructure.rv_generic:\n",
-      " |  \n",
-      " |  random_state\n",
-      " |      Get or set the generator object for generating random variates.\n",
-      " |      \n",
-      " |      If `seed` is None (or `np.random`), the `numpy.random.RandomState`\n",
-      " |      singleton is used.\n",
-      " |      If `seed` is an int, a new ``RandomState`` instance is used,\n",
-      " |      seeded with `seed`.\n",
-      " |      If `seed` is already a ``Generator`` or ``RandomState`` instance then\n",
-      " |      that instance is used.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "help(qp.stats.lognorm_gen)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Help on method create in module qp.pdf_gen:\n",
-      "\n",
-      "create(**kwds) method of builtins.type instance\n",
-      "    Create and return a `scipy.stats.rv_frozen` object using the\n",
-      "    keyword arguemntets provided\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "help(qp.stats.lognorm)"
    ]
@@ -897,22 +222,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYkAAAEJCAYAAABhbdtlAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqK0lEQVR4nO3deXhU530v8O9vRvs6WkYSYhMSSIDAgCTjLSwGgbEdO4mDTRInvU3syE1zn6TNvSHpcps+zR+JnTZL21u3OKmTuLFLjJfksW9skDBgGwMWSzCbBEiAWCSNltGKlpl57x9zxhqEhhlJM+fM8v08jx6d7ZV+COn8zruc9xWlFIiIiCZiMjoAIiIKX0wSRETkE5MEERH5xCRBREQ+MUkQEZFPcUYHEGy5ubmqqKjI6DCIiCLK4cOHO5RS1vHHoy5JFBUVob6+3ugwiIgiiohcnOg4m5uIiMgnJgkiIvKJSYKIiHzSPUmIyGYRqRaRrX6u2zrZMkREFFy6JgkRqQAApVQtALtnf4LrqgHcPpkyREQUfHrXJLYAsGvbTQCqQ1SGiIiCQO8kYQHQ5bWfM/4CEanQag0BlyEiotAIx/ckso0OgCiYegZHsfesDVft13FPSS7KCzNgMonRYREFRO8kYcdYErAA6PQ+OUEtwm8ZrVwNgBoAmDNnTrBiJZoypRR2HL6Ml+sv4/ClbjhdY+u2WNMTsX5hHr6xfgEKLckGRknkn95JYjuAKm27GEAtAIiIRSllB1AsIsWe81on9YRlvCmltgHYBgBVVVVcRYkM5XQpfP+NU/jl/gsozU/D19aUYN2iPMzKSsa7jR3YfaYdvzt2Fe80tOP5P12JxYUZRodM5JOuSUIpdUREqrTRS3al1BHtVB2ASqXUDuDjmoHFTxmisHN9xIlv/vdR7DzVhic/MQ9//cCiG5qWPls5C5+tnIUzrb348vMf4rH/+AD/9ngFVpfeNGUOUViQaFu+tKqqSnHuJjJC/7ADX/z5Qfzxsh1/98nF+PI98255fWvPEL78yw/R2NaHHz+2DJ9aPlOnSIluJiKHlVJV44/zjWuiIPn735/E8ct2PPt4pd8EAQAFmUn47VN3ompuFrbuOI5z7X06REk0OUwSREHw1olr2HH4Mr5+73xsWlIQcLn0pHj8yxdWIDUxDn+x/RhGHK4QRkk0eUwSRNPU3juEv3r1I9w2KxPfWL9g0uXz0pPwg0eW4sSVXvysrjEEERJNHZME0TQopfDtHcdxfdSJn2xZjnjz1P6k7isvwGNVs/DsnvOov9DlvwCRTpgkiKbhpUMt2Ntow988sAgl1rRpfa2/e6gcs7JS8Je/PYahUWeQIiSaHiYJoim6PuLEj3c1YmVRNr5459xpf720xDj88JGlaOm6jt8cvBSECImmj0mCaIpeOHABHf3D+N/3lUEkONNs3D0/F/fMz8Gze85hcMQRlK9JNB1MEkRT0D/swLN7zmN1qRUr5wV3urFvbShDR/8IfrV/wiWHiXTFJEE0Bc+/14zuwVH8rw2lQf/alXOzsG5hHv5973n0Do0G/esTTQaTBNEk9QyOYtu7TdiwOB/LZltC8j2+taEUPddH8Z/vNYfk6xMFikmCaJJ+/l4T+oYc+FYIahEeS2Zm4v4lBfjFu83oHhgJ2fch8odJgmgSBoYd+OX7F/Dg0hlYNCO0s7f+5YZS9A078MIB9k2QcZgkiCbhtaNX0DfswBOr/M/NNF2l+elYXWrFiwcvweHkdB1kDCYJogAppfDCBxexZGYGVoSoL2K8P7lzLlp7h7DrVJsu349oPCYJogAdau5CQ1sfvnTn3KC9F+HPvQvzMNOSjF9/wCYnMgaTBFGAXjhwEZnJ8Xh4mX7rPphNgsfvnIMPmjo5lTgZgkmCKADtvUN460QrHq2cheQEs67fe0vVbCSYTXiBtQkygO5JQkQ2i0i1iGz1cb5a+3ja69jT2ucaveIk8vbSoRY4XAqPB2GOpsnKSUvEg7fNwCtHrqB/mFN1kL50TRIiUgEASqlaAHbP/rjzG7TzFV7na0TkPIAmPeMlAoBRpwsvHrqI1aVWzMtNNSSGL901F/3DDrx29Ioh359il941iS0A7Np2E4Bq75NKqSNKqe9ou8VKqSPa9qNKqRIteRDpak+DDW29w/iSAbUIjxWzLSgvzMBLnB2WdKZ3krAA8F5RJWeii7SmqKe8DlX4aaKqEZF6Eam32WxBC5YIAF4/egU5qQlYW2Y1LAYRwebKWTh1rReNbezAJv2EZce1UuoZAE+JiMWzr9UickSkeoLrtymlqpRSVVarcX/IFH16h0ax63QbHlpWOOVV54Llk7cVwmwSvM4mJ9KR3r/1dgCeeZUtADq9T4qIdz9EE9x9EZtFZLN2rBNAsQ5xEgEA3vqoFSMOFz69Qr9hr75Y0xOxakEufnfsKlwuZXQ4FCP0ThLbMXaTLwZQCwCeGgPcfRTeSaRJ+/D0RZQAqNchTiIA7mk4inJSsGxWptGhAAA+vXwmrtiv40Oug0060TVJeDqitSYju1fHdJ32eRuAYk/NQSm1Q7vmMe3Yea8yRCF1rec6DjR34tMrZur2hrU/G8vzkZJgxuvH2ORE+ojT+xsqpbZNcKxS+2yHO1EAwI5blSEKtd8fuwql3E/v4SIlIQ73lRfgzePX8PcPlyMxTt8X+yj2hGXHNVE4eO3oFayYY0GRQe9G+PLpFTPRO+TAO2c4ko9Cj0mCaAKnr/XiTGsfPhMGHdbj3VOSg9y0RI5yIl0wSRBN4HfHrsJsEjy4dIbRodwkzmzCQ8tmYPeZdvRc5xrYFFpMEkTjKKXwhxPXcHdJDnLSEo0OZ0IPLSvEiNOF3We4zgSFFpME0Tinr/XhYucg7l8SfrUIj+WzLMjPSMRbJ1qNDoWiHJME0ThvnWyFiHu4abgymQSbyguwt9GGwRHODEuhwyRBNM5bJ67h9qJs5IZpU5PHfUsKMDTqwt4GjnKi0GGSIPJy3taPxrZ+3L+kwOhQ/FpZlI3s1AT8gU1OFEJMEkRePG3895WHf5KIM5uwYVE+dp9px7DDaXQ4FKWYJIi8vH2yFctmW1BoSTY6lIBsWlqA/mEH9p/r9H8x0RQwSRBpLncP4vjlHmyKgFqEx90lOUhPjMMfTlwzOhSKUkwSRJq3T7rfOdgUAf0RHolxZqxflIddp9rgcLqMDoeiEJMEkeatE9ewsCDdsHWsp2rTkgJ0D47iUDOnD6fgY5IgAtDZP4z6i93YGEFNTR5rSvOQFG/CzlN8+5qCj0mCCMA7DTYoBWxYFL4v0PmSnGDGPSW5qDvTBqW4Yh0FF5MEEYDdZ9qQn5GIJTMzjA5lStYvykdL13Wca+83OhSKMronCW3N6moR2erjfLX28XSgZYimY8Thwr7GDqxbmBc2K9BN1rqFeQCA2tPtBkdC0UbXJCEiFQCglKoFYPfsjzu/QTtfISIV/soQTdfB5k70DzuwfmHkNTV5FGQmYcnMDNSdZr8EBZfeNYktAOzadhOAau+TSqkjSqnvaLvF2nrWtyxDNF11p9uRGGfCPfNzjQ5lWtYtzMeRS93oGhgxOhSKInonCQsA73F6ORNdpDUrPRVoGRGpEZF6Eam32TjZGQVOKYW6M224Z34ukhMie73o6kV5cClgTwObnCh4wrLjWin1DICnRMQS4PXblFJVSqkqq9Ua2uAoqpxt70dL13WsX5RndCjTtqQwE3npiahjvwQFkd5Jwg4gW9u2ALhhwhnvPgi4m5Zq/JUhmg7PDdXT8RvJTCbBuoV52Ndow4iDb19TcOidJLYDKNa2iwHUAoBXjaEaNyaEJl9liIKh7nQbygszMCMzMib082f9onz0DTvw4QW+fU3BoWuS0DqiISLVAOyefQB12udtAIpFZLN2/Y5blCGalq6BERy51I31EfgCnS+fmJ+LxDgTajnKiYIkTu9vqJTaNsGxSu2zHe5EAQA7blWGaLr2NrbDpYD1UdDU5JGcYMbdJTnYfaYd33uo3OhwKAqEZcc1kR72NNiQm5aApTMzjQ4lqO5dmIeLnYNo7hgwOhSKAkwSFJOcLoW9jTasXmCFyRSZb1n7srbUXTPiUFgKBiYJikl/vGyHfXAUa8qib8j0nJwUFOemYk8D3xmi6WOSoJi0p8EGkwCrF0RfkgCANWVWHGjqxPURrn1N08MkQTFpb0M7ls+2ICs1wehQQuLesjwMO1w40MTXimh6mCQo5nT0D+OPl3uwtix6RjWNt3JeNpLjzeyXoGljkqCYs6/R3VZ/bxQniaR4M+4qydEWU+JCRDR1TBIUczxDX8sLI3OBoUCtLbPiUheHwtL0MElQTHG6FPadtWF1afQNfR1vbCgsRznR1DFJUEzxDH2N5qYmjzk5KSi2pmJPI5METR2TBMWUPWfaYRJg1YLIXmAoUGtL83CgqRODIw6jQ6EIxSRBMWVvow3LZ1tgSYnOoa/jrS2zYsThwsEmzgpLU8MkQTGja2AEx69E99DX8VbOy0ZSvAl72eREU8QkQTHj3bM2KAWsKY3Ot6wnkhRvxp3FOR8P+yWaLCYJihl7G23ISonHkiib9dWf1QusaOoYQEvXoNGhUATSPUmIyGYRqRaRrT7O12gfT3sde9pzTq84Kbq4XAr7GjuwaoEV5igf+jqeZxJDNjnRVOiaJDzrVyulagHYvdaz9pyvBlCrLTJUrO0DQI2InId7OVOiSTvd2ouO/uGYamryKM5NxaysZCYJmhK9axJbANi17Sa417T2Vux1rAlja1s/qpQq0ZIL0aR5bpCrSmNj6Ks3EcHqUiv2n+vAiMNldDgUYfROEhYA3mPxcrxPKqW2eS1VWgGg3rN9qyYqIn/2NtiweEYG8tKTjA7FEGtKrRgYceLwxW6jQ6EIE5Yd11oz1C6l1BEAUEo9o9UicryaoLyvrxGRehGpt9lYpaYb9Q87cPhid1QuMBSou0tyEGcS7DvLvw+aHL2ThB1AtrZtAeBrsvtqpdQzwMcd3Zu1450Ya4L6mFYDqVJKVVmtsXsjoIntP9cBh0vFZH+ER3pSPCrnZmEv53GiSdI7SWzH2E2+GEAtAIiIxXOBiNR4JYhquPsmPH0RJRhrgiIKyN5GG1ITzKiYk2V0KIZaXWrFqWu9aO8bMjoUiiC6JglP85F287d79gHUeR1/WkTOi0i3V5nHtNrEea8yRH4p5Z719e75uUiIC8vWVd14alL7GjsMjoQiSZze39CrY9r7WKX2uRbATY97E5UhCkRzxwBauq6jZnWJ0aEYbvGMDOSmJWJfow2bK2cZHQ5FiNh+tKKo5xn6ujaG+yM8TCbB6tJcvHvWBqeLq9VRYJgkKKrtbbShODcVs7NTjA4lLKwptaJ7cBQfXekxOhSKEEwSFLWGRp040NSJ1axFfGzVAitEwAn/KGBMEhS1PrzQhaFRV0y/HzFedmoCbpuZySk6KGBMEhS19jbYkBBnwp3zcvxfHEPWlFpx9FI3egZHjQ6FIgCTBEWtvY023DEvG8kJZqNDCStryqxwKeC9cxwKS/4xSVBUumq/jrPt/TH9lrUvy2ZZkJ4Ux34JCsik35MQkSK4J9/LhntqjSa4X4zbHdTIiKbBcwNkp/XN4swmrFqQi72NNiilIBJb62vQ5ARckxCRb4vITgBPwz09hgDo0bY3ishOEXlWRJaHJFKiSdjbaMOMzCQsyEszOpSwtKbUitbeITS29RsdCoU5vzUJEZkH4CkA/62U+pGfazPhXiCoSin18yDFSDQpDqcL753rwINLZ/Ap2QdPDWtvYzvKCtINjobC2S1rElqCWK+U+q5S6pi/L6aU6tESSZ2IPBmkGIkm5ViLHX1DDvZH3MKMzGSU5adzKCz5dcskoZRqnkqNYKrliIJhT4MNZpPg7vmxtwrdZKwps+LD5m4MDDuMDoXC2KRHN4lIRigCIQqWPY3tqJhjQWZyvNGhhLU1pVaMOF344LyvZV2IpjYEtsS7c1pE5onIuuCFRDR17X1DOHGlF2vL8owOJexVFWUhNcGMdxrajQ6Fwtikk4RS6iiA27WhsFBKNQPIEpEfBDk2oknzrLy2llNx+JUYZ8bd83Oxp8E9FJZoIlNpbtoO4DyAbq+mp1oANcEMjGgq9jTakJeeiMUz2CoaiLVlVlyxX8d5G4fC0sSm0txUCaBeKdUDQLRhr9UAfhhIYW3N6moR2erjfI328XSgZYgA99DXdxttWFNq5dDXAHma5fZw7WvyYSpJ4lFotQYtUWQDyPL3DgUAiEiFVq4WgN2z73W+GkCtthJdsZYYblmGyONYix29Qw72R0zCTEsyFuSlMUmQT1Pqk1BK/aPXfjOAwwG+ab0FgF3bboK7BuKt2OtYk7bvrwwRgLGhr59YwKGvk7G2zIpDzV0cCksTCsoEf1pndnMAl1oAdHnt3zCHs1Jqm9d61hUA6v2VIfLg0NepWVuWx6Gw5FPQZoHVmp6CQmtS2qWUOhLg9TUiUi8i9TYbq82xiENfp66qKAspCWbsaeRQWLqZ32k5pjK9xi3K2eHuwwDcNQRfjy7VSqlnAi2j1UCqlFJVViuHPsaifY3utRE4FcfkJcaZcXcJh8LSxPxOywH3PEz/HsgLcyKSISLfhnu+p4mm5dgOdz8DtM+1WjmL19eo8SQIrSN7wjJE3t5paIc1PRHlhRz6OhVry6y43M2hsHQzv7PAaoniz0TkqyLyXQAKwBGMPdHnwP2EXwL3+xPPaGUm+lpHRKRKu/nbvZqT6gBUasefFpHvwF17ePQWZYgAAKNOF/Y12nD/kgIOfZ2iexe6m+l2n2nH/DzOCktjAl50SCn1HIDntPciquBODNlwd1g3aZ3XgXydbRMcq9Q+1wLICqQMkUf9hW70DTmwbmG+0aFErJmWZCwsSEfd6XbUrC4xOhwKI5NemU7roK4LQSxEU7L7TBsSzCYOfZ2m9Yvy8O97m9AzOIrMFI4QI7cpjW4SkSe1Veie5KywZLTdZ9pxR3E20hIn/cxDXtYtzIfTpbDvLEcI0pipzN30QwDz4V669DEAzSLyRLADIwrEhY4BnLcNYN1CDn2druWzLchOTcDuMxwKS2Om8uj1oVLqFc+ONjLpuyLyiFLq1aBFRhQAzw2NSWL6zCbB2lIrdje0w+lSMJs4CICC8DKdUsqulPou+CY0GcA9GicNc3NSjQ4lKqxblAf74CiOXuo2OhQKE1NJEk0i8qGI3DuuP4Lv9JOu+ocdONjcifWsRQTNqgVWxJmETU70sakkiS0AfgvgawAuaAnjbbhnbU0HABF5JIgxEk3ovbM2jDoVm5qCKDM5HrcXZTNJ0MemkiTOA3hZKfWYUiob7mnDawFsBHBRRM4CePpWX4AoGOpOtyMjKQ6Vc296tYamYf2iPJxp7cPl7kGjQ6EwMJWpwp+De7nSIm3/qFLqR0qpjVrS2ILAZoQlmjKXS+GdBhvWlOUhzhy0eSoJN759TTSlvy4tMVzwce4IgO9MJygif4622NHRP4zqRWxqCrbi3FQU56Zi16k2o0OhMBCSR7BAp+ggmqqdp1oRZxJODR4CIoINi/NxoKkTvUOjRodDBmM9nSKOUgo7T7bhrpIcLjAUIhvL8zHqVFzWlJgkKPKct/WjuWMAGxdzQr9QWT47C7lpidh5stXoUMhgTBIUcd4+6W4rr2aSCBmzSbBhcR72NNgw7HAaHQ4ZiEmCIs7OU21YNisTMzKTjQ4lqm1cXID+YQfXvo5xuicJEdksItUisvUW11SM239a+1wT6vgovLX2DOGPLXZsLC8wOpSod1dJDlITzNjJUU4xTdck4bn5a4sL2ccnA+2aagDPjTtcIyLnATSFPkoKZ7tOu29Y7I8IvaR4M9aW5WHXqTa4XFz7OlbpXZPYAsCubTcBqB5/gZZAusYdflQpVaKdoxi282Qr5uWmYn5emtGhxISN5fmw9Q3j2GW70aGQQfROEhbcmAACnTm2wl8TFUW/nuuj+OB8JzYuzuda1jpZW5aHOJNg50k2OcWqiOi4Vko9o9UicrTmKIpBexra4XApbGBTk24yk+NxV0kOdp5shVJscopFeicJO4BsbduCAKYX1zq6N2u7nQCKJ7imRkTqRaTeZuPLP9HqzePXkJeeiIo5nNBPT5uWFKCpYwBnWvuMDoUMoHeS2I6xm3wx3LPHela386XJcx2AEgD14y9QSm1TSlUppaqsVmvwoqWw0T/swJ5GGx5YOgMmrpimq/vKC2AS4P99dM3oUMgAuiYJbfI/zwgmu2cfQJ3nGq3WUOWpPWjXPKbtn/cqQzGk7nQbRhwuPHjbDKNDiTm5aYm4qyQHbx6/xianGDSVNa6nRSm1bYJjlV7bOwDs8FeGYsubx68hPyMRlWxqMsQDS2fgb147gdPX+rC4MMN/AYoaEdFxTbGtb2gUexptuH8Jm5qMsolNTjGLSYLC3u4z7RhxuPBJNjUZJsfT5PQRm5xiDZMEhb03jl9DQUYSRzUZ7MGlhWjuGMDpaxzlFEuYJCis9Q2NYm+jDfcvLWBTk8HuK8+H2SR486OrRodCOmKSoLBWd5pNTeEiJy0RdxVzlFOsYZKgsOZpaloxm01N4eDB22bgQucgTl7tNToU0gmTBIWtroER7Glox8PLC9nUFCY2lRcg3ix47egVo0MhnTBJUNh64/hVOFwKn1kx0+hQSJOVmoB7y/Lwu2NX4XC6jA6HdMAkQWHr1SNXsLAgHYtm8OWtcPJIxUx09A/jvXMdRodCOmCSoLDUZOvHsRY7HqlgLSLc3LswD5nJ8WxyihFMEhSWXj96BSYBPrWcSSLcJMaZ8eBtM/D2yVb0DzuMDodCjEmCwo5SCq8du4J75uciPyPJ6HBoAo+smImhURfeOtFqdCgUYkwSFHbqL3ajpes6O6zDWOXcLMzJTsFrRy8bHQqFGJMEhZ1Xj1xBcrwZ95UXGB0K+SAi+PSKmdh/vhPXeq4bHQ6FEJMEhZWhUSfePH4Vm5YUIDVR95nsaRI+s2ImlAJeP8ppOqIZkwSFlbdOtKJ3yIHNlbOMDoX8mJebiqq5WfhtfQun6YhiuicJbc3qahHZeotrKiZbhqLDi4cuoSgnBXcV5xgdCgXgC3fMQXPHAD5o8rtcPUUoXZOE5+avlKoFYB+fDLRrqgE8N5kyFB3OtffhUHMXPrdyDqfhiBAPLJ2BzOR4vHjwktGhUIjoXZPYAsCubTcBqB5/gZYMuiZThqLDS4daEG8WNjVFkKR4Mx6pmIm3T7ais3/Y6HAoBPROEhbcmAACaVOYShmKMEOjTrxy5DI2lhcgNy3R6HBoEr6wcg5GnQo7DnM4bDSKio5rEakRkXoRqbfZbEaHQ1Pw1olW2AdH8YWVc4wOhSZpQX46bi/KwkuHLrEDOwrpnSTsALK1bQuAQHq7/JZRSm1TSlUppaqsVuu0gyT9vXiQHdaR7PMr5+BC5yA+OM8O7Gijd5LYDqBY2y4GUAsAImKZbBmKHufa+3DoAjusI5mnA/s3h9iBHW10TRJKqSPAxyOY7J59AHWea0RkM4Aq7fOtylCU+NX+i0gwm9hhHcGS4s34bMUsvH2iFa09Q0aHQ0Gke5+E1jRUq5Ta5nWs0mt7h1IqSym141ZlKDp0D4zg5cMt+NTyQnZYR7gv31MEl1L45f4LRodCQRQVHdcUuV48dAlDoy48uarY/8UU1mZnp2DTkgK8ePAiBjiFeNRgkiDDDDuc+OX+C1i1IBdlBelGh0NB8MQnitE75MDL9S1Gh0JBwiRBhvn9sauw9Q3jq6xFRI3KuVmomGPBf75/AU4Xh8NGAyYJMoRSCr94rxll+elYtSDX6HAoiJ5cVYxLXYPYdYoLEkUDJgkyxHvnOnCmtQ9PrJoHEQ57jSb3lRdgdnYyfv5us9GhUBAwSZAhtu1rQm5aIj61vNDoUCjIzCbBV+6Zh/qL3Th8sdvocGiamCRId4cvduHdsx14ctU8JMaZjQ6HQuCxqtnITk3AT2sbjQ6FpolJgnT3k11nkZOagD+5a67RoVCIpCbG4c/WFOPdsx2ov9DlvwCFLSYJ0tXBpk68d64DX1tbgpQELk8azb50ZxFy0xLxE9YmIhqTBOnqJ7WNyE1LxON3sBYR7ZITzPizNcV4/1wnDnDluojFJEG62X++AweauvDna0uQnMC+iFjwxTvnwpqeiB/vauQ04hGKSYJ0oZTCT3edRX5GIr5wB9eMiBVJ8WZ8fW0JDjV3cRrxCMUkQbqoO92OQxe68PV75yMpnrWIWPK5lXMwIzMJP/jDGbj4FnbEYZKgkBt2OPH9N0+hxJqKz3PluZiTFG/G1k1l+OhKD5c4jUBMEhRyz79/ARc7B/F3D5Uj3sxfuVj06eUzUTHHgmfePoO+oVGjw6FJ4F8shVR77xD+pe4sqhflYU0pl5aNVSKCv3+4HJ0DI/iX3eeMDocmQfckISKbRaRaRLYGel5EntY+1+gVJwXH0281YNSp8LcPLjY6FDLYbbMseLRyFp5/vxlNtn6jw6EA6ZokRKQCAJRStQDsnv0AzteIyHkATXrGS9Nz9FI3XjlyGV/5xDwU5aYaHQ6FgW/ftxCJcWb8wxunOCQ2Quhdk9gCwK5tNwGoDvD8o0qpEi15UAQYGnVi647jKMhIwv9cN9/ocChMWNMT8RfVC7CnwYbXj10xOhwKgN5JwgLAeyKXnADPV9yqiYrCz09qG3G2vR8//OxSpCVy+g0a8+V75qFybha+97uTaO0ZMjoc8iMiOq6VUs9otYgcERlf+4CI1IhIvYjU22w2AyIkb4cvduO5fU34/MrZWFuWZ3Q4FGbMJsE/ProMI04X/urV42x2CnN6Jwk7gGxt2wJg/CuYN53XOrI3a8c6Ady01qVSaptSqkopVWW1cgSNka6POPHtl/+IGZnJ+OsHFhkdDoWpebmp+M6mhXinwYaX6/nuRDjTO0lsx9hNvhhALQCIiOUW55s81wEoAVCvR6A0Nc+8fQZNHQP40ebbkJ4Ub3Q4FMb+x11FuLM4G//wxim0dA0aHQ75oGuSUEodAQCtycju2QdQ5+u8duwxrTZx3qsMhZk3jl/F8+9fwJ/eXYS753Pdaro1k0nwo83LIAC+9pvDGBp1Gh0STUCirT2wqqpK1dezsqG3M629+Mz/3Y/FhRl46at3IiEuIrq7KAzUnW7DE7+qxyMVM/FPjy7jmucGEZHDSqmq8cf5l0zT1jM4iqdeOIz0pDg8+3gFEwRNyvpF+fiL6gV49cgV/PqDi0aHQ+Pwr5mmxelS+Ob2o7hqv45nv1iBvIwko0OiCPSNdQtQvSgP33/jFA5ygaKwwiRBU+ZyKfzVq8exp8GG7z1Ujsq52f4LEU3AZBL8eMtyzMlOwVd/XY9TV3uNDok0TBI0JUopfP/NU/ht/WV8Y918fPFOLkdK05ORFI9ffWUlUhPj8Cf/eRDnOb9TWGCSoCn5Se1ZPP/+BXz5niL85YZSo8OhKDE7OwX/9eQdUAr44s8P4nI3h8YajUmCJkUphZ/WNuKf687isapZ+D8PLuZoFAqqEmsaXnjiDgwMO/CF5w7iYueA0SHFNCYJCtio04XvvvIRflp7Fo9UzMQPHrkNJhMTBAXf4sIM/PqJO9A7NIpH/m0/jrXYjQ4pZjFJUED6hx148lf12F7fgm+sm49/enQZzEwQFELLZ1vw6tfuRmpiHD637QPsOtVmdEgxiUmC/Drb1ofNz+7He+c68MNHluJbG8vYxES6KLam4dU/vxtl+el46oV6/HPdWThd0fUCcLhjkiCflFL4zcGLeOhf30N73zCe/9Pb8bmVc4wOi2JMbloiXqq5E5+8rRA/3tWIzz93AFft140OK2YwSdCE2nqH8NQLh/E3r53A7UXZeOubq7Caa1STQVIS4vCzzy3HPz26DCev9OD+n72L3x27wmnGdcC5m+gGww4nfvFeM/519zk4nApbN5XhK/fMYwc1hY0LHQP45vZj+GOLHSuLsvG9hxejvDDT6LAinq+5m5gkCADgcLrwhxOt+MedDbjYOYgNi/Pxtw8uwtwcrk1N4cfpUvhtfQt+9HYD7IMj2HL7bPz52vmYnZ1idGgRi0mCJjQ06sSOw5fx3LtNuNg5iAV5afg/n1zMpiWKCD2Do/hpXSP+68BFuBTw8LJCPLWmGAsLMowOLeIwSdDHlFL46EoPXjl8Gb//41V0D45i2WwLvramBBsX57NpiSLOtZ7r+MW7zXjx0CUMjjixsigbn62ciQeWzuDiVwFikohxDqcLx1rseKehHTtPtuFsez8S4kzYsDgfj98xB3cV53BYK0U8++AIXjx0CTsOX0aTbQBJ8SasW5iHe8vysKbMirx0zlLsS9gkCW2FOTuACqXUM4Gc91fGG5OE29CoEyeu9ODwxW4cudSNA01d6Lk+CrNJUDU3Cw8vL8QnlxYiM4VPWRR9lFI41mLHK0cuY9epNrT1DgMAygszcHtRNirmZqFybhYKM5P4cKTxlSTidA6iAgCUUrUiUiwiFd7LkU503nPOV5lY5nIpdPQP41LXIFq6B3GhYxBn2/vQ0NqHC52DH790NDcnBRsW5+Pesjx8YkEuMpOZGCi6iQhWzMnCijlZ+P6nluDUtV7sabDh3bM2bP+wBb/cfwEAYEmJR2l+Osry01FiTcXs7BTMyU7BrKwUJCeYjf1HhAldkwSALQB2adtNAKoBHPFzPsdPmYihlILTpeBwKYw6XXA4FUacLow4XBh2uDA06sTQqBPXR50YGHZiYNiBfu2je2AE9uujsA+OwNY3jPa+Ydj6huHwevtUBJibnYLS/HTcv2QGbpuViYq5WchNSzTwX01kLBFBeWEmygsz8fV758PhdOFMax+OXOrG6Wt9aGzrw+tHr6Bv2HFDufSkOOSlJyIvPQnZaQnISomHJTkBmcnxSEuKQ2piHNISzUiOj0NyghlJ8SYkxpmREGdCgtmEhDgT4s0Cs0kQbzJFbF+f3knCAqDLaz8ngPP+ytygobUPa370zi2DGN/CpqAmPDdRS5xS7quVcpdzf9aOK8ClFFzK/ZTv2Xa6FJxagpiqlAQzLMnxsKQkIDc9EQvy05GXnoiCzCTMzk7B7KwUzMpKRlI8n36IbiXObMKSmZlYMnPs3QqlFDr6R9DSPYiWrkFc7r6O9t4htGsPZKev9cI+6H5Im+qfsQgQZxKYxJ04TCIwiXvBJc82IBABBIBJxrbd5eWmrzfRtvZVfJ6bLL2TREiISA2AGgDIKCzGitmWQMrcuO9jR3Dzf4x8/Fn7TxT31zOJ9h+LG//jzSaT+5fDJIgzCeLM7ieLOLPc8NSRHG/WnkjMSI43Iz0pDmmJcUhLikNiHG/+RKEiIrCmJ8KanoiKOVk+r3O5FPpHHBgYdn/0DTkwNOpuBRgccWLE6fy4ZWDE4YLD5X44HHW64NJaEZzaA6TT5XmovPEBExjb9zyoeh5MPbwfbHHTQ6/X9iT6nPf5OK53krAD8KxxaQEwfjFbX+dvVQZKqW0AtgHujuuffm5FcKIlIvJiMgkykuKREYXDan/2+YmP650ktgPw9J4XA6gFABGxKKXsvs77OEZERCGm6wR/nlFJIlINwO41SqnO1/lblCEiohDTvU9Caxoaf6zSz/mbjhERUehxqnAiIvKJSYKIiHxikiAiIp+YJIiIyCcmCSIi8inqpgoXERuAiwaHkQugw+AYwgV/FmP4sxjDn8WYcPlZzFVK3bTaWNQliXAgIvUTTbkbi/izGMOfxRj+LMaE+8+CzU1EROQTkwQREfnEJBEafEN8DH8WY/izGMOfxZiw/lmwT4KIiHxiTUInIrLV6BiIKDyF8/0hKhYdCnfaDLa3Gx2H0bTFoQCgRCn1HUOD0ZmIbIZ7vZQKpdQzBodjqFj+PZhIuN8fWJMgXWh/CLXajL7F2n5MEJEKAFBK1QKwe/ZjUSz/HkQqJokQE5EK7eYQ64oBeG4ITdp+rNgCdy0CcP/bY/nGGMu/BzeJhPsDm5tCL9v/JdFv3JogFXCvQhgrLAC6vPZzDIrDcDH+ezCRsL8/MElMk1f7qrcmpVRtJDwl6E1ratnFFQZjG38PIqMWATBJTJufVfOKRaTYa7simv8obpUwvfarY7Dj1o6xJ0YLgE7DIgkfsfh7MF5E3B+YJEJIKbUD+PjmaTE2mtDzt8ysiNR4bgwiUh0JT1FBsh2AZ26eYgCx8u+eUAz/HtwgUu4PfJmOdKGNYnkZ7rb5bACPxtLNQbsRNAEojuU122P99yASMUkQEZFPHAJLREQ+MUkQEZFPTBJEROQTkwQREfnEJEFERD4xSRARkU9MEkRE5BOTBBER+cQkQUREPjFJEOlARCpE5LyIvOy1bzE4LCK/mCSI9FENoBLAf3hmy1VK2Q2NiCgAnLuJSEda7SFbKdVkdCxEgWCSINKJp3mJNQiKJGxuItKBZ3EZT4LwWmyGKKxx0SGiENOW6qwC0CUitXD3T9jhXl+CKKyxJkEUQl5NTNvgXpWuGcDtXGiHIgX7JIiIyCfWJIiIyCcmCSIi8olJgoiIfGKSICIin5gkiIjIJyYJIiLyiUmCiIh8YpIgIiKf/j9mV0b83Qb2HgAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "loc1 = np.array([[0]])\n",
     "scale1 = np.array([[1]])\n",
@@ -922,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,22 +255,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAZT0lEQVR4nO3df2hc553v8c83Njarxfqtm0BWjlZyTWMb3DuaQijqH3tX2bULuQyLE4P9T7Tbq1wXwi1U1ym3/i8Od+NVwG3/8I0aVoXisnayF4H/iEPkLqVDMezYXS+ubnEsJSUtuFcja2xRgXJtP/ePOcc6Hs8vyaMz82jeLzA65zznmfPMaDwfPec88xxzzgkAAN88Ve8GAACwHgQYAMBLBBgAwEsEGADAS1vr3QAAje3KlSv/YevWre9J2if+6EX8Hki6fu/evW8ODg7+32gBAQagrK1bt773zDPPPN/T07P41FNPMWwZsXrw4IHNz8/vuXXr1nuS/nO0jL+mAFSyr6en5y7hhXp46qmnXE9Pzx3lzwA8WlaH9gDwy1P1DK90Ot3S29u778iRI89ls9ktU1NTO1pbW79y4sSJp2dmZrYdPHiwv15tq0bY/mPHjj2bzWa3xH38qampHV/72te+VIvHOnbs2LMnTpx4unB79DlOTk52HDt27NmpqakdxcrGx8e7JycnO0rVPXHixNN79+59Pvr4wfvvsbziFCKAtXnHBmv6eN9xV8oVDw0NLe/bt2/5W9/61nx3d/f9VCq11Nvbu/Ltb387293dff8nP/nJb0vVnZyc7BgZGVmsaXvXKGz/0aNHF7u7u++X2m+j2ppKpZbefffdnnL7VHvso0ePLl68eHFH4fahoaHlr3/960tHjx5dHBoaWh4ZGVlsbW39yt27d/+tsEzKB2FHR8e9VCq1FH19wvJq0QMD4K2ZmZltv/nNb7YXK8tms1s+/vjj1rjbtB71bOtajt3Z2Xmv2sdta2u7NzMzs61Y2euvvz7/ve99789KtSeZTFYVZPTAAHjt+PHjz/7yl7/8JJ1OtxSeort27VpLtHcxPj7e/cILLyxfvny5ZWxsLJvNZrecPn26O5lMLmcymZb29vb7XV1d98+fP9/xyiuvLM7Ozm47efLkH8JTXgsLC1vGxsayU1NTO06dOvXM8ePHb2UymZaBgYEvOjo67p0/f77zBz/4we/K9bQK6x44cGApm81uKWzriRMnnk4mk8s3b97cXtimgYGBL8bHx5956623fnfz5s3tu3btWkmlUkvFnmPh8QufSzqdbil37LGxsWy4nslkWqr5nWSz2S2tra339+zZ80Wx8j179nzx+eefF/3D48KFC63V9kTpgQHwwsWLF3dMTk52TE5Odty9e3eLlP8gbGtruy9JZ8+e7ZDyp8x27969kkqllnbu3LkS/VDetWvXytDQ0PKuXbtWxsfHu9PpdEt7e/v9VCq1dOXKlT8dGxvLjoyMLF6/fr1lZGRk8eTJk39Ip9Mts7Oz20ZGRhYnJyd7wmPcuXNnayqVWjpy5Mji+fPnO1Kp1FIikfhjOp0u+yFfWPfs2bMdhW09duzYs8lkcjmVSi3Nzs5uL2zTyMjI4s6dO1dSqdTS2NhY9vXXX3+u1HOMHrvUcyl37PHx8e5w/cCBA0uVfkdTU1M7fvzjH3f8/Oc/v1Fu36WlpUf+2Lh48eKOI0eOPLewsFD1dUICDIAXDhw4sDQyMrIYXF95rIfz5ptv3vroo49a9+7d+/zt27cfO7t05cqVP929e/eKJO3evXvl0qVLrWGvZWpqasc777zzu3Dfffv2PTyFNTQ0tJxMJpenpqZ2tLW1PTyFFl3u6+tbkaSurq6SPa+oaN1iPvvss+2Li4tb0+l0y8DAwEphmwr19vauzMzMbCv2HKP7lXou5Y599erVh49ZSRh0Y2Nj2XK90Gw2u2XPnj2PPJ8DBw4s/fSnP/3trl27qjqWRIAB2CQuXLjQeubMmd//+te//j+FAw3S6XTL4ODgH2/cuLFdkm7cuLF9cHDwj+l0uuUb3/jG3VQqtVTqdNf4+Hj3zZs3t4dhF56mDHt+61GubtjWL33pSytDQ0PLr776atHTaXfu3NkSWd66Z8+eL4o9x2qeS7ljJxKJh49ZK6dPn+4eGxu7VawsbFs1uAYGoKGl0+mW69evt5w9e7bjy1/+8ko6nW75/PPPt58+fbr7wIEDS9evX2+ZmZnZNjs7uy28vnPkyJFFKd8zmpyc7HjppZfuDg0NLYdDwDOZTMvJkyf/IEl79+59fufOnSt9fX0rb7755q3weOl0uiU8FZfJZFrS6XTL/v37ly9cuNDa0dFxL9zn4sWLO65du9YyMzOz7fz58x0dHR33ox/CxdpfWDebzW4p1tZowETbJOVDK51Ot1y+fLnlrbfe+p0knTx58g+FzzF6vGLPZWRkZLHcscNrYOFj/uxnP2vNZrOP9LDC62hSvpdXWPaLX/xiR1tb271PPvlk++zs7Lb29vb74SnL6OvT2dl5r9QfEsUY9wMDUM61a9c+279//2ODATaDEydOPB0Ox5+Zmdn2wx/+sOfMmTO/r3e7qnHw4MH+Dz/8cK7e7YjLtWvXuvfv398X3UYPDEDTSiaTD3tUi4uLW48ePVrX74xVa2pqakfY81xLj2WzoQcGoKzN3AODP4r1wBjEAQDwEgEGAPASAQYA8BIBBqD2PvrbXn30t721eKjNMBv93r17n4/O1B7OkLHW9heb2b23t/ex24yUUmo2eV8xChFAQ9sMs9Hv379/uXCm9ldffXVxz549X5Rrf7HHKpy5vdrZP6TSs8n7ih4YAG/5Oht9b2/vSvjds1Ltr0Y2m93y0ksv3S0163uhtcwm7wN6YAC85tts9JIUzpwRbX+xWeor3R8rnEmju7v7frn6xWaTL3y91jKFU6OgBwbAC77PRn/58uWWqampHQcPHuwP74UVbX+xWerLvRbHjh17dnZ29mHPq1T9UrPJF75eT/K7qRcCDIAXfJ+N/oUXXlhOpVJLH3744VxbW9u9wludFD5mpdfizJkzvw9v/BieQixWv9Rs8pVeLx8QYAA2Bd9moy8Wdmt9zFQqtZTNZreEz6tY/VKzyZd7vXzhZeoCaB6bYTb6a9eutZw9e7YjnI29r69vZWRkZDE81szMzLYbN25sLzZLfeHM7uFr8cknn2xfWFjYMjk52fP+++/PhvMjFtYvNZt8sdfLN8yFCKCsdc2FGH4H7K//8fONaFOt+DwbfbNhNnoAiPB1NnrkEWAAaq/Be14hH4eOYxWDOABU8uDBgwdW70ageQXvvweF2wkwAJVcn5+fbyPEUA8PHjyw+fn5NknXC8s4hQigrHv37n3z1q1b7926dWuf+KMX8Xsg6fq9e/e+WViw6QKsu7vb9fX11bsZAOCVK1euZJ1zPfVux1rEHmBmdkhSTlLCOXeqSPlwsPiic+6NYNvbzrk3zGzUOTdR7vH7+vqUyWRq3WwA2NTMrOpZ8RtFrKcDzCwhSc65aUm5cL2g/MWgPBEpHzWzWUlzcbYXANC44u6BHZb0cbA8J2lY0tWw0Dl3NbLeH6xL0stBqAEAICn+AGuXdDuy3lVsJzM7Lum1yKaEmUklTjsCAJpPQ44oCkLqNTNrD9eDHlhX5BrZQ2Y2amYZM8vMz8/H3FoAQD3EHWA5SZ3BcrukhWihmUWve80pf+3rUDDwQ8H+/YUP6pybcM4lnXPJnh6vBtEAANYp7gA7p9UA6pc0LUlhT0v5a2LRgJsL/oXXvwYkMcQQABBvgIWDMoLTgLnIII1Lwc8JSf1hj8s590GwzyvBttlIHQBAE9t0t1NJJpOO74EBwNqY2RXnXLLe7ViLhhzEAQBAJZtuKimgqHeYh/ah72yusy5oXvTAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF7aGvcBzeyQpJykhHPuVJHy4WDxRefcG9XUAQA0n1h7YGaWkCTn3LSkXLheUP5iUJ4ws0SlOgCA5hT3KcTDyvekJGlO0nC00Dl3Nex1Sep3zl2tVAcA0JziDrB2Sbcj613FdjKz45JeW0sdAEBzachBHMF1rtfMrL2a/c1s1MwyZpaZn5/f2MYBABpC3AGWk9QZLLdLWogWRq95KX+6cLRSHUlyzk0455LOuWRPT0/NGw0AaDxxB9g5Sf3Bcr+kaUmK9LSG9WhYzZWqAwBobrEGWDAoIxwqnwvXJV0Kfk5I6g+Gzcs590GZOgCAJhb798CccxNFtg0GP3PKh5gkfVCuDgCguTXkIA4AACohwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeij3AzOyQmQ2b2fES5aPBv7cj294Oy+JqJwCgscUaYGaWkCTn3LSkXLgeKR+WNO2cm5DUH6xL0qiZzUqai7O9AIDGFXcP7LCkXLA8J2m4oLw/sm0uWJekl51zA0HwAQCgrTEfr13S7ch6V7Qw6HmFEpLOhctmJkkJ59ypjWwgAMAPDTmIIzi1+LFz7qokOedOBb2vrshpxej+o2aWMbPM/Px83M0FANRB3AGWk9QZLLdLWiix33DY0woGfRwKti9o9bTiQ865Cedc0jmX7OnpqW2LAQANKe4AO6fVAOqXNC1JZtYe7mBmo5HwGlb+Wlh47WtAUiauxgIAGlesARaeEgyCKReuS7oU2f62mc2a2WKkzitBL2w2UgcA0MTiHsRROFAj3DYY/JyW1FFNHQBAc2vIQRwAAFRCgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8RIABALxEgAEAvESAAQC8tDXuA5rZIUk5SQnn3Kki5aPB4oBz7o1q6gAAmk+sPTAzS0iSc25aUi5cj5QPS5p2zk1I6jez4Up1AADNKe5TiIeV70lJ0pyk4YLy/si2uWC9Uh0AQBNa8ylEM+uTlJDUKald+VDJOed+VkX1dkm3I+td0cKg5xVKSDonabBcHQBAc6o6wMzsv0t6UdKipIzyvaI7kgYkdZnZdyXNSnrXOfdvT9Ko4DThx865q2ZWzf6jkkYlaefOnU9yaACAJyoGmJn9uaTXJP2Tc+4fKuzbJmnUzJLOufeK7JJTvucm5XtjCyUeajgyWKNinaDnNiFJyWTSlWsjAGBzKHsNLAivv3TOfbeaXpVz7k4QcpfM7JtFdjmn/HUtBT+ng+O0R445GoZXMKijaB0AQHMrG2DOuU9L9KTKKlXPOXdVehhMuXBd0qXI9rfNbNbMFivUAQA0sfUM4mh1zt1d7wELBmqE2waDn9OSOqqpAwBobusZRj9gZl8JV8zsz83sP9WuSQAAVLbmAHPO/UrSV4Ph9HLOfSqpw8z+Z43bBgBASWsOMDM7p/xw+UUzaw02TysYxg4AQBzWcwpxUFLGOXdHkgVD54cl/X1NWwYAQBnrCbCXFfS2ghDrlNRR6TtiAADU0ppHIQbXwH4VWf/UzK6Y2VeedAYOAACqVZPbqTjnfhWcSgQAIBY1m40+OJ0IAEAsKk4lVWJKqLLWWw8AgGpVnEpK+XkN/1c1X1Y2s9Zg1vq/XM8UVAAAVKviNbAgxP6rmf2X4JYpTtJVrc4K36X8LPEDyn8/7FRQBwCADVP1IA7n3I8k/SgYrJFUPrQ6JX0qaS4YnQgAQCzWM4z+joLZ4wEAqJd1DaMPBmgMSroi6fyTzE4PAMB6rGcuxL+XtEvSHUmvSPrUzP6u1g0DAKCc9fTA/tU598/hSnA35e+a2d845/53zVoGAEAZT/xFZudczjn3XeVHIwIAEIv1BNicmf2rmf1F5HYq0uqwegAANtx6AuywpPOSjkn6LAizjyT1m9kOSTKzv6lhGwEAeMx6roHNSvo4vH2Kmf1H5e8H9leS/oeZhT0xrocBADbMmntgwReaO8ysL1j/lXPuH5xzf+Wc61S+h8ZMHACADbWuQRxBaH1WouyqpDdK1TWzQ2Y2bGbHy+yTKFh/O/g5up72AgA2n5rdTiWq1LRSYTA556Yl5QqDKthnWNKPCjaPmtmspLlatxUA4KcNCbAyDkvKBctzyl87e0QQbrcLNr/snBsIygAAqM0dmdegXY+GU7XfHUuYmSQlnHOnat0oAIB/4u6BrYtz7lTQ++oKTjECAJpc3AGWU/4WLFK+N1bxy8/BoI9DweqCpP4i+4yaWcbMMvPz8zVqKgCgkcUdYOe0GkD9kqalh/MpljIX7qf8TTMzhTs45yacc0nnXLKnp6d2rQUANKxYAywYYh+ONMyF64rcXyzobSXDXlewzyvB+mykDgCgicU9iEPOuYki2wYjyx9I+qBSHQBAc/NiEAcAAIUIMACAlwgwAICXCDAAgJdiH8SBJvOO1bsFKNQIv5PvuHq3AJsAPTAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJdiDzAzO2Rmw2Z2vMw+ibXWAQA0l1gDLAwm59y0pFxhUAX7DEv60VrqAACaT9w9sMOScsHynKThwh2CoLq9ljoAgOYTd4C169Fw6tqgOgCATY5BHAAAL8UdYDlJncFyu6SFWtQxs1Ezy5hZZn5+/okbCQBofHEH2DlJ/cFyv6RpSTKz9rXWiXLOTTjnks65ZE9PT+1aCwBoWLEGmHPuqvRwpGEuXJd0KdzHzA5JSgY/y9UBADSxrXEf0Dk3UWTbYGT5A0kfVKoDAGhuDOIAAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHiJAAMAeIkAAwB4iQADAHgp9gAzs0NmNmxmx6stN7O3g5+jcbUTANDYYg0wM0tIknNuWlIuXK+ifNTMZiXNxdleAEDjirsHdlhSLliekzRcZfnLzrmBINgAANDWmI/XLul2ZL2ryvKEmUlSwjl3aqMaBwDwhxeDOJxzp4LeV5eZFfbaZGajZpYxs8z8/HwdWggAiFvcAZaT1Bkst0taqFQeDOo4FGxbkNRf+KDOuQnnXNI5l+zp6alxkwEAjSjuADun1QDqlzQtSWbWXqZ8LtxP0oCkTBwNBQA0tlgDzDl3VZKC04C5cF3SpVLlwbZXgl7YbKQOAKCJxT2IQ865iSLbBiuUP7YNANDcvBjEAQBAIQIMAOAlAgwA4CUCDADgJQIMAOAlAgwA4CUCDADgJQIMAOAlAgwA4CUCDADgJQIMAOAlAgwA4CUCDADgpdhno0eM3rF6twAorlHem99x9W4BngA9MACAlwgwAICXCDAAgJcIMACAlwgwAICXCDAAgJcIMACAlzZfgC19Xt/j/8u38//qrRHaADS6ev8/aaDPi+c61FvvZqxV7F9kNrNDknKSEs65U9WUV6oDAGg+sfbAzCwhSc65aUm5cL1ceaU6AIDmFPcpxMPK96QkaU7ScBXlleoAAJpQ3KcQ2yXdjqx3VVFeqU7jufr9/D8Aja0R/q8m/lt9j++xTTGZr5mNShqVpG1b9P/M7N/r1ZbnOtS7tKI/ub2sG/VqQ9gOSfrtouo2qoXX4tE28FqstoHXYrUNSyvf/5Pby9+v+2uR/aNa69mG9Yg7wHKSOoPldkkLVZaXqyPn3ISkiVo18kmZWcY5l6x3OxoBr8UqXotVvBareC3WL+4AOycp/EX1S5qWJDNrd87lSpWX2AYAaGKxDuJwzl2VJDMblpQL1yVdKlVepg4AoInFfg0sON1XuG2wQnnDnB6skm/t3Ui8Fqt4LVbxWqzitVgnc447ksbBzI7zJWwAxfD5sD6bYhRiowtOf3613u2ot2C0qCQNOOfeqGtjYsZsMqua+X1QDJ8P67f55kJEQwr+k04Hp4P7g/WmwGwyq5r5fYDaI8A2mJklgg+uZtev1VlU5oL1ZsFsMqua+X3wGD4fngynEDdeZ+VdNr+CgTgJ5b8y0Sza5dtsMhukyd8HxfD58AQIsCcUOZ8fNeecm+avq8cFp88+5usQzY33Ab2vWiDAnlCFIf79ZtYfWU5s5v+w5cI8sj7chIMYcqowm0wTasb3QaGm+nzYCATYBnLOfSA9/GBvr29rNl6l7+uZ2WjkHm/DTfTXZ6kZZppSE78PHtFsnw8bge+BIRbBaLP3lb8W1Cnp5Wb64Ao+pOYk9Xv4xfyaafb3AWqLAAMAeIlh9AAALxFgAAAvEWAAAC8RYAAALxFgAAAvEWAAAC8RYAAALxFgAAAvEWAAAC8RYEAMzCxhZrNm9n5kvb3OzQK8RoAB8RiWNCjp3XDWfudcrq4tAjzHXIhAjIJeV6dzbq7ebQF8R4ABMQlPGdLzAmqDU4hADMIbF4bhFbmRIYB14oaWwAYzs4TyN7S8bWbTyl8Pyyl/fzAA60QPDNhAkdOGE8rfjflTSV/lJo7Ak+MaGADAS/TAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXiLAAABeIsAAAF4iwAAAXvr/rlQvqIXbTYAAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Convert to a histogram by computing the bin values by taking the intergral of the CDF\n",
     "xvals = np.linspace(-5, 5, 11)\n",
@@ -982,17 +281,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "For an input vector of shape (2, 1) the output shape is (2, 1)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "xvals_x = np.array([[-1.], [1.]])\n",
     "yvals_x = hist_dist.pdf(xvals_x)\n",
@@ -1013,60 +304,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The input and output shapes are: (11,) (1, 11)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAoQUlEQVR4nO3de3hb5Z0n8O9Pku832Y5zIReCDbQEaIqjMp2UDm0x5TLApEwglO52YEpN0y2dzjYEWmDbZ2CmJaWzne20DIFppmV4ltB0yELLZXGgZVOgxTGEhsBAbEgDJME3OY7vsn77xzlHkh3Jkh3pHOmc7+d58vhc3iO9UqTz0/ue9/xeUVUQEREVGp/TFSAiIpoLBjAiIipIDGBERFSQGMCIiKggBZyuABGRV+3atWt+IBC4D8AZYIMilSiAPZFI5LpVq1a9n7iDAYyIyCGBQOC+hQsXntbQ0NDv8/k4JDyJaDQq3d3dKw4dOnQfgMsS9zHiExE554yGhoYjDF6p+Xw+bWhoGIDRSp26z4H6EBGRwef24LV3797iiy66qBEAtm/fXrV69epTZvsY5nt0TLxiACMioqzasmVLrbW8YsWK8fvvv38/AKxZs2awpqZmMlvPwwBGRERZ09PT43/qqaeqrfW9e/cWv/766yW5eC4O4iAiyhPfO+PAqlT7zv16zf6zr63uAYDfbzky7zffHzgxVdkb9yzdlelzrl+/fvEFF1xwBAD27dtXcvLJJ49t2rRp4XPPPffm+vXrFwPA3Xff/S4Qb1n19vb6N2zY0LN9+/aqTZs2Ldy4ceOh9vb28gsvvHCwp6fHv3v37vItW7bUXnvttf0AsHHjxsXPPffcm9Of+9Zbb10QCoWG9+3bV/LRj350uKenx2/tW7NmzWC6urMFRkTkUXfddde8+vr6iBUswuGwPzFw3HDDDd3W8s6dO8s7OzuLr7322v4tW7Y0AEaQGRgYCKxZs2bw6quv7n/ggQdq16xZM7hs2bIxK3itWLFiPFm34fr16xeHQqHhNWvWDHZ2dpY88MADtdZjnnrqqWOZ1J8tMCKiPJFpy+nsa6t7rNbY8ejo6Kj48pe/3A0Ap5566lh7e3s5ACQLOOecc85wT0+Pf/v27VU1NTURa3vi8my8/fbbJf39/YGdO3eWNzU1jV1zzTX9t91228JbbrllyT333LMfwHi6x2ALjIjIo5qbm4deeOGFcgB44403jrlOlbjtrrvumrdv374Sq4VmdffNNChj586d5an2rVq1auiUU04ZO+ecc4avueaa/kcffbT67rvvfvfVV1997YknnqjKpP5sgRERedSGDRt61q9fv3j79u1VVusLMILL9u3bq/r7+wPPPvts9d69e7tPPvnksfb29vKdO3eWr1y5cvjRRx+trq2tjezZs6d8586d5U888UTV7t27y3t6evzLly8f27JlS+2ll156ZOfOneV79uwp37t3b3FfX1/AKn/HHXccvvXWWxdYgbCzs7PYusZ29dVX92dSf+F8YEREzti9e/fbK1euPO6uwGywgtAdd9xx2Om6JLN79+55K1euXJ64jV2IRESEBx54oPbpp5+uThwJmO/YhUhERLGh8oWELTAiIipIDGBERFSQGMCIiKggMYARERWQx2/rW/r4bX1Lna5HprKRjT4VBjAiIsoqZqMnIqKCw2z0RERkC2ajJyKiglPo2egZwIiIPKqjo6PiwgsvHASMbPTW9lTZ6EOh0HCustHffvvth5588snq008//bS+vr6MegcZwIiIPIrZ6ImIqCAxGz0REc3JXLLRW/eAXXR73YFs1oXZ6ImIqCAxGz0REeVUtlteFmajJyKi2YhGo1FxuhL5znyPotO3M4ARETlnT3d3dw2DWGrRaFS6u7trAOyZvs/2LkQRWQsgDKBZVTfNUG6jtT/TY4iICkkkErnu0KFD9x06dOgMsEGRShTAnkgkct30HbYGMBFpBgBVbRORRhFpVtWOJOVaAHxkNsdY5s2bp8uXL8/NCyAicqldu3b1qGqD0/WYDbtbYOsAPGUudwFoAZAyGM3lmOXLl6O9vf04q0lE5C0ist/pOsyW3U3WIIC+hPX66QXMFlbbbI4hIiLvycc+1zqnK0BERPnP7gAWRjxABQH0Ju5M0vpKe4x5XKuItItIe3d39/TdRETkQnYHsK0AGs3lRgBtACAiQWubiKw1Rx02mgM4kh6TSFU3q2pIVUMNDQV1DZKIiObI1gBmjR40RxmGE0YT7jD3b1PVbTBaXME0xxARkYe5LplvKBRSjkIkIpodEdmlqiGn6zEb+TiIg4iIKC0m8yWaBY0qnvxWP3o6J6ZsP/2yCpx1VSUA4L3dY3j6znDKx1jzT/NQ2WAk/P7N/wzjwIvJZ09fdGYxzvtGbXYqTuRCDGBEs9DTOYE/PDx0zPZlZ8cnsx07GsXBV8ZTPsbkeLzbvn9/JGXZkkp2kBDNhAGMaBaGeoyE2AtWFKHllnjrqHJ+fAqlRWeW4HMPzE/5GBUN8bJ/9rUanH1t8tnTGcCIZsYARjQLkVFFSbWg9sQinLCyJGmZ0mpfyn3T1S0vSrlvbDCK5+85AlXF6i/VzKm+RG7GAEY0Cyd/sgxffW4JNJr70bvRqGLnDwdQXCkMYERJsI+CaA7El/vpm0qrffAFgPGjisiYu253IcoGBjCiPCUiKK83rpcN9U46XBui/MMARjQLj3y9B/defBDvdCQf+p5tFfXGV3SohwGMaDoGMKJZCB+IIPzHCPypx15kVYXZAhvujdrzhEQFhAGMaBaGzEBide3lGrsQiVJjACPKkKpi2AwkFTYFsJrFfgSXBuAP5H7QCFGh4TB6ogyNHokiGgGKKwWBEnsCyur1NVi9nkPoiZJhC4woQ8NmFg67Wl9ENDMGMKIMWdehyuvt/9pEJ3kfGNF07EIkylD1ogDOuaEaFfPsa4H175/Av3/2fVTM8+GvH1lk2/MSFQIGMKIMBZcG8KfX23s9qqTKh9EjHEJPlIztfSEislZEWkRkY4r9Lea/OxO23Wn+bbWrnkT5oCzog/iNASSTE+xGJEpkawATkWYAUNU2AGFrfdr+8839zQn7W0WkE0CXnfUlSnSgfRT7nhmxNSuG+ATltcbXdJj3ghFNYXcLbB2AsLncBaAlcaeqdqjqTeZqo6p2mMtXqGqTGdiIHPH7nwzi4Rt68N4Mk1XmQvxmZnYlEiWyO4AFAfQlrNcnK2R2L16fsKl5pm5HIjvEb2K292sTTyfFFhhRorwcRq+qmwBcLyJBa91sfdWLSMv08iLSKiLtItLe3d1tc23JK2JppOrsvQ/MGrbPdFJEU9k9CjEMoM5cDgLoTdyZcI2sA0YXY6uIdJnbtpnlG6c/qKpuBrAZAEKhEK90U9apKob7nLkPbMUlFThhZXHGszwTeYXdAWwrgJC53AigDQBEJKiqYRjXxKzrXkEAL8IIZNbgjSYA99hUV6KY8aOKyXGgqExQXG5vADvpY6UASm19TqJCYOs30RqUYXYDhhMGaeww/24G0Cgia83y28wyV5rbOhOOIbKNk1k4iCg5229kNrv7pm9bZf4Nw+wKBLBtpmOI7DTc51wexOH+SXT9ZhT+YuC0iytsf36ifMVMHEQZWNJcgq+9uBjjw/ZfYj16eBKP39qH+qYAAxhRAgYwogwVlflQVGb/85abuRetViARGdihT5TnyoM+QICRcBTRCAfZElkYwIgy8NsfDeDBa97HW78dtf25fQEznZQCw/1shRFZGMCIMvD+6+M40D6GiWFnAkg8nRRvZiayMIARZSCWhcOh2Zit4ftMJ0UUxwBGlIFYHsR5znxlKur98BcD40O8BkZk4ShEojRUNdYCc+I+MAC46I46/Pl36yAijjw/UT5iACNKY2JEERlVBEoEReXOBBB/EQMX0XTsQiRKY6jHuv7lYwuIKI+wBUaURqAYWHlFBYornfu9d/APY3jif/SjvjGAy74/z7F6EOUTBjCiNKoWBvDpb9WlL5hDvoCg580JR+tAlG8YwMhT3n15DJ2/HgEALPpQCU75lJEb6sjBCF7eejTlcc2fq0JlgzMDOID44JEj70Xw7A/Cse1/+qVqFJUaLcNXfnEU4QORY44tC/rw4asqY+WI3IIBjDzlidv60PeWcZL/8LpoLIAd7Z7E7+4bTHncBy8sdzSAldX6UFQmGB/SKfU8+6+rUWROFfbaY8P44+/Gkh5fOT+A0y4ut6OqRLZhACNPGQkbAzI++sUqLFkVn+G4aoEfH/9qTcrjKuY5F7wAYxTi5T+ah/deHp+yPVASH1Ry5mcqcOKfTJ348sV/G0TlAr9joyeJcklU3XVjZCgU0vb2dqerQXnqB2e/g4lhxd/8bjGKK9ilRmQRkV2qGnK6HrPBbzB5SmTM+MGW2HIhosJkexeiiKwFEAbQrKqbkuxvMRfPV9WbMjmGKBPRiEInAfEbo/q8IDqpiIwpRIz5zIjcxNZPtIg0A4CqtgEIW+vT9p9v7m8WkeZ0xxDNxgXfrsV536h1uhq22XX/IP7p7Hex858HnK4KUdbZ/ZNsHYyWFAB0AWhJ3KmqHVarC0CjqnakO4YoU76A4ENrK3HWVZVOV8U2frOrNJJ8cCJRQbM7gAUB9CWs1ycrJCIbAVw/m2OI6FhFVgAbdddgLSIgTwdxmNe5rheRYCblRaRVRNpFpL27uzu3laOCNTIwiZe3HsUbbcNOV8U28RYYAxi5j90BLAzAyskTBNCbuDPxmheM7sLWdMcAgKpuVtWQqoYaGhqyXmlyhyMHJ/HU7f147sdHnK6KbQIMYORidgewrQAazeVGAG0AkNDSasHUYNWV6hii2Zr04BB6BjByM1sDmDkowxoqH7bWAeww/24G0GgOm4eqbpvhGKJZ8eI9YAxg5Ga23wemqpuTbFtl/g3DCGIAsG2mY4hmyzqJ+z0UwOqbinDxd+pQOd/ZVFhEucBciOQZ1kg8L7XAKur9OP3SCqerQZQTeTkKkSgXIuPeC2BEbsYWGHlG1JwP0ksBbHw4ile2DcEXAJqvrnK6OkRZxQBGnnHGmgqcflk5opNO18Q+EyOKZzaFUVbrYwAj12EAI08Rn8DvoY7zolJm4iD38tBXmch7/MVmABtnACP3YQAjz9j174P42ZWHsGf7kNNVsY2/SCB+QCeByQkGMXIXBjDyjCMHIzi8dwIjYQ9dBAMQMFthk2yFkcswgJFnxO4DK/XOKEQg/noneB2MXIaDOMgzYqmkir0VwEqrfdBJIMouRHIZBjDyDGtSR6+1wK771SKnq0CUE+xCJM+I5UL0WAuMyK0YwMgzrGtgRR5rgRG5FQMYeUbjx0vxob+sQNUib/WcP3ZLLzZf+B7efWnM6aoQZZW3vsnkaav+qzdTKQ33RjHwziTGjkadrgpRVrEFRuRysWwcHEZPLmN7ABORtSLSIiIbU+xvNf/dmbDtTmufXfUk9zm8dxyH9457Lq1SLB+ix143uZ+tAUxEmgFAVdsAhK31hP0tANrMGZgbzXUAaBWRTgBddtaX3OXhG3rwsysPY7jXW5k42AIjt7K7BbYOQNhc7gLQMm1/Y8K2LnMdAK5Q1SYz8BHNiVeH0QfYAiOXsnsQRxBAX8J6feJOs+VlaQaw1VoWEQBoVtVNuawguZcVwLw2jD5QYvxlC4zcJi9HIZpdi0+pagcAWEFLRM4XkZbpLTHz2lgrACxbtszu6lIBUNV4KikPzcgMAMvOLoXPL1h0RrHTVSHKKrsDWBhAnbkcBNCbolxLQtBaCwCqus0s3zi9sNly2wwAoVCIPzPpGNEIoFFA/IAv4K0A1nRuGZrOLXO6GkRZZ/c1sK2IB6BGAG0AICJBq4CItCYErxYY18KsFlcTgHa7Kkvu4dXWF5Gb2RrArC5BMzCFrXUAOxK23ykinSLSn3DMlWZLrDPhGKKMeTmAHe2exP4XRtH95rjTVSHKKtuvgU0bqGFtW2X+bQNQm8kxRLNRWu3DX/1iAdSDySi6nh3Bk9/qxxlrynHRHfXpDyAqEHk5iIMo2/xFgvkf8OYghtgweqZCJJdhKikil7O6Ta1uVCK3YAAjT+jfP4HHbunF735yxOmq2I4BjNyKAYw8YfDwJF79P8N469lRp6tiOwYwcisGMPKE2ChEj2XhAOKveZIBjFyGAYw8wUqj5LU8iAAQMF/zBFNJkctwFCJ5glfzIAJAXWMRrntsIYrK+XuV3IUBjDzBq5noAaMFVrusyOlqEGUdf5KRJ3j5GhiRWzGAkSeUBf1YdGYxgkv8TlfFdpFxxaMbevDI13ucrgpRVs26C1FElsOYq6sORkb5Lhh5DZ/Oas2Isui0i8tx2sXlTlfDET4f8PoTIxCfMa2MObceUcHLOICJyI0AzgfQDyMjfBjAAIwM8fUicjOATgD3qOrLWa8pEc2JLyAQP6CTxrQyfl4OI5dIG8BE5CQA1wN4UFW/l6ZsDYBWEQmp6n1ZqiPRcZucUIh4by4wS6BEMDFsTOrpL/Lme0DuM+M1MDN4naeqN2fSqlLVATPI7RCR67JUR6Lj9vR3+/H9D7+Dlx4cdLoqjohl4+C9YOQiM7bAVPUtALNuSc31OKJciY1C9OAweiAhgI0zgJF7zHoUoohU56IiRLlkTSXi1WH0bIGRG83lRuYmEVGrS9HsZjyJoxApn3n5RmYAWNJcguDSgGdfP7nTrAOYqr4kIl8UkbCqvq2qb4lIs4h8R1W/ke54EVkLYwRjs6puSrK/1VxsUtWbMjmGKB2r5eHFVFIAcOHtdU5XgSjr5tKFuBXGcPn+hO7ENgCtqY+KHdsMAKraBiBsrSfsbwHQpqqbATSKSEu6Y4gyYV37sbrSiKjwzSUTxyoA7ao6AEDMofMtAL6bwbHrYLSkAOMG6JZp+xsTtnWZ6+mOIUorlo3eowFsYiSKod5JTIxGna4KUdbMJYBdAbO1ZQaxOgC16e4RMwUB9CWs1yfuVNXNZusLMLJ9tKc7higTq9dX44Jv1yK41Jv5q395Ux9+fO57eOv/eW9CT3KvOV0DA/BSwvpbIrJLRD6crQwcZjfhU6rakUnaG/O6WSsALFu2LBtVIJdpOrfM6So4yrr2x2H05CZZSeZrBrW3MigahtFiA4yWVW+Kci0JgzXSHmO23EKqGmpoaMis0kQeYo0+5DB6cpOsZaM3uxPT2QrjuhbMv20AICJBq4CItFrByxzUkfQYotl46cGjeOnBo55tgQTYAiMXSptKai4poVIdp6od5v4WGBnsO8xdOxK23ykinSLSn+YYooz95vthtN3Rj2jEmyfwQInxly0wcpO0qaREZIeI/AuAh9LdrGwOq78eQH+qZL4JgzQSt60y/7YBqM3kGKJMqSpTSZUYv1Wt94HIDdIO4jDzGn7JvHn5ZgAKoAPxa1H1MK5NNcG4P2yTeQxRXohGAI0CvoC3s9EDwCQDGLlIxqMQVfVeAPea932FYAStOhiDN7rMgRxEecfraaQA4NSWMtQ1BlDfyMnAyD3mMox+AOY1K6JC4PU0UgBQ31SE+iYGL3KXOd3VaQ7QWAVgF4xrY0eyWiuiLLJG3nm5BUbkRnPJhfhdACcDGABwJYC3ROQL2a4YUbZEJxSBUkFRmXcDWG/XBJ6/5whef3zY6aoQZc1cWmAvquovrBXzHq6bReRyVf2PrNWMKEtqTyzC37Yvgap3BzD0dk1g5w8HcPKnyvDBi8qdrg5RVhz3jcyqGlbVm8EchZTnMklL5laxVFK8D4xcZC4BrEtEXhSRT06bnTlVWigiclgslRQzcZCLzCWArQPwEID1AN42g9mTMObvqgIAEbk8i3UkOi5//P0ofnLZQbT9fb/TVXFMgC0wcqG5XAPrhJEp/nsAICJnwZij69MAvikiVkuM18MoL4wORNHbFUHt8kmnq+IYKwMJM3GQm8y6BWbe0FwrIsvN9ZdU9Xuq+mlVrYPRQmMmDsob1knby/eBxVpgDGDkInO6D2ymrBvmHF43zb1KRNkVy4Po0dmYASN4l1b7UFLp3feA3Ccn09MyrRTlk1gqKQ8HsKqFAdzw3GKnq0GUVVmbD4woX7EFRuRODGDkerwGRuROtgcwEVkrIi0isnGGMs3T1u80/7bmun7kPovOKEbz5ypxwspip6viqPsuOYgfnfsuJic4kIPcwdYAZgUmc+LK8PRAZZZpAXDvtM2tItIJoCv3tSS3OemcMpz3jVo0/lmZ01Vx1FD3JIZ7oxyJSK5hdwtsHYCwudwF4/6xKczg1jdt8xWq2mTuI6I5sK4B8mZmcoucjEKcQRBTg1Om+RObzTx2zaq6KduVInfr6ZzA6EAUdScFUF7rd7o6jokFMKaTIpcoiEEcqrrJbH3Vm12MRBl7/u4B/O/Pv4/9z486XRVH+dkCI5exO4CFAdSZy0FkkADYHPSx1lztBdCYpEyriLSLSHt3d3eWqkpuwWH0hlgLjNfAyCXsDmBbEQ9AjQDagNicYql0WeUANAFon15AVTerakhVQw0NDdmrLblCZMz4ywDGAEbuYmsAU9UOIDbSMGytA9hhlTFbWyGr1WWWudJc70w4higjbIEZzvxMBVavr0blfO9eByR3sXsQB1R1c5JtqxKWtwHYlu4YokwxlZRh5RWVTleBKKsKYhAH0fFgC4zInRjAyPUYwAzdb46j89cjOHIw4nRViLKCAYxc78p7G3DNwwtQfYLtPeZ5ZdfPjuI/vtKDt3/r7dsJyD28/Y0mT6hZzI85kHAfGG9kJpdgC4zII5hKityGAYxcTVXx6I29eOyWXqh6+8TNVFLkNgxg5GrRCPD648N47VfDMPNpehZbYOQ2DGDkahyBGBcoMf6yBUZuwQBGrma1NhjAgEApW2DkLhyeRa5mtTYYwIAVl1Tg5E+WoaSSv1vJHRjAyNViLbBSBrCSSh+DF7kKAxhl5MjBCPrejuCElcUoLjdOgt1vjGOoN5q0fGm1DwtPLwYARCOKP744lvKx551ShMp5RoLZgfci6N+fPFOEzw8sO7s0tv7uS2OYSNEdVr3Ij7rlRYiMKfxFgL+YAQwAJkaiePfl8aT7ymp9WPBB4/8sMq54Z1fq/7P5HyhCeZ3xfxY+EEH4neT/Z/4iYGko/n92oH0UkxPJHzO4JIDgUuOUNNw3iff/c2rBQLHghJXF8AX4f0kGBjBKa3w4ip9cdggTI4ov/HIh6pYbAeyFewfx+uPDSY9ZGirBVf82H4AxkOLnX0w9T9slm+pw2sUVAIA3/u8wfn3XQNJyReWCr/1+SWz98Vv7Uga70F9V4pM31qKkyodPf7sOu39+NP0LdbnuN8ex838NYN8zyTNxNJ1bist/ZExHNBqOzvh/dvk/z0PTJ8oAAK8+MoTn7j6StFxFgw9ffmZxbP3RDb0Y6kn+o2f1+mp87L/VAADee2UcD3+lZ8YyRAxglNZQ9yQmRoyWTlFCV9y8k4uw7KMlSY+Z/4Gi2LL4kLIcAJTXx6f3qF4USFm2aNp1rBNWFqNqUfKpQWqXGc8fXBLAxHAUf/KF6pTP7xW1y4pQUuVL+f42fKA4tuwrmvn/rKw23hVZsyT1/1lZzdQuyyWrSjAykDyA1SyJn47KglPrOdwbRc+bEyl/sJA3idtu7gyFQtrefsycl3QcDu0Zx/1XHcaCFUX4/EMLna4OedC+Z0bw8A09aPyzUvzljzlpbS6IyC5VDTldj9lgC4zSGhsyfjEXV3AAADlj8VnF+OxP56OigZ9BimMAo7TGjxoBrKSKJw9yRlnQjyWrOJM0TWX7GUlE1opIi4hsnKFM82yPodwZO2p0MxdXcPQXEeUPWwOYFZhUtQ1AeHqgMsu0ALh3NsdQbvkCQM1iPyrn8xcwOWNiNIqn7+xH2z/0O10VyiN2t8DWAQiby10AWqYXMANV32yOodxa8ecVaH3yBJz7t0Gnq0IeJT7BrvuPYvdDRz0/qwDF2R3AgpganOpzdAwRuUigWOAvNmYXsBI0E/GqPBEVBCsN1vhRBjAy2B3AwgDqzOUggN5sHCMirSLSLiLt3d2pswfQ3Dz2zV788GPv4o225Fk3iOxQbAWwoeQ3QpP32B3AtgJoNJcbAbQBgIgEZ3tMIlXdrKohVQ01NPAmx2wbCUcxOhBlDjpyVEml8fkbG2QLjAy2BjBV7QBiIw3D1jqAHVYZEVkLIGT+nekYssn4kHHCKOEwenKQdSP9GFtgZLL9RmZV3Zxk26qE5W0AtqU7huwzNmhm4uBUHOSg+sYAxoei8BfxhxQZmImD0rKuOXAuKXLS+bfVpS9EnsIzEqUVy8RRyV++RJQ/GMBoRqqKsaNM5kv5QaOKyQkO4iADz0g0I40Cn7wxiHNuqEGAsxqTg1786SDuWvkOdv4w+YSn5D28BkYz8vkFq/5LldPVIEKgRACNDyoiYguMiAqCdR+YdVsHEQMYzWioZxKvPjKEAy+OOl0V8jjrNg7rmiwRAxjNqKdzAo99sw/P3X3E6aqQx1k30rMFRhYGMJoRb2KmfFFszgjOa2Bk4VmJZmT92uVszOS0kgom86WpOAqRZjR+lFk4KD+U1/vQcmsQ5bWcGZwMDGA0o1gWDrbAyGHF5T6cdRVv6aA4/qymGcXyIFbxo0JE+YVnJZoR00hRPnntsWG03z/IofQEgF2IlMb5t9biExuCEMYvygO//dEA+vdH0PjxUl6XJQYwmpn4BMXlvP5F+cG6Fsuh9ASwC5GICojV6uLNzAQ4EMBEZK2ItIjIxkz3i8id5t9Wu+pJhkc39ODBa99H+J2I01UhYjopmsLWACYizQCgqm0AwtZ6BvtbRaQTQJed9SXg4B/GceDFMaerQQQg3oXIFhgB9rfA1gEIm8tdAFoy3H+FqjaZgY1sNDZonChKOBsz5QHrdo5xtsAI9g/iCALoS1ivz3B/s4gAQLOqbspV5WgqVcXYEIfRU/4oqRD4AkBknC0wKpBRiFbQEpHzRaRlekvMvDbWCgDLli1zoIbuFBlV6KQxkaC/iC0wct7HvlKDc75aA/MHLXmc3T+rwwDqzOUggN50+81BHWvNbb0AGqc/qKpuVtWQqoYaGhqyXGXvGmMiX8ozPr8weFGM3QFsK+IBqBFAGwCISHCG/V1WOQBNANrtqCglJPJlGikiykO2nplUtQMARKQFQNhaB7Aj1X5z25VmK6wz4RjKsUCJ4MzLK3DKeWVOV4UIAPBOxxi2fOYQHr+1L31hcj3br4Gp6uYk21al2X/MNsq96kUBXPh3dekLEtlEo4qeNydQUsVuRGImDiIqINaNzONHOQqRGMBoBkM9kzj8+jiGeiadrgoRgPiszMzEQQADGM3g9SeG8bO1h/H8PUecrgoRAMS6DtkCI4ABjGYQm8ySWTgoT1g31I8NRaHKIOZ1DGCU0pj5K7eY8y5RnvAXCQIlAp00brQnbyuITBzkDM7GTPnorM9WQnwAG2DEAEYpWdcZOGSZ8sknNgSdrgLlCf60ppRimTjYAiOiPMQzE6UUy0TPQRyUR3q7JrD/hVEM9fL2Dq9jFyKldNEddRjujWLeKUVOV4Uo5tkfDGDf0yP4ix/U49SWcqerQw5iAKOUapcVoZaz01Ceic3KzHvBPI9diERUUKzZEZiNgxjAKClVxeO39mLHP/RDo/ylS/mjxGqBDTGAeR0DGCUVGVXs2T6MV34xBPFxEAflD+vG+rFB/rDyOgYwSiqehYPBi/JLYjop8jYGMEoqdg8Y00hRnrFyc3IQB3EUIiUVTyNlnCye/m7/lP2furnW9jodL+s1HE/d5/oYdh+Xq8exW2K9reXVX67BFx5diLJa/rjyOtsDmIisBRAG0KyqmzLZn+4Yyr6xWBopniQov5RW+1Bazc8l2dyFKCLNAKCqbQDC1vpM+9MdQ7kxzkS+RJTn7G6BrQPwlLncBaAFQEea/fVpjpkiOqEYPBRJuq+szo9AsdElNnokionh5BeBJSConOePrQ8ejgAputtLqnyxk/zESBSjA6kvLFfO98dG9A33TWJyPPmDBkoFZUHj+ScnFMMzpMzJ1WsqKhcsOrMY9Sexl5nyy0h4Eju+E4bPD3z8qzVT9vkCggrzc66qOHo49XenpNqH4nLjuzs+HMXYkdTf3aqF8e/BUM8kopHkX56iMh9Ka4zHTPfdLa/3w19kfncHopgYSf78drymQr0lwe6zUxBAX8J6fQb70x0zxftvTOBfWg4m3bfuJw1YdnYpAOD5e46g/aeDScvVnhjAdb9aFFv/10sPYWI4+Qf23K/X4OxrqwEA+54ZwS839iUtBwB/87vFsWtKj/z3XhxoH0ta7oMXlePS7xkvc+DdCP71kkMpHzOXr+mkj5WlfF4iJ732q2EAwKuPDE/ZvmBFET7/0MLYeqpzAQB8+tu1WLm2EgCw95fDeOrv+lOWvXHP0tjytvXdeP+1iaTlPnRFBS74Vh0AoPs/J3D/VYdTPubnH1qABSuKAQC/+ccwXvnFUNJydryml7ceTVkun7ni57WItAJoBYAl5WegcoE/aTl/cXxIeEmVpCxXXj+126xyvh8TI8lP9tavHQAIlKR+TKOi8cWyOl/KstYvOADw+Wd+zFy/JqJ8U1rjw2kXl+PArmN/AJbXT/38z/TdKSqTKcszfncTn6POj8oFyVsspQnXjH2BmZ/fl3D2LalKfT6w4zUVFeh33u4AFgZQZy4HAfRmuH+mY6CqmwFsBoBQKKTrd5yQtiKrv1SD1V+qSVsOAK775aL0hQCccl45Tjkvs+Sif/GP8zIqF1waQCavB8jNayLKNyKCSzbN2BETK5fpd+f0Sytw+qUVGZW94p6GjMrN/2Bxxs//iQ3BjOY5y9VrOuuqSuCzGRXNK3YHsK0AQuZyI4A2ABCRoKqGU+1PsY2IiDzM1najqnYAgIi0AAhb6wB2pNo/wzFERORhtl8DM7v7pm9blWb/MduIiMjbRNVd6VhCoZC2t7c7XQ0iooIiIrtUNZS+ZP4ozKEnRETkeQxgRERUkBjAiIioIDGAERFRQXLdIA4R6Qaw3+FqzAPQ43Ad8gXfizi+F3F8L+Ly5b04UVUzu0s7T7gugOUDEWkvtNE8ucL3Io7vRRzfizi+F3PHLkQiIipIDGBERFSQGMByg5lD4vhexPG9iON7Ecf3Yo54DcwmIrJRVTc5XQ8iyj88P8yNK+YDy3dmIuKPOF0Pp5nztgFAk6re5GhlbCYia2FMF9Ts9ROVlz8HyfD8MHfsQiRbmF/SNjMxc6O57gki0gwAqtoGIGyte5GXPweUfQxgOSYizeaJy+saAVgnqy5z3SvWwWh9AcZr9/JJ28ufg2Pw/HB82IWYe3Xpi7jftClxmmFMXuoVQQB9CevppxN2KY9/DpLh+eE4MIAdp4T+/ERdqtrGX1fHMrvPnuLEpN7GzwFbX9nAAHac0ky22SgijQnLzW7+ws4UzBPWWzw4iCGM+C/tIIBex2qSP7z4OZjOU+eHXGAAyyFV3QbETuxBZ2uTe+lmzhaRVuukJSItHvr1uRWAlSqoEYBXXndSHv4cTOG180Mu8D4wsoU52uznMK4F1QG4wksnLvMk1QWgMV2gdzOvfw4ouxjAiIioIHEYPRERFSQGMCIiKkgMYEREVJAYwIiIqCAxgBERUUFiACMiooLEAEZERAWJAYyIiAoSAxgRERUkBjAiG4hIs4h0isjPE9aDDleLqKAxgBHZowXAKgD3WFn7VTXsaI2IChxzIRLZyGx11alql9N1ISp0DGBENrG6DNnyIsoOdiES2cCauNAKXgkTGRLRHHFCS6IcE5FmGBNa9olIG4zrYWEY84MR0RyxBUaUQwndhpthzMb8FoCPcBJHouPHa2BERFSQ2AIjIqKCxABGREQFiQGMiIgKEgMYEREVJAYwIiIqSAxgRERUkBjAiIioIDGAERFRQWIAIyKigvT/AWYnZMmpbvQuAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define the quantile values to compute the locations for\n",
     "quants = np.linspace(0.01, 0.99, 7)\n",
     "# Compute the corresponding locations\n",
     "locs = norm_dist1.ppf(quants)\n",
     "# Construct the distribution using the quantile value and locations\n",
-    "quant_dist = qp.quant(quants=quants, locs=locs)\n",
+    "quant_dist = qp.quant_piecewise(quants=quants, locs=locs)\n",
     "quant_vals = quant_dist.pdf(xvals)\n",
     "print(\"The input and output shapes are:\", xvals.shape, quant_vals.shape)\n",
     "# Construct a single PDF for plotting\n",
-    "quant_dist1 = qp.quant(quants=np.atleast_1d(quants), locs=np.atleast_2d(locs[0]))\n",
+    "quant_dist1 = qp.quant_piecewise(quants=np.atleast_1d(quants), locs=np.atleast_2d(locs[0]))\n",
     "fig, axes = qp.plotting.plot_native(quant_dist1, xlim=(-5., 5.), label=\"quantiles\")\n",
     "leg = fig.legend()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0.01       0.17333333 0.33666667 0.5        0.66333333 0.82666667\n",
-      " 0.99      ]\n",
-      "[0.         0.01       0.17333333 0.33666667 0.5        0.66333333\n",
-      " 0.82666667 0.99       1.        ]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(quants)\n",
     "print(quant_dist.dist.quants)"
@@ -1086,29 +346,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The input and output shapes are: (11,) (1, 11)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAthUlEQVR4nO3deXhU93kv8O87M1rRhqRBQsMylsAYgdHqBYHTOJUd41U42DhOHKMnLrm+bZI+T12Se+u2z22dtiY89zZpe9uQ3IBjuwkxDfIW20F2FgsZ20JCmMXGSAjECAltIwmEltH87h86A4OsXTPnzJn5fp7Hj8468yLPzFfnzHt+R5RSICIiMhuL0QUQERHNBgOMiIhMiQFGRESmxAAjIiJTshldABGR2R06dGiBzWb7CYDV4IFBoHkBHPV4PE8UFRVd8F/BACMimiObzfaTzMzMlXa7vdtisbC1O4C8Xq+0t7fntra2/gTA/f7r+JcCEdHcrbbb7b0Mr8CzWCzKbrf3YPTo9tp1BtRDRBRuLEaG1/Hjx6M3bNiQbcRzV1RUJJaUlCwPxGM9+eSTjqeffjpj7HLtd/uZvGKAERGZXG5u7tDzzz9/ZrJtdu3aNT8Yz11WVtaXnJw8Eojn/spXvtI9k+dmgBERmdzx48ejP/7445iJ1nd0dFj379+fpGdNs3nu1NRUz0wem00cREQB9Jd76xefbO2LD+RjXp+Z2P/9TXnNk22zbds2R3V19acVFRWJ27dvz9y2bVtrTU1N/F133dXX0dFhra+vj9+1a9f88vLybgB4+umnM4qLi/tPnToVk5aWNvLLX/5y/sMPP9zd0NAQnZOTM7Rjx47M733ve+dOnToVs2zZssGysrI+ANixY0f6rbfe2n/w4MH4p556qmNsHb6jrc7OTutTTz3VUVVVFT/Zcz/11FMdvvmampoZ/d54BEZEZHK5ublDvtN4ZWVlfT09PbaysrK+Rx99tPvFF1+cX1ZW1rdkyZJBX4A8+eSTjuLi4v6ysrK+hoaGmPLy8u6jR4/Gl5eXdz/zzDNt5eXl3UuWLBksKyvre+qppzq++c1vLgVGg2fZsmWD69ev71+2bNngjh070v3rqKqqim9oaIguLy/v3rVrl91Xz2TPvWPHjnTf/F133dU3k383j8CIiAJoqiMlPSQnJ096Kq6pqSmmu7vbVlVVFZ+TkzMIAKtXr+6faPvFixcPHj9+PPrQoUPzHn300W4AuP766wd/9KMf2f2PwtavX9/f0dFhraioSJyohrHPXVtbO+/uu+/unc2/k0dgRERhZrKmiqqqqviioqJLy5cvH1y/fn3/li1bxm2c6OnpsfpN23Jzc4eKioounTx5MgYATp48GVNUVHTJf58dO3aknzp1KsZ3urGjo8Pqv3685y4sLLzymDPFIzAiIpOrqqqKP3r0aPzx48ejT548GXP06NH4qqqq+DfffDOxvr4+vqOjw+p0Ogd37do1/7777utdv359/9NPP53hHzC+fdavX98PjIZWVVVV/MGDB+O/973vnQOAZ555ps3X5l5TUxP/zDPPtPmeu6qqKn7ZsmWDNTU18VVVVfF5eXn9r776alJ5eXn3ZM/t+w7M95jvvPNOUkdHR0d6evqknY0AILwfGBHR3NTX1zfl5eV9pqHBzDZs2JD9xhtvNBpdh099fX16Xl6e038ZTyESEdE1KioqEn1HdEbXMhkGGBERXaOsrKyvubn5aG5u7pDRtUyGAUZERKbEACMimjuv1+sVo4sIV9rv1jt2OQOMiGjujra3tyczxAJPu51KMoCjY9exjZ6IaI48Hs8Tra2tP2ltbeUNLQPvyg0tx65gGz0REZkS/1IgIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKbEACMiIlNigBERkSkxwIiIyJQYYEREZEphNxp9enq6cjqdRpdBRGQqhw4d6lBK2Y2uYybCLsCcTidqamqMLoOIyFRE5IzRNcwUTyESEZEpMcCIiMiUGGBERGRKugeYiGwSkVIR2TbFdttmug8REUUOXQNMRAoBQClVCcDtmx9nu1IAN81kHyIiiix6H4FtBuDWphsBlAZpHyIiCnN6B1gKgC6/+bSxG4hIoXa0Ne19iIgo8oRiE0eq0QUQBdrZzn7sPXTO6DKIworeFzK7cTWgUgB0+q8c5+hryn20/bYC2AoAS5YsCVStRAHz968fx/7jbbghMxGrHclGl0MUFvQ+AtsDIFubzgZQCQAikuJbpnUcbtKmCyfax59SaqdSqlgpVWy3m2okFIoAzV39qDzRBgB4rrrJ2GKIwoiuAaaUqgWudBm6ffMA3tbW71VK7cXoEVfKFPsQmcJz1U2wiuCO3Ay8XN+CzouDRpdEFBZ0HwtRKbVznGVF42yzc7J9iMzg0qAHe2qaseHGhfjWF5Zh//E2/PyDs/izLyw3ujQi0wvFJg6isPGrOhf6BjzYUuLE8oxE3LY8Hc8fPIPhEa/RpRGZHgOMKEiUUth94DTWLEpG4ZIUAMCWEifaegfx5tFWY4sjCgMMMKIgqTrVgYb2S9hS4oSIAABuX7EAS9PisZvNHERzxgAjCpJdB5qQnhCDe9YsvLLMYhE8vtaJQ2e6ceSc27jiiMIAA4woCE53XMI7H1/AV25Zghib9Zp1m4oXYV60FbsPNBlTHFGYYIARBcHP3mtClFXwlVs+e2F9UmwUNhUtwqtHWnChb8CA6ojCAwOMKMAuDnrwUs053HPjQixIih13m6+VODE8ovDz95t1ro4ofDDAiALsvw6dw8VBD7asu27CbXLsCfij6+144f0zGPKwpZ5oNhhgRAHk9Srsrm5CwZIU5C9OmXTb8nVOtPcN4tcfndenOKIwwwAjCqDff9qO0x2jrfNT+dxyO7LT52EXW+qJZoUBRhRAuw80YUFiDDasXjjlthaL4PESJ+qb3ag7261DdUThhQFGFCAN7Rfx+5Pt+OqtSxFtm95b60tFi5AQY+OFzUSzwAAjCpCfVTch2mrBl2+e/j3pEmJseKh4EV4/ch5tvWypJ5oJBhhRAPQODGPvoXO4Ly8L9sSYGe37+FonRpTCiwfPBKk6ovDEACMKgJdqzuHS0Mi0mjfGcqbPwxdWLMCL75/FoGck8MURhSkGGNEcjXgVnqtuQvHS+bhxUfKsHmPLOic6Lw3htXq21BNNl+4BJiKbRKRURLZNsL5U++9Zv2XPaj+36lUn0XT97pMLONvVjy3rnLN+jPXL0rFsQQJ2VzdBKRW44ojCmK4BJiKFAKCUqgTg9s2PWX+Htr7Qb/1WEWkA0KhnvUTTsbu6CZlJsfjiqsxZP4aIYEuJEx+5elDLlnqiadH7CGwzALc23Qig1H+lUqpWKfUdbTZbKVWrTT+klMrRgo0oZHza1od3P+3AY2uXIso6t7fTg4UOJMba8FOOUk80LXoHWAqALr/5tPE20k4vfsNvUeFkpx2JjLK7ugnRtpm1zk8kPtqGR25ajDePtuJ8z+UAVEcU3kKyiUMptR3AN0QkxTevHX2liUjp2O1FZKuI1IhITXt7u87VUqTq6R/Gr2pdKMvPQuq86IA85tfWOuFVCi+wpZ5oSnoHmBtAqjadAqDTf6WI+H/v1YjR7742icgmbVkngOyxD6qU2qmUKlZKFdvt9qAUTjTWL2uacXl4BI/PonV+IotT41G6MgP/+f5ZDAyzpZ5oMnoH2B5cDaBsAJUA4DvSwuh3Yv4B16j95/vuKwdAjQ51Ek1qxKvw3HtNuPm6VKzKml3r/ETK1znR3T+MV+pbAvq4ROFG1wDzNWVopwHdfk0ab2s/dwLI9h1xKaX2ats8rC1r8NuHyDBvn2jDue7LKA/g0ZfP2uw0rMhIxO4DbKknmoxN7ydUSu0cZ1mR9tON0RADgL2T7UNkpF0HmuBIicMduRkBf2wRwZZ1TvyPX32ED0534ZbscXudiCJeSDZxEIWyj1t78V5jJx5buxS2ObbOT6Qs34HkuCiOUk80CQYY0Qw9V92E2CgLHrlpcdCeIy7aikduXoy3jrXC5WZLPdF4GGBEM9B9aQj76lzYWOBASnxgWucn8rW1TgDA8++xpZ5oPAwwohnYU9OMgWFvQFvnJ+JIicMXV2XiFx+exeUhttQTjcUAI5omz4gXP6tuQklOGm7ITNLlObeUOOHuH0bFYZcuz0dkJgwwomnaf7wNLT0Ds7rn12zdfF0qVi5MYks90TgYYETTtKu6CYvmx+GPVwa+dX4iIoLyEic+aevDe42dU+9AFEEYYETTcKylBx+c7sLja52wWkTX575fG2txN0epJ7oGA4xoGp6rbkJclBUPFwevdX4isVFWfPnmxag80Ybmrn7dn58oVDHAiKbQeXEQFYdb8KUiB5Ljowyp4au3LoWI4GfvNRny/EShiAFGNIVffNiMIY8Xj2vXZRlhYXIc7lqdiV982IxLgx7D6iAKJQwwokkMj3jx/HtncNvydCzPSDS0lvISJ/oGPNhXx5Z6IoABRjSpt461orVX39b5iRQtnY8bHcnYXc2WeiKAAUY0qd0HmrA0LR63r1hgdCmjo9SXOHHqwkUcOMWWeiIGGNEEPjrXg5oz3Xh8rRMWnVvnJ3Jv3kKkJ0Rj14HTRpdCZDgGGNEEdlWfxrxoKzYVLzK6lCtibFY8evMSvPPJBTR1XDK6HCJD6R5gIrJJREpFZNsE60u1/56d7j5EgdbeN4jX6s9jU9EiJMUa0zo/ka/euhRWEfyMo9RThNM1wESkEACUUpUA3L75Mevv0NYXikjhVPsQBcPPPziLoREvvhYCzRtjLUiKxT1rFuKlmmZcZEs9RTC9j8A2A3Br040ASv1XKqVqlVLf0WazlVK1U+1DFGhDHi9eOHgGf3S9HTn2BKPLGdeWEif6Bj34Ve05o0shMozeAZYCoMtvPm28jbRThd+YyT5EgfLG0fO40DeI8nVOo0uZUMGS+chbnILdB5rg9bKlniJTSDZxKKW2A/iGiKRMZ3sR2SoiNSJS097eHtziKOztOtCE7PR5+Nxyu9GlTKq8xInGjkv4w6d8zVNk0jvA3ABStekUANdczOL/nRdGTxdunWofAFBK7VRKFSuliu320P7QodBWd7Ybh5vdeLwkdFrnJ3L3jQthT4zB7uomo0shMoTeAbYHQLY2nQ2gEgD8jrRKcW1YNU60D1EwPFfdhIQYG75UFDqt8xOJtlnw1VuW4neftKOx/aLR5RDpTtcA05oyICKlANy+eQBvaz93AsgWkU3a9nsn2YcooC70DuD1j87joeJFSIixGV3OtDx6yxJEWdlST5FJ93epUmrnOMuKtJ9ujIYYAOydbB+iQHvx/bPweJWho87PlD0xBvetycJLNc34izuvR2KIXbNGFEwh2cRBpLdBzwhefP8MvrBiAZzp84wuZ0a2rHPi0tAIXqphSz1FFgYYEYDXj5xHx8UhbAnh1vmJrFmUgqKl8/Hce2ypp8jCAKOIp5TCrgNNWLYgAeuXpRtdzqxsKXHiTGc/fnfygtGlEOmGAUYRr/asGx+5evB4iRMiod06P5G7VmciIykGuw40GV0KkW4YYBTxdlc3ITHWhgcLHEaXMmtRVgseu3Up3v20A6cu9BldDpEuGGAU0Vp7BvDGR+fxyE2LMc8krfMT+fLNSxBts/DCZooYDDCKaC8cPIMRpfA1E7XOTyQtIQYP5GXhvw650HN52OhyiIKOAUYRa2B4BP/5wVmUrszA4tR4o8sJiMdLnLg8PIKXapqNLoUo6BhgFLFerW9B16UhlIfgPb9ma7UjGTc7U/Hce00YYUs9hTkGGEUkpRR2VzdhRUYi1uaE1x16tqxzornrMt75mC31FN4YYBSRPmzqxrGWXmxZZ97W+YncmZuBrORY7Dpw2uhSiIKKAUYRaXf1aSTHRaEs37yt8xOxWS14bK0T1Q2d+KSVLfUUvhhgFHFc7st461gbHrl5MeKirUaXExSP3LQYMWyppzDHAKOI88LBM1BK4bFblxpdStDMnxeNjQUO7Ks7B3f/kNHlEAUFA4wiysDwCH7+wVncmZuJRfPDo3V+Io+XODEw7MWeD9lST+GJAUYRpaLOBXf/MMpNOOr8TK1cmIRbs1Pxs/fOwDPiNbocooDTPcBEZJOIlIrItgnWb9X+e9Zv2bO+dXrVSeHH1zq/cmESbr4u1ehydFG+7jq43JdReaLN6FKIAk7XABORQgBQSlUCcPvm/daXAqjU7sCcrc0DwFYRaQDQqGe9FF4ONnbh49Y+lJt41PmZKl2ZAUdKHEepp7Ck9xHYZgBubboRQOmY9dl+yxq1eQB4SCmVowUf0azsrj6N+fFRuD8/y+hSdGO1CB4vWYr3T3fheEuv0eUQBZTeAZYCoMtv/pohEJRSO7WjLwAoBFDjm57stCPRVJq7+rH/eBu+fPMSxEaFZ+v8RDYXL0FclBXPsaWewkxINnFopxb3K6VqAUAptV07+krzO63ov/1WEakRkZr29na9yyUTeOHgGYgIHlsbvq3zE0mOj8KDhQ5UHHah6xJb6il86B1gbgC+b89TAHROsF2pUmo7cKXpY5O2vBNXTyteoR25FSuliu12e2ArJtPrH/Lg5x+cxV2rM7EwOc7ocgyxpcSJQY8XP//grNGlEAWM3gG2B1cDKBtAJQCISIpvAxHZ6hdepRj9Lsz33VcOrp5WJJqWfXUu9A54wmrU+ZlanpGI9cvS8cLBMxhmSz2FCV0DzHdKUAsmt28ewNt+y58VkQYR6fbb52HtKKzBbx+iKSml8Fx1E1Y7klC0dL7R5RhqS4kT53sG8JtjbKmn8KD7PdT9mjT8lxVpPysBfOZTZrx9iKbjyLkenGy7iH968MaIaZ2fyO03LEBWciz2HmrGPWsWGl0O0ZyFZBMHUaDsq3Mh2mbBhhv5gW21CB4ocOAPn3ag4+Kg0eUQzRkDjMLW8IgXr9a3oHTlAiTHRRldTkjYWODAiFfhtfoWo0shmjMGGIWtqlMd6Lw0FJb3/Jqt6zMSkbswCfsOM8DI/BhgFLYq6lxIiY/C51csMLqUkLKxwIH6Zjca2y8aXQrRnDDAKCxdHPTgrWOtuOfGhYi28WXu7/78LIgAFTwKI5PjO5vC0m+OtWJg2IuNBTx9OFZGUizW5aSjos4FpZTR5RDN2owDTEScIvKgiDwhIk9p018IRnFEs7WvzoVF8+Mi/tqviZQVOHC2qx+1Z91Gl0I0a9MOMBH5SxH5DYBnMToihgDo0abvFJHfiMi/i0h+UColmqYLvQM4cKoDGwscEX/t10S+uCoDsVEWVNS5jC6FaNamvJBZRK4D8A0Av1BKfX+KbZMxeu+uYqXUTwJUI9GMvFLfAq8aPcqg8SXGRuGO3Ey8dqQFf31vLr8nJFOa9FWrhdcfK6W+q5Q6PNWDKaV6tJB7W0SeCFCNRDNScdiFvEXJyLEnGF1KSNtYkIXu/mH84STv4EDmNGmAKaVOz+ZIarb7Ec3Vp219OOrq5dHXNNy23I7UedHYd5inEcmcZtPEkRSMQogCoeKwC1aL4N41kXPX5dmKslpw35qFqDzeht6BYaPLIZqx2Zz4zvFv1BCR69iFSKHA61WoqGvBbcvTYU+MMbocUygrcGDQ48WbR1uNLoVoxmYcYEqpOgA3iYhTmz8NYL6I/GOAayOakZoz3XC5L/ParxnIX5wCZ1o8uxHJlGZzCnEPgAYA3X6nEysBbA1kYUQzta/OhfhoK+7IzTC6FNMQEZQVOPBeYyfO91w2uhyiGZnNKcQiADVKqR4AorXOlwL4p4BWRjQDg54RvH6kBXetykR8tO63uTO1snwHlAJe4dBSZDKzCbCHoB1taSGWCmD+VNeI+YjIJhEpFZFtE6zfqv337HT3Ifrtx+3oHfCw+3AWnOnzULAkBft4GpFMZlbfgSmldvjNnwZwaDojcIhIobZPJQC3b95vfSmASu0OzNlaaE26DxEwOvK8PTEGJTlpRpdiSg8WOPBxax9OnO81uhSiaQvI5fdaY8fpaWy6GYBbm27E6KlHf9l+yxq1+an2oQjX0z+Mdz6+gPvzsmCzckSJ2bhnTRZsFkEFrwkjEwnYu107nTiVFABdfvPX/LmslNqpHX0BQCGAmqn2Ifr10fMYGuHI83OROi8an19hx8t1LfB6OUI9mcOUQ0nNZkio2e7nt38hgP1Kqdppbr9VRGpEpKa9ncPiRJp9dS4sW5CAVVm8xn4uygocaO0dwMHTnUaXQjQtUw4lhdFxDf9jOhcri0iSiPwlRsdPHG8oKTdGmz6A0SOrid4ppUqp7dPdRztyK1ZKFdvt9qnKpDByrrsfH5zu4sjzAVC6MgMJMTZeE0amMWW/sRZi/01E/kREvgtAAajF1SBJw2iw5GD0+rDt2j7j2QOgWJvOxuj1YxCRFKWUW5ve6gsvralj3H2IAOBlrfX7/jwOHTVXsVFWbFidiTc+asXfPbAasVFWo0simtS0vwNTSv1YKXUngIcxGiKnMXo/sBoAO5VSdyqlnpwkvOA7JagFk9vvFOHbfsufFZEGEemeYh+KcEop7Ktz4WZnKhanxhtdTljYWOBA36AHb5+4YHQpRFOa8RWfWrPG27N9Qr8mDf9lRdrPSgCfuYXuePsQHWvpxakLF/EPG280upSwcUt2GjKTYrGvzoV71iw0uhyiSc2qC1FEntDuvvwER6cno+yrcyHaasE9N/KDNlCsFsED+Vn43ScX0HVpyOhyiCY1m7EQ/wnAMoyePnwYwGkR+XqgCyOajGfEi1fqW3D7DXYkx0cZXU5YKStwwONVeP0Ih5ai0DabI7APtTs0f1f7TiwHwHIReTDAtRFNqLqhE+19g7z2KwhWLkzCDZmJHFqKQt6cL2RWSrmVUt8FLzAmHVXUuZAUa8PnVywwupSwVFbgQO1ZN850XjK6FKIJzSbAGkXkQxG5fcz3X7z6kXTRP+TBm8dacc+ahWz1DpL787IgAlTU8TQiha7ZBNhmAL8E8CSAJi3M3sLo4LuJAMDTiRRM+4+3oX9oBGX5PH0YLFkpcbj1ujRUHHZBKQ4tRaFpNgHWAOAlpdTDSqlUjN5apRLAnQDOiMinAJ6d7AGI5mJfnQuOlDjc5EydemOatY0FDpzuuIT6c9MZ5pRIf7O5ncqPAcwXEac2X6eU+r52IXMqRo/QpjMyPdGMtfcN4t1PO/BAfhYsFg4dFUx33ZiJaJuFQ0tRyJpVE4cWWk0TrKsF8J25FEU0kdeOtGDEq9h9qIOk2CjcsTIDr9a3YHjEa3Q5RJ8RlJsnafcHIwq4ijoXVmUlYXlGotGlRISyAgc6Lw2h6tMOo0sh+gze/Y9Mo6H9IurP9fDoS0d/dL0dKfFRvCaMQhIDjEzj5ToXLALcx5HndRNts+DeNQvxm+OtuDjoMbocomswwMgUlFLYd9iFdcvSkZEUa3Q5EWVjgQMDw168dbTV6FKIrsEAI1OoPduN5q7LvPbLAIVL5mNxahwqDvM0IoUW3QNMRDaJSKmIbJtkm8Ix889qP7cGuz4KTfvqXIiNsuCLqzONLiXiiAg25jtw4FQH2noHjC6H6ApdA8wXTNp9v9xjg0rbphTAj8cs3ioiDQAag18lhZohjxevHTmPO3MzkRAz41vYUQA8UOCAVwGv1nNoKQodeh+BbQbg1qYbAZSO3UALt64xix9SSuVo6yjC/P5kO9z9w+w+NFCOPQF5i5LZjUghRe8AS8G14TTdEewLpzrtSOGros6FtHnRWL883ehSIlpZgQPHWnpxsq3P6FKIAJikiUMptV07+krTTjFShOgdGMb+E224Ly8LUVZTvFzD1r1rsmC1CIeWopCh9yeCG4BvBNYUTOMWLFrTxyZtthNAdlAqo5D05ketGPJ4UcbTh4azJ8bgtuXpePlwC7xejlBPxtM7wPbgagBlY3QUe4hIyiT7NPq2w+jdn2vGbiAiW0WkRkRq2tvbA1ctGW5fnQvXpc9D3qJko0shjF4T5nJfxodNY7+mJtKfrgGmDfTr6zR0++YBvO3bRjvaKvYddWnbPKzNN/jt4/+4O5VSxUqpYrvdHvR/B+mjxX0ZB093oizfARGOPB8K7sjNQHy0ldeEUUjQvSdZKbVznGVFftN7Aeydah8Kf6/Ut0ApoKyAQ0eFivhoG+5alYnXjpzH3963infEJkPxW3EKWRV1LhQuScHStHlGl0J+ygoc6Bvw4HefXDC6FIpwDDAKSSfO9+Lj1j5e+xWCSnLSYE+M4TVhZDgGGIWkijoXbBbBPWt4+jDU2KwW3J+Xhd9+3A53/5DR5VAEY4BRyBnxKrx8uAWfX2FH6rxoo8uhcWwscGBoxItff8QR6sk4DDAKOe83dqK1d4DXfoWwVVlJWLYggRc1k6EYYBRy9tW5kBBjQ+nKDKNLoQmICDYWOPBBUxeau/qNLociFAOMQsrA8AjeONqKDasz2aId4u7X7oz9CkeoJ4MwwCikVJ5ow8VBD7sPTWBxajxudqbiV7XnoBSHliL9McAopFTUuZCZFItbsqd7owIyUlmBAw3tl3CspdfoUigCMcAoZHRdGsLvPmnHA/mjo55T6LvnxoWItlp4TRgZggFGIeP1Iy3weBU2FvL0oVkkx0fh9hvseKW+BZ4Rr9HlUIRhgFHI2Ffnwg2ZibghM8noUmgGNhY40N43iOqGKe+ORBRQDDAKCWc6L6H2rJvNGyb0+RULkBRr4zVhpDsGGIWEiroWiAD353PoKLOJjbLinjUL8eaxVvQPeYwuhyIIA4wMp5RCxWEX1manYWFynNHl0CyU5TvQPzSC/cfbjC6FIggDjAxXf64HpzsucegoE7vJmQpHShy7EUlXugeYiGwSkVIR2TbJNoUz3YfMq6LOhRibBXetzjS6FJoli0XwQH4W3v20A+19g0aXQxFC1wDzBZNSqhKAe2xQaduUAvjxTPYh8xoe8eLV+haU5mYgKTbK6HJoDjYWODDiVXjtCIeWIn3ofQS2GYBbm24EUDp2Ay2oumayD5lX1acd6Lw0hI35PH1odsszErEqK4ndiKQbvQMsBdeG03TGC5rNPmQS++pcmB8fhc9dbze6FAqAjQUO1J/rQUP7RaNLoQjAJg4yzMVBD35zvBX3rslCtI0vxXBwX14WLAK8zKMw0oHenxpuAKnadAqA6Vy6P+U+IrJVRGpEpKa9vX3ORZI+3jraioFhL7sPw0hGUizWLUvHvsMujlBPQad3gO0BkK1NZwOoBAARSZnpPv6UUjuVUsVKqWK7naeizKLisAtLUuNRuCTF6FIogMryHWjuuozas91Gl0JhTtcAU0rVAlc6Dd2+eQBv+7YRkU0AirWfk+1DJtbWO4ADpzpQVuCACEeeDydfXJ2J2CiOUE/BZ9P7CZVSO8dZVuQ3vRfA3qn2IXN7tb4FXgWUceiosJMQY8OduZl47ch5/M29q/j9JgUNX1lkiH11LuQtTkG2PcHoUigINhY44O4fxu9P8jtpCh4GGOnuZFsfjrX0YiOPvsLW+uXpSJsXzWvCKKgYYKS7ijoXrBbBvXkMsHAVZbXgvrws7D/Rht6BYaPLoTDFACNdeb0KLx9uweeWpyM9IcbociiIygocGPJ48eZHrUaXQmGKAUa6+rCpCy73ZV77FQHyFiXjuvR57EakoGGAka4qDrswL9qKO3M58ny4ExGU5Ttw8HQnWtyXjS6HwhADjHQzMDyC146cxxdXZyIu2mp0OaSDsoIsKAW8Us8R6inwGGCkm999cgF9Ax5s5OnDiLE0bR4Kl6SwG5GCggFGuvlVrQv2xBiU5KQbXQrpaGOBAx+39uF4S6/RpVCYYYCRLtz9Q/jtJxfwQF4WrBYOHRVJ7lmTBZtFUHGYR2EUWAww0sXrH53H8Ihi92EESp0Xjc+vsOPlwy6MeDlCPQUOA4x0UVHnwvIFCViVlWR0KWSAsgIH2noHcbBxOndQIpoeBhgFXXNXPz5s6ubI8xGsdGUGEmJsvCaMAooBRkH3svbdxwMc+zBixUZZsWF1Jt482orLQyNGl0NhggFGQaWUwr46F26+LhWL5scbXQ4ZaGOBAxcHPag80WZ0KRQmGGAUVEddvWhov8Rrvwi3ZKchMymW14RRwDDAKKj21bkQbbXg7tULjS6FDGa1CB7Iz8LvT7aj8+Kg0eVQGNA9wERkk4iUisi26a4XkWe1n1v1qpPmzjPixSv1LfjCDQuQHB9ldDkUAsoKHPB4FV7/6LzRpVAY0DXARKQQAJRSlQDcvvlprN8qIg0AGvWsl+bmrWNt6Lg4yGu/6IqVC5NwQ2Yi9nzYjIFhNnPQ3Oh9BLYZgFubbgRQOs31DymlcrRgoxA34lX4t9+ewrd+UYds+zzcfoPd6JIohHx9/XU41tKLsn87gFMXLhpdDpmY3gGWAqDLbz5tmusLJzvtSKHjQu8AHvt/7+P7b32Cu29ciJf/dB1ibBx5nq56qHgxdm25CRf6BnHfv1ThlzXNUIojdNDMmaKJQym1XTv6ShORsUdtEJGtIlIjIjXt7e0GVEgA8NtPLmDDD95F7dlubP/SGvzwkXwkxvK7L/qs229YgDe+fRvyF6dg294j+PM9h9E3MGx0WWQyegeYG0CqNp0CYOy4Mp9ZrzV1bNKWdQLIHvugSqmdSqlipVSx3c7TVXob8njxD78+gfJdH8KeGIPXvrkeD9+0mKNu0KQykmLxwhO34C/uuB6v1rfg3n+pwpFzbqPLIhPRO8D24GoAZQOoBAARSZlkfaNvOwA5AGr0KJSm52xnPx76j2rs/EMjHrt1KSr+dB2WLUg0uiwyCatF8M0/Xo4931iLYY8XX/r3avzk3UZ4OegvTYOuAaaUqgUA7TSg2zcP4O2J1mvLHtaOwhr89iGDvVLfgrt/+C5Od1zCf3y1EH9fthqxUfy+i2buJmcqfv3t23D7igV45vUT+PpzH/JaMZqShNuXp8XFxaqmhgdpwdQ/5MH/euU49tQ0o2jpfPzgkXwOE0UBoZTC8wfP4JnXTyAlLgr//Eg+b4CqExE5pJQqNrqOmTBFEweFjo9be3H/vx7ALw81489uX4Y9W29leFHAiAi+ttaJiv++DgmxNnzlJ+/jf//mE3hGvEaXRiGIAUbT4vvL+P5/PYCey8N48eu34KkvroDNypcQBV5uVhJe++Z6PFS0CD985xS+/OODcLkvG10WhRh++tCUevqH8eQLtfjriqMoyUnDG9++DSXLeFqHgis+2obtm/Lwg0fyceJ8H+7+wbt461ir0WVRCGGA0aRqmrpw9w/fReWJNvzV3Svx08dvQnpCjNFlUQR5IN+B1765HktS4/GN5w/hb14+ymGoCAADjCbgGw5q886DsFoE//VkCf7kc9mwWHhtF+nPmT5v9DV423X42XtnOAwVAWCA0TjGDgf1+rfWI29xitFlUYSLtlnwV/fkchgquoIBRtfgcFAU6jgMFfkwwAgAh4Mic+EwVAQwwAgcDorMicNQEQMswnE4KDI7DkMVuRhgEap/yIPv7D2Cb/28DisyE/Hrb9+Gu1YvNLosollJiY/Gjx4rwt89sAoHGjqx4Qfvorqhw+iyKMgYYBGIw0FROOIwVJGHARZBxg4H9QKHg6Iw5BuGalMhh6EKd/zkihD+w0GtzR4dDmodh4OiMBUfbcP3H8rDP2/Ox/GWXg5DFaYYYBHg0Jmrw0H9z7tvwK4tHA6KIkNZgQOvf+u2K8NQ/S2HoQorDLAw5hsO6uEfjQ4HtffJEmz9XA6Hg6KI4huG6on11+G5985g4/+t5jBUYUL3ABORTSJSKiLbprt+qn3oWkopnO+5jK/9dHQ4qA2rM/Hat9Yjn8NBUYSKtlnw9L25+OmWYrT1DlwZhmqE14yZmk3PJxORQgBQSlWKSLaIFCqlaidb71s30T7hasjjRe/AMHovD6N3wIOey77pYfRe1ua19T3aNn3asp7LwxgeUYiNsuDZL92Ih4s5ogYRAHzhhgy88e3b8Oe/OIxte49g294jSIixITkuComxNiTFRSE5LgpJsVFIirMhKVabj4tCUqzt6rQ2nxBj43vLQLoGGIDNAPZr040ASgHUTrE+bYp9QtKIV+HiwLVB4wuX3ssev+nR8LkaRKPrL09xnj7KKlfeaInam2nx/DjtjTX6prtzVQZy7Ak6/YuJzME3DNXLh10409l/5T3ne082d/WjT3tP9g16Jn0si+DKey4pznY1/GKjkBw/+r70f0+ODcUYm4UBOAd6B1gKgC6/+bRprJ9qn2t80tqH27a/AwDwDVI9drBq3+jVCteuV9qSq/Nj959o/bWP5xlRuDiNF37imBd1jj3h2hd5/ER/CUYhNoovfKLZsloEDxYumnI7z4gXFwc9nznrMfaPUf8zIRd6L15ZPzA8+TVo0VYL4qKt8L2Vfe9o33v76rxvD7lmfux6mXD9tZ8VV9aP2c9s9A6woBCRrQC2AkBSVjaKl6ZizP/vSf7HTrB+Di8Yi0W04PGdjvD7K0z7q2xetI3NFEQhzma1ICU+Ginx0bPaf9Azgr5rvgIY52zL0Ogfu3P+g3qa+/nW+/9QSuHdWf0LjaV3gLkBpGrTKQA6p7l+sn2glNoJYCcAFBcXq/+zOT8gxRIRzUWMzYqYBKspLlv5wZeNrmDm9A6wPQCKtelsAJUAICIpSin3ROsnWEZERBFM1zZ6X/egiJQCcPt1E7490fpJ9iEiogim+3dg2um+scuKplj/mWVERBTZOBIHERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpiRo7zpLJiUg7gDMGl5EOoMPgGkIFfxdX8XdxFX8XV4XK72KpUspudBEzEXYBFgpEpEYpVTz1luGPv4ur+Lu4ir+Lq/i7mD2eQiQiIlNigBERkSkxwIKDI4dcxd/FVfxdXMXfxVX8XcwSvwPTiYhsU0ptN7oOIgo9/HyYnbC4H1io0wYivsnoOoym3bcNAHKUUt8xtBidicgmjN4uqDDSP6gi+XUwHn4+zB5PIZIutDdppTYwc7Y2HxFEpBAAlFKVANy++UgUya8DCjwGWJCJSKH2wRXpsgH4PqwatflIsRmjR1/A6L89kj+0I/l18Bn8fJgbnkIMvtSpNwl/Y26JU4jRm5dGihQAXX7zaQbVYbgIfx2Mh58Pc8AAmyO/8/n+GpVSlfzr6rO002f7eWPSyMbXAY++AoEBNkdT3GwzW0Sy/aYLw/kNO1mY+82XRmATgxtX/9JOAdBpWCWhIxJfB2NF1OdDMDDAgkgptRe48sGeYmw1wTfVnbNFZKvvQ0tESiPor889AHxDBWUDiJR/97gi+HVwjUj7fAgGXgdGutC6zV7C6HdBqQAeiqQPLu1DqhFA9lRBH84i/XVAgcUAIyIiU2IbPRERmRIDjIiITIkBRkREpsQAIyIiU2KAERGRKTHAiIjIlBhgRERkSgwwIiIyJQYYERGZEgOMSAciUigiDSLykt98isFlEZkaA4xIH6UAigD8yDdqv1LKbWhFRCbHsRCJdKQddaUqpRqNroXI7BhgRDrxnTLkkRdRYPAUIpEOfDcu9IWX340MiWiWeENLoiATkUKM3tCyS0QqMfp9mBuj9wcjolniERhREPmdNtyJ0bsxnwZwE2/iSDR3/A6MiIhMiUdgRERkSgwwIiIyJQYYERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRK/x/3dQ76LKvSlgAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define the x-grid locations\n",
     "xvals = np.linspace(-5, 5, 11)\n",
@@ -1139,29 +379,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The input and output shapes are: (11,) (2, 51)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtJUlEQVR4nO3deXhb5Z0v8O9PkvdNXmQ7mx3sLHYWkthOCBACJCZlmXYoDUkppYUWTNP13g5Ne1vuTOdO55lCe9uZ3i4Q6EBZQgNpS6EzbE4ogaYk2E5Cs5hgO7YTJ443KV7iTdZ7/9BRopjYkh35HB3p+3keP9LZ5F8cW1+957znfUUpBSIiIrOxGF0AERHRZDDAiIjIlBhgRERkSgwwIiIyJZvRBRAR0dSorq7OttlsjwNYBPM2WDwADrrd7ntLS0vb/DcwwIiIIpTNZns8Nze32OFwOC0Wiym7nHs8Hmlvb1/Q2tr6OIBP+G8zayITEVFgixwOR7dZwwsALBaLcjgcZ+BtRV64zYB6iIhIHxYjw+uJJ55Iv+mmmwrG2r5p06YZDz74YE6g19H+DR/JKwYYERFNiXvuucc53vY777xz3O2BMMCIiMgQGRkZ7ks5np04iIiiwLe2H5h1tLUnMZSvOS835eyP1i85Hsy+CxcuLL7nnnvaH3jggY4HH3wwp6ys7GxVVdUF9fjW19XVxT3wwAMdgV6TLTAiIppSL774YsoLL7xQ/8ADD3T8+Mc/ziorKzt766239tx44409vn02bdo0w7e+vr4+LpjXZQuMiCgKBNtSCrXm5ua4Rx991PG9732vFcBQTU1N0s0339w9er/GxsY4p9Npe+eddxILCwsHg3lttsCIiGjKLFmy5OzTTz/dtHnz5hkAUFJS0nf06NGPtLBKS0v75s6dO7hq1aqzd999d1CdO9gCIyKiKfHiiy+mvP322yltbW3WtLS0kc985jP5W7dubfJ1na+qqkrcuXNnakdHR8cPfvCD0w8++GBOR0eHFQBuvfXWnvFfHRDOB0ZEFJkOHDjQuGTJkoCdIczgwIEDWUuWLJntv46nEImIyJQYYEREZEoMMCIiMiUGGBFR5PJ4PB4xuohLpf0bPKPXM8CIiCLXwfb29jQzh5g2nUoagIOjt7EbPRFRhHK73fe2trY+3traGhETWo7ewG70RERkSmZNZCIiinIMMCIiMiUGGBERmRIDjIiITIkBRkREpsQAIyIiU2KAERGRKekeYCKyXkTKRWRzgP02T/QYIiKKHroGmIiUAIBSqhKAy7d8kf3KASyfyDFERBRd9G6BbQTg0p43ACifomOIiCjC6R1gdgBdfsuZo3cQkRKttRX0MUREFH3CsRNHhtEFEBFR+NN7NHoXzgeUHUCn/8aLtL4CHjNaVlaWmj179qVVSUQUZaqrqzuUUg6j65gIvQNsG4Ay7XkBgEoAEBG7UsoFoEBECnzbtQ4bFz3Gn4hUAKgAgLy8PFRVVU3ZP4CIKBKJSJPRNUyUrqcQlVI1wLlehi7fMoAd2vbtSqnt8La47AGO8X/dLUqpMqVUmcNhqg8QREQ0SRE3H1hZWZliC4yIaGJEpFopVRZ4z/ARjp04iIiIAmKAERGRKTHAiIjIlBhgRERkSgwwIiIyJb3vAyMiAEoptHYPoLa1B0dbe1CSn47lszkIDdFEMMCIdNAzMIz/ev8UjpzqRm1rD2pbe3Cmf/jc9hir4NG7SrGmKMfAKonMhQFGNMWG3B584cn38F6jE0mxVszPTcEtl09DUW4KinJTMd0ejy89U40vPVODX3++DNfM5c34RMFggBFNsX/502G81+jE/719CT65bAYsFvnIPk9/4Qrc8di7uO+pKjx5zwqsLOCkC0SBsBMH0RTa9l4znn63CRWrC/Cp0pkXDS8ASE+KxTP3XoEZ9gR88cn3UN3k1LlSIvNhgBFNkZpmJ/73i4dwzdwsbP7Y/ID7ZyXHYet9K+FIicPd/7kX759wTX2RRCbGACOaAm09A9j0TDVy0uLw/+5YBps1uD+1nNR4PHvfSqQmxOCuX+/F4ZPdU1wpkXkxwIhCbMjtwaZnatDd78aWu8pgT4yd0PEz7Al47r6VSIix4q5f70FTZ98UVUpkbgwwohD7/suHUN3kxI9uvxzF01In9Rp5mYnYet8V6Bty49FdDSGukCgyMMCIQmjrnmZs3dOML11biL+7fPolvVaBIxm3LJ6OP+5rQd+gO0QVEkUOBhhRiNS19eCfXjqI1fMc+FYQnTaC8Zkr8tA3NIKXD5wMyesRRRIGGFGI/GxHHWKsFvx0wxJYx+guP1EleXbMz0nBc3ubQ/J6RJGEAUYUAnVtvXj5/ZO468p8ZCbHhex1RQR3rJiFAyfO4GDLmZC9LlEk0D3ARGS9iJSLyOYxtpdrXw/5rXtIe6zQq06iifjFm3WIt1lRcU1ByF/7k8tmIs5mYSuMaBRdA0xESgBAKVUJwOVbHrX9Bm17id/2ChGpB8DuWBR2Gtp78cf9LSFvffmkJcbglsun4Y/7T7IzB5EfvVtgGwG4tOcNAMr9NyqlapRS39YWC5RSNdrz25VShVqwEYWVX7xZj1ibBfdNQevL5zMr8tA76Maf3mdnDiIfvQPMDqDLb/miI5Zqpxfv91tVMt5pRyKjNHX24cX9Lbjzinw4UkLf+vIpzU/H3OxkbN17fMq+B5HZhGUnDqXUwwDuFxG7b1lrfWWKSPm4BxPp6Oc762CzCO5fPXWtL8DXmSMPB467cOgkO3MQAfoHmAuAb9pZO4BO/40i4n/dqwHea1/rRWS9tq4TwEfeKUSkQkSqRKSqvb19SgonGu1411n8fl8L7liRh+zU+Cn/freVzECczYLfshVGBED/ANuG8wFUAKASAHwtLXivifkHXIP25bv2VQigavSLKqW2KKXKlFJlDgcnAyR9/OLNOlgtgk3XFery/eyJsbhl8TS8uK8FZ4fYmYNI1wDzdcrQTgO6/Dpp7NAetwAo8LW4lFLbtX02aOvq/Y4hMszxrrPYXn0Cn14+Czk6tL587rgiDz2Dbvzp/VO6fU+icKX7jMxKqS0XWVeqPbrgDTEA2D7eMURG+tVb9bCIfq0vn7L8dMzJTsZze5uxoWyWrt+bKNyEZScOonDW4urHC1XHsWH5TExLS9D1e/s6c+xrduHIKc4VRtGNAUY0QY/8uR4AsOm6OYZ8/9uWzUCszYLfcmQOinIMMKIJOOnqx7b3jmN96SzMsOvb+vJJT4rFzYty8ft9LRgYHjGkBqJwwAAjmoBf/rkOCgpfuV7fa1+j3VYyEz0Dbuyu7zC0DiIjMcCIguRrfd1eNgsz0xMNreWKggwkx9nwxuE2Q+sgMhIDjChIv3izDgDwleuNufblL85mxep5WdhZexoejzK6HCJDMMCIgnDCeRbPVx3HhjLjrn2NtrYoB6e7B3GQQ0tRlGKAEQXhl1rPw3BofflcX5QNiwCVR3gakaITA4wogBPOs3ih6jg2Lp+F6WHS+gKAjKRYlOano/LwaaNLITIEA4wogF+8WQ+BhFXry6e8OAeHT3XjpKvf6FKIdMcAIxrH8S5v6+vTK2bpPupGMNYW5wAAdtTyNCJFHwYY0Th+8WadIWMeBqvQkYTZmYk8jUhRiQFGNAbfiPN3hGnrC/COjVhenIO/1neib5BTrFB0YYARjeHnO+tgsYhhYx4Ga21xDoZGPHj7Q07mStGFAUZ0Ec2dZ/G7mhP4zIo85KbpN9/XZJTNTkdaQgy701PUYYARXcSv3vK1vsLz2pe/GKsF1813YGdtG0Y4KgdFEQYY0ShtPQP4XXULbi+dqetsy5dibXEOuvqGsP+40+hSiHSje4CJyHoRKReRzWNsL9e+Hgr2GKJQemp3E4Y9Htx7TYHRpQTt2nkO2CzC04gUVXQNMBEpAQClVCUAl2951PYbtO0lIlIS6BiiUOobdOPpd5uwbkEOLstKMrqcoKUlxGDFZRnsTk9RRe8W2EYALu15A4By/41KqRql1Le1xQKlVE2gY4hC6YWq4zjTP4yK1eF/7Wu0tcU5+LCtF02dfUaXQqQLvQPMDqDLbznzYjtppwrvn8gxRJfKPeLB4+8cQ1l+Okrz040uZ8LKi7MBcHBfih5h2YlDKfUwgPtFxB7M/iJSISJVIlLV3s57YWhyXjnYihPOfty32jzXvvzlZyZhbnYydhzhaUSKDnoHmAtAhvbcDqDTf6P/NS94TxdWBDoGAJRSW5RSZUqpMofDEfKiKfIppbBlVwMKspJwgza+oBmVL8jB3mNdONM/bHQpRFNO7wDbBsD38bYAQCUA+LW0ynFhWDWMdQxRKL3b0IW/tZzBvdcUwGIRo8uZtPLibLg9Cm8d5ZkIiny6BpjWKQMiUg7A5VsGsEN73AKgQETWa/tvH+cYopDZsqsemUmxuK1khtGlXJKls9KRkRTL3ogUFWx6f0Ol1JaLrCvVHl3whhgAbB/vGKJQOXq6B29+0I5v3jAP8TFWo8u5JFaLYE1RNl4/1IrhEQ9irGF5mZsoJPjbTVHvsV0NiI+x4K6V+UaXEhLlxdnoHnCjqpGjclBkY4BRVDvdPYAX97dgQ9kspCfFGl1OSFwz14FYqwWV7I1IEY4BRlHtyd2NGPEofHHVZUaXEjJJcTZcWZiJyiOnoRQH96XIxQCjqNU76MYz7zbhxkW5yM80z7BRwShfkIOmzrOob+81uhSiKcMAo6j12sFW9Ay4I6r15bO2iKNyUORjgFHU2lnbhpzUOJTkmW/YqECm2xOwcHoqu9NTRGOAUVQacnuw62g71hRlQ8S8Ny6PZ21xDmqanejsHTS6FKIpwQCjqFTV2IWeQTfWFJl32KhAbijOgUcBb37AUTkoMjHAKCrtqG1DrM2Cq+dE7uQGi2akIic1joP7UsRigFFU2lnbhqsKM5EYq/tgNLoREawtzsGuo+0YdI8YXQ5RyDHAKOo0tPfiWEffuZ56kay8OBt9QyN4t6Er8M5EJsMAo6izs9bbtfz6KAiwqwqzkBBjZW9EikgMMIo6O460oSg3BTPTE40uZcrFx1ixam4WdnBUDopADDCKKmf6h/FeYxfWREHry+eG4hycPDOAw6e6jS6FKKQYYBRV3v6wHW6Pwtri6Amw64uyIeJteRJFEgYYRZWdR9qQnhiDpbMib/SNsThS4rB0lp2j01PEYYBR1BjxKPz5aDuum58NqyUyR98YS3lxDt4/cQanuweMLoUoZHQPMBFZLyLlIrJ5jO0V2tdDfuse8m3Tq06KPPuPu9DVNxRV1798you9I47wNCJFEl0DTERKAEApVQnA5Vv2214OoFIptQVAgbYMABUiUg+gQc96KbLsrD0Nq0Wwep7D6FJ0Ny8nGTPTEzgqB0UUvVtgGwG4tOcNAMpHbS/wW9egLQPA7UqpQi34iCZlx5E2LJ+djrSEGKNL0Z2IoLw4B+/UdaB/iKNyUGTQO8DsAPyHBLhgIDql1Bat9QUAJQCqfM/HO+1IFEiLqx+1rT1YG8GD9wZSXpyDQbcHb3/IwX0pMoRlJw7t1OIbSqkaAFBKPay1vjL9Tiv6718hIlUiUtXezj9O+ijf6Btroqj7/GgrLstASpzt3M+CyOz0DjAXgAztuR1A5xj7lSulHgbOdfpYr63vxPnTiudoLbcypVSZwxF91zcosJ1HTmN2ZiIKspKMLsUwsTYLVs9zYGdtGzwejspB5qd3gG3D+QAqAFAJACJi9+0gIhV+4VUO77Uw37WvQpw/rUgUlLNDbvylvhNrinIidvLKYK0pykZbzyAOneSoHGR+ugaY75SgFkwu3zKAHX7rHxKRehFx+h2zQWuF1fsdQxSU3XWdGHJ7omr0jbFcN9/hHZWjlr0Ryfx0nwzJr5OG/7pS7bESwEeGSLjYMUTB2lHbhuQ4G5bPzgi8c4TLTI7Dsll27Kxtw/8on2d0OUSXJCw7cRCFilIKb9a2YfW8LMTa+OsOAGu1UTnaOCoHmRz/oimiHe/qR2v3AK4qzDK6lLDhG4nkzQ/YG5HMjQFGEa262XvbYdns6Bm8N5Ci3BRMT4vnsFJkegwwimjVTU6kxNkwNzvF6FLChohgTXE23qnrwMAwR+Ug82KAUUSrbnJhaZ496kafD2RtUQ7ODo1gz7GuwDsThSkGGEWsnoFhfNDajZI8nj4c7crCTMTHWLCTg/uSiTHAKGIdOH4GHgWU5jPARouPsWLVnCzsqG2DUhyVg8yJAUYRq6bZCRFgaZ7d6FLC0pqiHJxw9uPDtl6jSyGaFAYYRazqJifm56QgNT76pk8Jhq87PXsjklkxwCgieTwKNc1OlPD04Zhy0+KxcHoqdnJYKTIpBhhFpLr2XvQMuNmBI4C1RdmobnLC2TdkdClEE8YAo4hU3eQEwA4cgawpzoFHAW8d5Tx6ZD4THsxXRGbDO1tyBrxzejXAO7L8zpBWRnQJqpucyEiKxezMRKNLCWuXz0hDVnIcdtS24dZlM4wuh2hCgg4wEfkWgBsAOOGdk8sF4Ay8c3Rlish3ANQDeFQptT/klRJNQE2zEyV56VE//1cgFotgTZEDrx5sxfCIBzFWnpQh8wgYYCJyGYD7AfxWKfWjAPumAagQkTKl1OMhqpFoQrr6htDQ3of1pTONLsUU1hTl4PmqE6hucmJlQabR5RAFbdyPW1p4rVVKfSeYVpVS6owWcjtE5N4Q1Ug0Ifuatetf7MARlFVzsxBrtWBnLbvTk7mMG2BKqWOTaUlN9jiiUKhucsJmEVw+0250KaaQHGfDFQUZ2MFhpchkJnzCW0RSL+Ubish6ESkXkc1jbK/Qvh4K9hgif9VNTiycnoqEWKvRpZjG2qJs1Lf3obGjz+hSiII2mSu2hSKy1LcgIpeJyJpgDhSREgBQSlUCcPmW/baXA6hUSm0BUKCF1rjHEPkbHvHg/RNneAPzBK0tzgEAvHGYrTAyjwkHmFJqH4DlWnd6KKWOAUgXkX8L4vCN8PZeBLzd78tHbS/wW9egLQc6huic2lM96B8e4Q3MEzQrIxELpqXi9cOtRpdCFLTJnELcBm93eaff6cRKABVBHG4H4D8B0QVdnpRSW7TWF+C916wq0DFE/qqbvL8qvIF54tYtzEFVkxMdvYNGl0IUlMmcQiwFUKWUOgNAtK7z5QB+GKqitNOEbyilaoLcv0JEqkSkqr2dIwpEs+pmF6alxWO6PcHoUkxn3YJcKAV25iDTmEyA3Q6ttaWFWAaA9ED3iGlc2v6At2XVOcZ+5Uqph4M9Rmu5lSmlyhwORxBlUKSqaeIAvpNVPC0FM9MT8PohBhiZw6SugSmlfuy3fAxAtX/HjnFsg/e6FrTHSgAQEbtvBxGp8IWX1qnjoscQjdZ6ZgAtrn7e/zVJIoJ1C3Lxdl0H+gbdRpdDFFBIxo3ROnYcC2K/GuBcMLn8ThHu8Fv/kIjUi4gzwDFEF6jRbmBmC2zy1i3MwZDbg10c3JdMYMKD+Y5FO50YzH5bLrKuVHusBPCRd5+LHUM0WnWTE3E2CxZMu6RbFaNaWX460hNj8Prh07hp8TSjyyEaV8ChpCYzJNRkjyO6FNVNTiyZaUesjQPSTpbNasHa4hzsOHIawyMeo8shGlfAoaTgHdfwkWBuVhaRVG3U+rUcSor0NDA8gkMneQNzKKxbkIPuATf2HusKvDORgQKeQtRC7Esicp82ZYoCUIPzvQEz4e0dWAjv/WEPa8cQ6eZvLWcwPKJQkmc3uhTTu2auA/ExFrx+qBVXz8kyuhyiMQV9DUwp9RiAx7T7vsrgDa0MeDtvNGgdOYgM4ZuBmS2wS5cQa8XquQ68fvg0vv+JhZxTjcLWhDtxaJ01dkxBLUSTVt3kRH5mIrKS44wuJSKsW5iL1w+fxsGWbiyemWZ0OUQXNamr3SJyr4j8Sntkly8ylFIKNU1ODh8VQmuLsmERcGxECmuTGQvxhwDmADgDYAOAYyLyxVAXRhSsxs6z6OwbQll+RuCdKSjpSbFYcVkGR+WgsDaZFth72gzN31FKrYO388ZcEbktxLURBaWq0dtbrmw2W2ChtG5BLj443cM5wihsXfINM0opl1LqO+Ao8WSQmmYnUuNtmONINrqUiHLDAs4RRuFtMgHWICLvicj1o65/jTUwL9GUqmr0DuBrsbC3XChxjjAKd5MJsI0AngewCUCjFmavwTuDcgoA8HQi6cV1dggftvWijB04pgTnCKNwNpkAqwfwglJqg1IqA96pVSoBrAPQJCIfAngohDUSjWlfswsA7/+aKpwjjMLZZKZTeQxAuojM1pb3KaV+pJRapwXaRgQxMj1RKFQ1dcFqESydZTe6lIjkmyPsNfZGpDA0qU4cWmg1jrGtBsC3L6UoomBVNTqxYFoqEmNDNrEC+RER3Lx4GnYdbUdbz4DR5RBdYEqG7eawUqSH4REPDpxw8QbmKXbHijy4PQrPv3fc6FKILsB5J8i0Dp/sxsCwh/d/TbHLspKwak4Wntt7HCMeZXQ5ROfoHmAisl5EykVk8zj7lIxafkh7rJjq+sg8qrQBfNkCm3qfXZmHFlc/3qxtM7oUonN0DTBfMGkzL7tGB5W2TzmAx0atrhCRegANU18lmUVNkxMz7AmYlpZgdCkRb21xDrJT4vDMniajSyE6R+8W2EYALu15A4Dy0Tto4TZ6Jr3blVKF2jYiKKVQ1dTF1pdOYqwWfHpFHt462o7jXWeNLocIgP4BZseF4RTs8FMlgU47UnQ54ezH6e5BBpiO7lgxCxYRbN3bbHQpRABM0olDKfWw1vrK1E4xUpSraeb1L71NS0vA2qJsPP/ecQy6R4wuh0j3AHPBO4sz4G2NBRw/Uev0sV5b7ARQcJF9KkSkSkSq2tvbQ1QqhbOqRieSYq0oyk0xupSo8tmV+ejsG8KrBzk+IhlP7wDbhvMBVADvEFQQEfs4xzT49oN36paq0TsopbYopcqUUmUOhyN01VLYqm5yYmmeHTarKU4iRIxVc7KQn5mIZ9/laUQynq5//dooHb6ehi7fMoAdvn201laZr9Wl7bNBW673O4aiVO+gG7Wt3SjlBJa6s1gEn1mRh72NXfigtcfocijK6f7xVWstVSqltvitK/V7vl0pla6U2j7qmO1KqYf1rpfCz75mJzwKHIHeILeXzUKszYJn2aWeDMbzL2Q61U1OiABL8+xGlxKVMpJiccviafh9TQv6Bt1Gl0NRjAFGplPd5MT8nBSkxscYXUrU+uzKPPQOuvHSgZNGl0JRjAFGpjLiUdjX7OL4hwYryUtHUW4Knnm3CUpxfEQyBgOMTOWD1h70Drp5/5fBRAR3rszHoZPd2H/cZXQ5FKUYYGQq1U3egVzK2APRcJ9cNgNJsVb8518ajS6FohQDjEylqsmJ7JQ4zEznAL5GS46z4bMr8/Ff759EQ3uv0eVQFGKAkalUNzlRmp8OETG6FAJw7zUFiLFa8Ms/1xtdCkUhBhiZxunuAZxw9vP6VxhxpMThjhV5+MO+Fo5ST7pjgJFp7D3mvf7FAAsv919bAKsIHnmLrTDSFwOMTKPyyGmkJ8Zg8Yw0o0shP9PSErC+bCZeqDqB1jMDRpdDUYQBRqYw6B7BziNtuGFBDgfwDUObri3EiFJ4dBdbYaQfvhOQKeyu60TPoBs3LZpmdCl0EbMyEvHJZTOwdU8z2nsGjS6HogQDjEzh1YOtSI6z4ao5wU7iTXr78nWFGB7x4PF3GowuhaIEA4zCnnvEgzeOnMaaomzE2axGl0NjKHAk4+8un46n/9oEZ9+Q0eVQFGCAUdh7r9GJrr4h3Lgo1+hSKICvrpmDs0MjeOIvx4wuhaIAA4zC3muHWhFns+DaeZxtO9zNy0nBjQtz8cTuRnQPDBtdDkU4BhiFNY9H4dWDrbh2ngNJcTajy6EgfHXNHPQMuPHU7kajS6EIp3uAich6ESkXkc3j7FMy0WMoMh044UJr9wBPH5rIohlpWFOUjV+/c4wTXtKU0jXAfMGklKoE4BodVNo+5QAem8gxFLlePdQKm0WwtijH6FJoAr66Zg6cZ4fx3N5mo0uhCKZ3C2wjAJf2vAFA+egdtKDqmsgxFJmUUnjtYCuuLMxEWiJnXzaTkrx0rCzIwONvH8OQ22N0ORSh9A4wOy4Mp2Bu6pnMMRQBalt70Nh5lqcPTWrTdXPQ2j2AF/e3GF0KRSh24qCw9erBVogA6xYwwMxo9dwsLJiWikfeqofHo4wuhyKQ3gHmAuCbStcOoDMUx4hIhYhUiUhVe3v7JRdJ4eG1Q61Ynp8BR0qc0aXQJIgINl1XiIb2Prx++LTR5VAE0jvAtgEo0J4XAKgEABGxT/QYf0qpLUqpMqVUmcPBe4UiwbGOPtS29uBjPH1oajctykV+ZiJ+9VY9lGIrjEJL1wBTStUA53oaunzLAHb49hGR9QDKtMfxjqEI9tqhVgDAxxay96GZ2awWVKwuwIHjLvy1IZgTLkTB0/3OUKXUlousK/V7vh3A9kDHUGR75WArLp+ZhpnpiUaXQpfoUyUz8dM3PsSv/lyPqwqzjC6HIgg7cVDYOenqx4HjLnxsIU8fRoL4GCu+uOoyvP1hBw62nDG6HIogDDAKO69rpw/ZfT5y3LkyDylxNvzqLU54SaHDAKOw8+qhVszNTkahI9noUihEUuNj8Nkr8/HK307hWEef0eVQhGCAUVg5fLIbe491sfUVge65ejZsVgu27OKElxQaDDAKG/1DI/j6b/chKzkO91x9mdHlUIhlp8Tj9tKZ+F31CbR1DxhdDkUABhiFjR/812HUtfXiJxuWIiMp1uhyaApUrC6A2+PBrznhJYUAA4zCwuuHWvHsnmZUrC7Aqrnsah2p8jOTcMvl0/Hsu81w9g0ZXQ6ZHAOMDHe6ewDf/t37WDQjFQ+sm290OTTFvnr9HPQOuvH4O7wWRpeGAUaG8ngUvvn8fgwMe/Afn16GWBt/JSPd/NwU3LJ4Gp78SyNbYXRJ+G5Bhnrs7Qb8pa4T//jxBew2H0W+UT4XZ4dH8NjbbIXR5DHAyDAHW87gx69/gBsX5uLTy2cZXQ7paF6OtxX2m92N6GIrjCaJAUaGODvkxtef24fMpDj88FOLISJGl0Q6+8ZabyuM94XRZDHASHcnXf342tZ9ONbZh59sXAJ7IrvMR6O5OSn4+OXT8dRfG9HZO2h0OWRCDDDSTffAMB56tRbX//jPeLuuAw/esoCjk0e5r6+diwG2wmiSdJ9OhaLPkNuDrXua8LOddejqG8Inl83AP6ybx6lSCHOyk/GJJdPx1F+bcN/qAmQlc/ZtCh4DjKaMUgqvHmzFQ6/WorHzLK4qzMR3by7GohlpRpdGYeRra+fipQMnsWVXA757c7HR5ZCJMMBoSgy6R/DAC+/j5QMnMS8nGU/cvRzXzXewswZ9RKEjGX+/dAae+msj7rumAI4UtsIoOLwGRiF3pn8Yn/v1Xrx84CQeWDcP//31a3B9UTbDi8b0tTVzMOT24FHOF0YToHuAich6ESkXkc3BbheRh7THCr3qpMk56erH7Y/sRk2zE/++cSm+umYubFZ+TqLxFTiSceuyGXhmTxPaejhSPQVH13cWESkBAKVUJQCXbzmI7RUiUg+AXZXC2JFT3bjtl7txyjWAJ+9ZgVuXzTC6JDKRr6+Zi+ERhV/srDO6FDIJvT8abwTg0p43ACgPcvvtSqlCLdgoDO2u68CGR/4KAHj+S1fi6jnsHk8TMzsrCXesmIWn323C306cMbocMgG9A8wOoMtvOTPI7SXjnXYkY/1xfws+/8ReTLPH4/dfvgrF01KNLolM6lsfK0Jmchz+1x/eh3vEY3Q5FOZMcXFCKfWw1vrKFJHRrTaISIWIVIlIVXt7uwEVRq9X/nYK3/jtfpTkpeOFL12F6fYEo0siE0tLiMH3P74QB1u68eTuRqPLoTCnd4C5AGRoz+0AOgNt1zp1rNfWdQIoGP2iSqktSqkypVSZw+EIcck0lsMnu/HN5w9gWZ4dv/nCCqQlxBhdEkWAmxfn4vr5DvzkjaNocfUbXQ6FMb0DbBvOB1ABgEoAEBH7ONsbfPsBKARQpUehNL6O3kHc91QV0hJi8OhnSxEfYzW6JIoQIoL/8/eLoBTwjy8ehFLK6JIoTOkaYEqpGgDQTgO6fMsAdoy1XVu3QWuF1fsdQwYZcnvw5Wdq0NE7iC2fK0V2arzRJVGEmZWRiG/eMA87atvwysFWo8uhMKX7SBxKqS0XWVcaYPtH1pExlFL4p5cOYm9jF/7j00tx+Uy70SVRhLrn6tl4cX8Lvv/SIayam4XUeJ6ipguZohMHhY+n323Cc3uP48vXFeLvl/I+L5o6NqsF/3bbYnT0DuLhV2uNLofCEAOMgra7rgP//PJhlBdn44F1840uh6LA5TPt+PxVs/HsnmZUNzmNLofCDAOMgtLU2Ycvb61BQVYSfrpxKSwWjmtI+viHdfORmxqP7/7+bxjmvWHkhwFGAXX1DeGLv6mCUsDjny9DCq9FkI6S42z4508sxAene/CPfzzEXol0DgOMxtUzMIy7n9iL411n8ehdpcjPTDK6JIpC6xbmYtN1hXhubzN+9NoHRpdDYYLzgdGYBoZHcO9vqnD4ZDe2fK4UKwtGj/xFpJ/NH5sP19lh/PLP9UhPjMV9qz8ypgFFGQYYXdSQ24MvP1uDvY1d+PeNS7GmKMfokijKiQh+cOsidA8M41//+wjSEmKwYfkso8siAzHA6CNGPArffH4/dta24V8/uYjd5SlsWC2Cn25Yiu7+YXzn9+8jNcGGGxdNM7osMgivgdEFlFJ48MWD+NP7p/Cdm4pw5xX5RpdEdIFYmwWP3lWKJbPs+Ppz+/GXug6jSyKDMMDoHKUUfvhKLZ7b24yvXF+IL11baHRJRBeVGGvDE3cvx2VZSah4qgoHjruMLokMwAAjAN7Thj98pRaP7mrAXSvzeaMyhT17Yiye+uIKZCTH4q5f78Ef97ewi32UYYARnH1DuPuJvXh0VwPuvCIP//yJhRDhjcoU/nJS47H13pUocCTjG7/dj4qnq9HWPWB0WaQTBliUO9hyBh//+TvY09CFf7ttMf71k4s5ygaZyqyMRPxu01X43s3F2HW0HeU/eQvbq0+wNRYFGGBR7A/7TuBTv9oN94jCtvtX4o4VeUaXRDQpVovgvtUFeOUb12B+bgoeeOEA7nnyPZw6wwkxIxkDLAoNj3jw/ZcO4X9uO4Als+x4+WursCwv3eiyiC5ZgSMZ2yquxD99fAH2NHRh3U924fG3G9AzMGx0aTQFJNKa2WVlZaqqipM2j+XwyW58/6VD2NvYhS9cfRn+181FiLHycwxFnubOs/juH/6Gd+o6kBRrxadKZ+JzV87GnOxko0sLSyJSrZQqM7qOiWCARQGlFN5t6MIjb9XjraPtSI6z8QZlihrvn3Dhyd2N+NOBUxga8eCauVn43JWzsaYoG1Ze7z2HARbMNxRZD8AFoEQp9XAw2wMd448Bdp7Ho/D64dN45K167D/uQlZyLO65+jJ89op8pCVyRHmKLh29g9j23nE8824TTp0ZwKyMBNy4MBdXzcnCitkZSIqL7oGJzBhguv6PiUgJACilKkWkQERKlFI14233bRvrGDpPKYW2nkHUt/fiyKkePLunCQ3tfcjLSMS/3LoIt5fORHyM1egyiQyRlRyHr1w/B/evLsDrh09j655m/GZ3Ex57+xhsFsHSWXZcVZiJq+ZkYVmeHXE2/q2EO70/cmwE8Ib2vAFAOYCaANszAxxjOKUU3B6FIbcHQ24PBtwj6Bt0o2fAjb7BEfQODqN3cAS9A8M4OzyCwWHvPoPDHgy6PRh0j2DQ7YFFBLFWC2JtFsRaxftosyDGaoFVBFareB8tAov22DMwjPr2PjS096K+vQ+9g+5zdS2Yloqf3bEMNy/KhY3XuYgAADarBTcvnoabF0/DwPAIqhqd+Et9B3bXd+Lnb9bhZzvrEGMVTLcnYIbvKz0BM9MTMcOeAEdKHBJirYi3WbRHK289MYjeAWYH0OW3PHp+jottD3TMBT5o7cG1P3pzQkWNdRZVQUEpaF8KHgV4tEelFIZGvIE1NOIZ8zXGEmezeL9irOeee5R3FPhBtwfDfq894hn/xaenxaMwOxmfKpmBwuxkFDqSUeBIQm5qPG9IJhpHfIwVq+ZmYdXcLADAmf5h7D3WhZpmJ044+9HiPItdH7bjdPfguK8TZ7MgPsaKGKtARGARwCLeD5oi8H5h7L9F/plOTkSc9BWRCgAVAJA6vQDLZtkn8xoXX69tO/cLafGutQgQY/UGj7fFZDnXYoqzWZEcb0NKnA1JcTYkx9mQEu99TIi1ItZqmdAnNo9HYUQpjHi0L6W86zwKCbFWJMZGxH8jkeHSEmJww4Ic3LDgwumDBt0jOOUaQIurHx29gxgc9qB/eAT9wyMY8D0OjcDtOf8B1+P3oXe8D7jh0pFul9EFTILe73wuABnaczuAziC3j3cMlFJbAGwBvJ04/v3Ty0JTbZiwWAQWCHj5isgYcTYrZmclYXZW5M5I/h93GF3BxOkdYNsA+Hq5FACoBAARsSulXGNtH2MdERFFMV2v7Pt6D4pIOQCXX2/CHWNtH+cYIiKKYrpfPNFO941eVxpg+0fWERFRdGPfaiIiMiUGGBERmRIDjIiITIkBRkREpsQAIyIiU4q46VREpB1Ak8FlZAHoMLiGcMGfxXn8WZzHn8V54fKzyFdKOYwuYiIiLsDCgYhUmW1agqnCn8V5/Fmcx5/FefxZTB5PIRIRkSkxwIiIyJQYYFODI4ecx5/FefxZnMefxXn8WUwSr4HpREQ2K6UeNroOIgo/fH+YHE4kpQNtIOLlRtdhNG3eNgAoVEp929BidCYi6+GdLqgk2t+oovn34GL4/jB5PIVIutD+SCu1gZkLtOWoICIlAKCUqgTg8i1Ho2j+PaDQY4BNMREp0d64ol0BAN+bVYO2HC02wtv6Arz/9mh+047m34OP4PvDpeEpxKmXEXiXyDdqSpwSeCcvjRZ2AF1+y5kG1WG4KP89uBi+P1wCBtgl8juf769BKVXJT1cfpZ0+e4MTk0Y3/h6w9RUKDLBLFGCyzQIRKfB7XhLJf7DjhbnfcnkUdmJw4fwnbTuATsMqCR/R+HswWlS9P0wFBtgUUkptB869sduNrWbqBZo5W0QqfG9aIlIeRZ8+twHwDRVUACBa/t0XFcW/BxeItveHqcD7wEgXWm+zF+C9FpQB4PZoeuPS3qQaABQECvpIFu2/BxRaDDAiIjIldqMnIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKbEACMiIlNigBHpQERKRKReRF7wW7YbXBaRqTHAiPRRDqAUwKO+UfuVUi5DKyIyOY6FSKQjrdWVoZRqMLoWIrNjgBHpxHfKkC0votDgKUQiHfgmLvSFl99EhkQ0SZzQkmiKiUgJvBNadolIJbzXw1zwzg9GRJPEFhjRFPI7bbgF3tmYjwFYzkkciS4dr4EREZEpsQVGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKb0/wEFZshz/FLIqwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Take 100 random samples from each of 2 PDFs\n",
     "samples = norm_dist1.rvs(size=(2, 1000))\n",
@@ -1192,34 +412,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The input and output shapes are: (11,) (1, 11)\n",
-      "Spline knots [[-5. -5. -5. -5. -3. -2. -1.  0.  1.  2.  3.  5.  5.  5.  5.]] [[ 1.48609459e-06  1.68880388e-03 -5.05824770e-03  2.11574348e-02\n",
-      "   2.37684221e-01  4.79319775e-01  2.37684221e-01  2.11574348e-02\n",
-      "  -5.05824770e-03  1.68880388e-03  1.48609459e-06  0.00000000e+00\n",
-      "   0.00000000e+00  0.00000000e+00  0.00000000e+00]] [[3]]\n",
-      "(1, 15)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAsAUlEQVR4nO3deXhT95kv8O8rywsG28K2sLFYHANhxyskGNJpOs5CSIJJSUgzTQJPM3Ry56ad55kM7b1t595n2s5MaO99usw8ndLcQrZJaZjiENKQxLRpAw5JDMaELQk2BiNj8CbbYLzI+t0/fATCeJFl6Rwd6ft5Hh6fVX7xI+vrc857fkeUUiAiIjIbi9EFEBERBYIBRkREpsQAIyIiU2KAERGRKVmNLoCIiMbm0KFDU6xW6/MAFiHyD0Q8AI653e6nCgsLL/muYIAREZmM1Wp9PjMzc77dbm+zWCwR3Uru8XikqalpQWNj4/MAHvRdF+nJTUQUiRbZ7faOSA8vALBYLMput7dj4GjzxnUG1ENERONjMUN4lZWVJRUXF88BgBMnTsStWrUqJ5DX0f6vN+UVA4yIiEKitLS0MyUlpR8AFixY0PvSSy+dDebrM8CIiCjkTpw4EXfq1Kn4YL4mmziIiEzsH3ZWT/+ssTMxmK95a2ZS14/W5dYPt37//v2Jzc3NMd75trY2649//OPMH/7wh+dPnz4dP3v27J7S0tLOwftt3rzZUVFR8XlZWVnSli1bMjdv3txYWVmZeO+993auXLmy67vf/W5GUVFR1+nTp+OfffbZ5tHq5BEYERGNySuvvDIZGDhFeOutt/Zs3LixbcaMGT2lpaWdzz77bPMzzzwzc/A+CxYs6PWeTiwtLe1sb2+3lpaWdj722GNtr7zyyuSnn37aUVRU1FVaWtpZU1Pj15Eaj8CIiExspCOlUPn+97/f+L3vfS/zO9/5zrRf/vKXZwH0+q6fPn16z4kTJ+IWLFjQO8xLICUlxe07X1dXF9/W1mbdv39/4qxZs3r8qYNHYERENCZvvPFG8i9+8Qvn8ePHT+7duzcJANrb26+dUmxvb7eOFF4A4D0a8yosLLwyZ86cnpUrV3Zt2LChzZ86eARGRERjUlNTE7dt27bJAPDYY4+1AQOhtX///sSDBw8m/vCHPzwPDFwrO3bsWOL+/fsTAeDYsWOJJ06ciPvss8/ivcv37t2bVF1dnbh79+7an/zkJ+nea2tDXUMbTPg8MCIic6murq7Lzc0dtclBT6tWrcp56623akP1+tXV1em5ubnZvst4CpGIiMalrKwsyXt0pef3ZYAREdG4lJaWdtbX1x8b7bpXsDHAiIjIlBhgRETm4/F4PGJ0EXrR/q+ewcsZYERE5nOsqakpJRpCTHucSgqAY4PXsY2eiMhk3G73U42Njc83NjZG1QMtB69gGz0REZlSpCc3ERFFKAYYERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIiMiUGGBERGRKDDAiIjIlBhgREZkSA4yIiEyJAUZERKYUcaPRp6enq+zsbKPLICIylUOHDjUrpexG1zEWERdg2dnZqKysNLoMIiJTEZGzRtcwVjyFSEREpsQAIyIiU9I9wERknYiUiMjmUbbbPNZ9iIgoeugaYCJSAABKqXIALu/8ENuVAFg6ln2IiCi66H0Eth6AS5uuBVASon2IiCjC6R1gNgCtPvNpgzcQkQLtaMvvfYiIKPqEYxNHqtEFEBFR+NM7wFy4HlA2AC2+K4c4+hp1HyIzONfShZ2HzhtdBlFE0ftG5h0AirTpHADlACAiNqWUC0COiOR412sNG0Pu40tENgHYBAAzZswIWfFEgfr+myfw7omLmJeZhEWOFKPLIYoIuh6BKaUOA9e6DF3eeQD7tPU7lVI7MXDEZRtlH9/X3aqUKlJKFdntphoJhaJAfWsXyk9eBAC8UFFnbDFEEUT3oaSUUluHWFY4xDZbR9qHyCxeqKhDjAjunD8Fr1c34Nur5iFtUrzRZRGZXjg2cRBFjCs9buyorMeqxVOx+Z656HV78OpH54wuiygiMMCIQuh3VU50druxoTgbczKScMecdLx08Cz6+j1Gl0ZkegwwohBRSmH7gTNYMi0FBTNsAIANxdm42NGDvccajS2OKAIwwIhCZP/pZtQ0XcGG4myICADgzrlTMDMtEdvZzEE0bgwwohDZdqAO6ZPisXrJ1GvLLBbBk8uzcehsG46edxlXHFEEYIARhcCZ5iv4w6lL+KvbZiDeGnPDunVF0zAxLgbbD9QZUxxRhGCAEYXAix/UITZG8Fe33XxjfXJCLNYVTsMbRxtwqbPbgOqIIgMDjCjILve48VrleaxePBVTkhOG3OaJ4mz09Su8+mG9ztURRQ4GGFGQ/deh87jc48aGFbcMu80s+yT8xa12vPzhWfS62VJPFAgGGFEQeTwK2yvqkD/DhrzpthG33bgiG02dPfj9Jxf0KY4owjDAiILoT5834UzzQOv8aL4wx46c9InYxpZ6ooAwwIiCaPuBOkxJiseqRVNH3dZiETxZnI3qeheqzrXpUB1RZGGAEQVJTdNl/OmzJnz19pmIs/r3q/XlwmmYFG/ljc1EAWCAEQXJixV1iIux4CvL/H8m3aR4Kx4umoY3j17AxQ621BONBQOMKAg6uvuw89B5PJCbBXvS2B6V8uTybPQrhVcOng1RdUSRiQFGFASvVZ7Hld5+v5o3BstOn4gvzZ2CVz48hx53f/CLI4pQDDCicer3KLxQUYeimZOxeFpKQK+xYUU2Wq70Yk81W+qJ/KV7gInIOhEpEZHNw6wv0f4957PsOe3rJr3qJPLXe59ewrnWLmxYkR3wa6ycnY7ZUyZhe0UdlFLBK44ogukaYCJSAABKqXIALu/8oPV3aesLfNZvEpEaALV61kvkj+0VdchMTsA9CzMDfg0RwYbibHzibMdhttQT+UXvI7D1AFzadC2AEt+VSqnDSqlvabM5SqnD2vTDSqlZWrARhY3PL3bi/c+b8fjymYiNGd+v00MFDiQlWPFrjlJP5Be9A8wGoNVnPm2ojbTTi1/3WVQw0mlHIqNsr6hDnHVsrfPDSYyz4tGl07H3WCMutF8NQnVEkS0smziUUlsAfF1EbN557egrTURKBm8vIptEpFJEKpuamnSulqJVe1cffnfYidK8LKROjAvKaz6xPBsepfAyW+qJRqV3gLkApGrTNgAtvitFxPe6Vy0Grn2tE5F12rIWADmDX1QptVUpVaSUKrLb7SEpnGiw31bW42pfP54MoHV+ONNTE1EyPwP/+eE5dPexpZ5oJHoH2A5cD6AcAOUA4D3SwsA1Md+Aq9X+ea99zQJQqUOdRCPq9yi88EEdlt2SioVZgbXOD2fjimy0dfVhd3VDUF+XKNLoGmDepgztNKDLp0ljn/Z1K4Ac7xGXUmqnts0j2rIan32IDLPv5EWcb7uKjUE8+vJanpOGuRlJ2H6ALfVEI7Hq/Q2VUluHWFaofXVhIMQAYOdI+xAZaduBOjhsE3DXgoygv7aIYMOKbPyP332Cj8604racIXudiKJeWDZxEIWzU40d+KC2BY8vnwnrOFvnh1Oa50DKhFiOUk80AgYY0Ri9UFGHhFgLHl06PWTfY0JcDB5dNh1vH2+E08WWeqKhMMCIxqDtSi92VTmxNt8BW2JwWueH88TybADASx+wpZ5oKAwwojHYUVmP7j5PUFvnh+OwTcA9CzPxm4/P4WovW+qJBmOAEfnJ3e/BixV1KJ6VhnmZybp8zw3F2XB19aHsiFOX70dkJgwwIj+9e+IiGtq7A3rmV6CW3ZKK+VOT2VJPNAQGGJGftlXUYdrkCfjL+cFvnR+OiGBjcTY+vdiJD2pbRt+BKIowwIj8cLyhHR+dacWTy7MRYxFdv/eD2liL2zlKPdENGGBEfnihog4TYmPwSFHoWueHkxAbg68sm47ykxdR39ql+/cnClcMMKJRtFzuQdmRBny50IGUxFhDavjq7TMhInjxgzpDvj9ROGKAEY3iNx/Xo9ftwZPafVlGmJoyAfcuysRvPq7HlR63YXUQhRMGGNEI+vo9eOmDs7hjTjrmZCQZWsvG4mx0druxq4ot9UQAA4xoRG8fb0Rjh76t88MpnDkZix0p2F7BlnoigAFGNKLtB+owMy0Rd86dYnQpA6PUF2fj9KXLOHCaLfVEDDCiYXxyvh2VZ9vw5PJsWHRunR/O/blTkT4pDtsOnDG6FCLDMcCIhrGt4gwmxsVgXdE0o0u5Jt4ag8eWzcAfPr2EuuYrRpdDZCjdA0xE1olIiYhsHmZ9ifbvOX/3IQq2ps4e7Km+gHWF05CcYEzr/HC+evtMxIjgRY5ST1FO1wATkQIAUEqVA3B55wetv0tbXyAiBaPtQxQKr350Dr39HjwRBs0bg01JTsDqJVPxWmU9LrOlnqKY3kdg6wG4tOlaACW+K5VSh5VS39Jmc5RSh0fbhyjYet0evHzwLP7iVjtm2ScZXc6QNhRno7PHjd8dPm90KUSG0TvAbABafebThtpIO1X49bHsQxQsbx27gEudPdi4ItvoUoaVP2MycqfbsP1AHTwettRTdArLJg6l1BYAXxcRmz/bi8gmEakUkcqmpqbQFkcRb9uBOuSkT8QX5tiNLmVEG4uzUdt8BX/+nO95ik56B5gLQKo2bQNww80svte8MHC6cNNo+wCAUmqrUqpIKVVkt4f3hw6Ft6pzbThS78KTxeHTOj+c+xZPhT0pHtsr6owuhcgQegfYDgA52nQOgHIA8DnSKsGNYVU73D5EofBCRR0mxVvx5cLwaZ0fTpzVgq/eNhPvfdqE2qbLRpdDpDtdA0xryoCIlABweecB7NO+bgWQIyLrtO13jrAPUVBd6ujGm59cwMNF0zAp3mp0OX557LYZiI1hSz1FJ91/S5VSW4dYVqh9dWEgxABg50j7EAXbKx+eg9ujDB11fqzsSfF4YEkWXqusx9/ffSuSwuyeNaJQCssmDiK99bj78cqHZ/GluVOQnT7R6HLGZMOKbFzp7cdrlWypp+jCACMC8ObRC2i+3IsNYdw6P5wl02wonDkZL3zAlnqKLgwwinpKKWw7UIfZUyZh5ex0o8sJyIbibJxt6cJ7n10yuhQi3TDAKOodPufCJ852PFmcDZHwbp0fzr2LMpGRHI9tB+qMLoVINwwwinrbK+qQlGDFQ/kOo0sJWGyMBY/fPhPvf96M05c6jS6HSBcMMIpqje3deOuTC3h06XRMNEnr/HC+smwG4qwW3thMUYMBRlHt5YNn0a8UnjBR6/xw0ibFY01uFv7rkBPtV/uMLoco5BhgFLW6+/rxnx+dQ8n8DExPTTS6nKB4sjgbV/v68VplvdGlEIUcA4yi1hvVDWi90ouNYfjMr0AtcqRgWXYqXvigDv1sqacIxwCjqKSUwvaKOszNSMLyWZH1hJ4NK7JR33oVfzjFlnqKbAwwikof17XheEMHNqwwb+v8cO5ekIGslARsO3DG6FKIQooBRlFpe8UZpEyIRWmeeVvnh2ONseDx5dmoqGnBp41sqafIxQCjqON0XcXbxy/i0WXTMSEuxuhyQuLRpdMRz5Z6inAMMIo6Lx88C6UUHr99ptGlhMzkiXFYm+/ArqrzcHX1Gl0OUUgwwCiqdPf149WPzuHuBZmYNjkyWueH82RxNrr7PNjxMVvqKTIxwCiqlFU54erqw0YTjjo/VvOnJuP2nFS8+MFZuPs9RpdDFHS6B5iIrBOREhHZPMz6Tdq/53yWPeddp1edFHm8rfPzpyZj2S2pRpeji40rboHTdRXlJy8aXQpR0OkaYCJSAABKqXIALu+8z/oSAOXaE5hztHkA2CQiNQBq9ayXIsvB2lacauzERhOPOj9WJfMz4LBN4Cj1FJH0PgJbD8ClTdcCKBm0PsdnWa02DwAPK6VmacFHFJDtFWcwOTEWD+ZlGV2KbmIsgieLZ+LDM6040dBhdDlEQaV3gNkAtPrM3zAEglJqq3b0BQAFACq90yOddiQaTX1rF949cRFfWTYDCbGR2To/nPVFMzAhNgYvsKWeIkxYNnFopxbfVUodBgCl1Bbt6CvN57Si7/abRKRSRCqbmpr0LpdM4OWDZyEieHx55LbODyclMRYPFThQdsSJ1itsqafIoXeAuQB4r57bALQMs12JUmoLcK3pY522vAXXTyteox25FSmliux2e3ArJtPr6nXj1Y/O4d5FmZiaMsHocgyxoTgbPW4PXv3onNGlEAWN3gG2A9cDKAdAOQCIiM27gYhs8gmvEgxcC/Ne+5qF66cVifyyq8qJjm53RI06P1ZzMpKwcnY6Xj54Fn1sqacIoWuAeU8JasHk8s4D2Oez/DkRqRGRNp99HtGOwmp89iEalVIKL1TUYZEjGYUzJxtdjqE2FGfjQns33jnOlnqKDLo/Q92nScN3WaH2tRzATZ8yQ+1D5I+j59vx2cXL+NeHFkdN6/xw7pw3BVkpCdh5qB6rl0w1uhyicQvLJg6iYNlV5USc1YJVi/mBHWMRrMl34M+fN6P5co/R5RCNGwOMIlZfvwdvVDegZP4UpEyINbqcsLA234F+j8Ke6gajSyEaNwYYRaz9p5vRcqU3Ip/5FahbM5KwYGoydh1hgJH5McAoYpVVOWFLjMUX504xupSwsjbfgep6F2qbLhtdCtG4MMAoIl3ucePt441YvXgq4qx8m/t6MC8LIkAZj8LI5PibTRHpneON6O7zYG0+Tx8OlpGcgBWz0lFW5YRSyuhyiAI25gATkWwReUhEnhKRZ7XpL4WiOKJA7apyYtrkCVF/79dwSvMdONfahcPnXEaXQhQwvwNMRP5BRN4B8BwGRsQQAO3a9N0i8o6I/EJE8kJSKZGfLnV048DpZqzNd0T9vV/DuWdhBhJiLSirchpdClHARr2RWURuAfB1AL9RSv1olG1TMPDsriKl1PNBqpFoTHZXN8CjBo4yaGhJCbG4a0Em9hxtwPfuX8DrhGRKI75rtfD6S6XUt5VSR0Z7MaVUuxZy+0TkqSDVSDQmZUecyJ2Wgln2SUaXEtbW5mehrasPf/6MT3AgcxoxwJRSZwI5kgp0P6Lx+vxiJ445O3j05Yc75tiROjEOu47wNCKZUyBNHMmhKIQoGMqOOBFjEdy/JHqeuhyo2BgLHlgyFeUnLqKju8/ocojGLJAT37N8GzVE5BZ2IVI48HgUyqoacMecdNiT4o0uxxRK8x3ocXuw91ij0aUQjdmYA0wpVQVgqYhka/NnAEwWkX8Jcm1EY1J5tg1O11Xe+zUGedNtyE5LZDcimVIgpxB3AKgB0OZzOrEcwKZgFkY0VruqnEiMi8FdCzKMLsU0RASl+Q58UNuCC+1XjS6HaEwCOYVYCKBSKdUOQLTW+RIA/xrUyojGoMfdjzePNuDehZlIjNP9MXemVprngFLAbg4tRSYTSIA9DO1oSwuxVACTR7tHzEtE1olIiYhsHmb9Ju3fc/7uQ/THU03o6Haz+zAA2ekTkT/Dhl08jUgmE9A1MKXUj33mzwA45M8IHCJSoO1TDsDlnfdZXwKgXHsCc44WWiPuQwQMjDxvT4pH8aw0o0sxpYfyHTjV2ImTFzqMLoXIb0G5/V5r7Djjx6brAbi06VoMnHr0leOzrFabH20finLtXX34w6lLeDA3C9YYjigRiNVLsmC1CMp4TxiZSNB+27XTiaOxAWj1mb/hz2Wl1Fbt6AsACgBUjrYP0e+PXUBvP0eeH4/UiXH44lw7Xq9qgMfDEerJHEYdSiqQIaEC3c9n/wIA7yqlDvu5/SYRqRSRyqYmDosTbXZVOTF7yiQszOI99uNRmu9AY0c3Dp5pMboUIr+MOpQUBsY1/A9/blYWkWQR+QcMjJ841FBSLgw0fQADR1bD/aaUKKW2+LuPduRWpJQqstvto5VJEeR8Wxc+OtPKkeeDoGR+BibFW3lPGJnGqP3GWoj9jYj8tYh8G4ACcBjXgyQNA8EyCwP3h23R9hnKDgBF2nQOBu4fg4jYlFIubXqTN7y0po4h9yECgNe11u8Hczl01HglxMZg1aJMvPVJI/5pzSIkxMYYXRLRiPy+BqaU+pVS6m4Aj2AgRM5g4HlglQC2KqXuVko9PUJ4wXtKUAsml88pwn0+y58TkRoRaRtlH4pySinsqnJiWXYqpqcmGl1ORFib70Bnjxv7Tl4yuhSiUY35jk+tWWNfoN/Qp0nDd1mh9rUcwE2P0B1qH6LjDR04feky/nntYqNLiRi35aQhMzkBu6qcWL1kqtHlEI0ooC5EEXlKe/ryUxydnoyyq8qJuBgLVi/mB22wxFgEa/Ky8N6nl9B6pdfocohGFMhYiP8KYDYGTh8+AuCMiHwt2IURjcTd78Hu6gbcOc+OlMRYo8uJKKX5Drg9Cm8e5dBSFN4COQL7WHtC87e1a2KzAMwRkYeCXBvRsCpqWtDU2cN7v0Jg/tRkzMtM4tBSFPbGfSOzUsqllPo2eIMx6aisyonkBCu+OHeK0aVEpNJ8Bw6fc+FsyxWjSyEaViABVisiH4vInYOuf/HuR9JFV68be483YvWSqWz1DpEHc7MgApRV8TQiha9AAmw9gN8CeBpAnRZmb2Ng8N0kAODpRAqld09cRFdvP0rzePowVLJsE3D7LWkoO+KEUhxaisJTIAFWA+A1pdQjSqlUDDxapRzA3QDOisjnAJ4b6QWIxmNXlRMO2wQszU4dfWMK2Np8B840X0H1eX+GOSXSXyCPU/kVgMkikq3NVymlfqTdyJyKgSM0f0amJxqzps4evP95M9bkZcFi4dBRoXTv4kzEWS0cWorCVkBNHFpo1Q2z7jCAb42nKKLh7DnagH6PYvehDpITYnHX/Ay8Ud2Avn6P0eUQ3SQkD0/Sng9GFHRlVU4szErGnIwko0uJCqX5DrRc6cX+z5uNLoXoJnz6H5lGTdNlVJ9v59GXjv7iVjtsibG8J4zCEgOMTOP1KicsAjzAked1E2e14P4lU/HOiUZc7nEbXQ7RDRhgZApKKew64sSK2enISE4wupyosjbfge4+D94+1mh0KUQ3YICRKRw+14b61qu898sABTMmY3rqBJQd4WlECi+6B5iIrBOREhHZPMI2BYPmn9O+bgp1fRSedlU5kRBrwT2LMo0uJeqICNbmOXDgdDMudnQbXQ7RNboGmDeYtOd+uQYHlbZNCYBfDVq8SURqANSGvkoKN71uD/YcvYC7F2RiUvyYH2FHQbAm3wGPAt6o5tBSFD70PgJbD8ClTdcCKBm8gRZurYMWP6yUmqWtoyjzp8+a4OrqY/ehgWbZJyF3Wgq7ESms6B1gNtwYTv6OYF8w2mlHilxlVU6kTYzDyjnpRpcS1UrzHTje0IHPLnYaXQoRAJM0cSiltmhHX2naKUaKEh3dfXj35EU8kJuF2BhTvF0j1v1LshBjEQ4tRWFD708EFwDvCKw2+PEIFq3pY5022wIgJySVUVja+0kjet0elPL0oeHsSfG4Y046Xj/SAI+HI9ST8fQOsB24HkA5GBjFHiJiG2GfWu92GHj6c+XgDURkk4hUikhlU1NT8Kolw+2qcuKW9InInZZidCmEgXvCnK6r+Lhu8GVqIv3pGmDaQL/eTkOXdx7APu822tFWkfeoS9vmEW2+xmcf39fdqpQqUkoV2e32kP8/SB8Nrqs4eKYFpXkOiHDk+XBw14IMJMbF8J4wCgu69yQrpbYOsazQZ3ongJ2j7UORb3d1A5QCSvM5dFS4SIyz4t6Fmdhz9AL+1wML+URsMhSvilPYKqtyomCGDTPTJhpdCvkozXegs9uN9z69ZHQpFOUYYBSWTl7owKnGTt77FYaKZ6XBnhTPe8LIcAwwCktlVU5YLYLVS3j6MNxYYyx4MDcLfzzVBFdXr9HlUBRjgFHY6fcovH6kAV+ca0fqxDijy6EhrM13oLffg99/whHqyTgMMAo7H9a2oLGjm/d+hbGFWcmYPWUSb2omQzHAKOzsqnJiUrwVJfMzjC6FhiEiWJvvwEd1rahv7TK6HIpSDDAKK919/XjrWCNWLcpki3aYe1B7MvZujlBPBmGAUVgpP3kRl3vc7D40gempiViWnYrfHT4PpTi0FOmPAUZhpazKiczkBNyW4++DCshIpfkO1DRdwfGGDqNLoSjEAKOw0XqlF+992oQ1eQOjnlP4W714KuJiLLwnjAzBAKOw8ebRBrg9CmsLePrQLFISY3HnPDt2VzfA3e8xuhyKMgwwChu7qpyYl5mEeZnJRpdCY7A234Gmzh5U1Iz6dCSioGKAUVg423IFh8+52LxhQl+cOwXJCVbeE0a6Y4BRWCiraoAI8GAeh44ym4TYGKxeMhV7jzeiq9dtdDkURRhgZDilFMqOOLE8Jw1TUyYYXQ4FoDTPga7efrx74qLRpVAUYYCR4arPt+NM8xUOHWViS7NT4bBNYDci6Ur3ABORdSJSIiKbR9imYKz7kHmVVTkRb7Xg3kWZRpdCAbJYBGvysvD+581o6uwxuhyKEroGmDeYlFLlAFyDg0rbpgTAr8ayD5lXX78Hb1Q3oGRBBpITYo0uh8Zhbb4D/R6FPUc5tBTpQ+8jsPUAXNp0LYCSwRtoQdU6ln3IvPZ/3oyWK71Ym8fTh2Y3JyMJC7OS2Y1IutE7wGy4MZz8GS8okH3IJHZVOTE5MRZfuNVudCkUBGvzHag+346apstGl0JRgE0cZJjLPW68c6IR9y/JQpyVb8VI8EBuFiwCvM6jMNKB3p8aLgCp2rQNgD+37o+6j4hsEpFKEalsamoad5Gkj7ePNaK7z8PuwwiSkZyAFbPTseuIkyPUU8jpHWA7AORo0zkAygFARGxj3ceXUmqrUqpIKVVkt/NUlFmUHXFiRmoiCmbYjC6Fgqg0z4H61qs4fK7N6FIowukaYEqpw8C1TkOXdx7APu82IrIOQJH2daR9yMQudnTjwOlmlOY7IMKR5yPJPYsykRDLEeop9Kx6f0Ol1NYhlhX6TO8EsHO0fcjc3qhugEcBpRw6KuJMirfi7gWZ2HP0Av7x/oW8vkkhw3cWGWJXlRO5023IsU8yuhQKgbX5Dri6+vCnz3hNmkKHAUa6++xiJ443dGAtj74i1so56UibGMd7wiikGGCku7IqJ2IsgvtzGWCRKjbGggdys/DuyYvo6O4zuhyKUAww0pXHo/D6kQZ8YU460ifFG10OhVBpvgO9bg/2ftJodCkUoRhgpKuP61rhdF3lvV9RIHdaCm5Jn8huRAoZBhjpquyIExPjYnD3Ao48H+lEBKV5Dhw804IG11Wjy6EIxAAj3XT39WPP0Qu4Z1EmJsTFGF0O6aA0PwtKAburOUI9BR8DjHTz3qeX0NntxlqePowaM9MmomCGjd2IFBIMMNLN7w47YU+KR/GsdKNLIR2tzXfgVGMnTjR0GF0KRRgGGOnC1dWLP356CWtysxBj4dBR0WT1kixYLYKyIzwKo+BigJEu3vzkAvr6FbsPo1DqxDh8ca4drx9xot/DEeopeBhgpIuyKifmTJmEhVnJRpdCBijNd+BiRw8O1vrzBCUi/zDAKOTqW7vwcV0bR56PYiXzMzAp3sp7wiioGGAUcq9r1z7WcOzDqJUQG4NVizKx91gjrvb2G10ORQgGGIWUUgq7qpxYdksqpk1ONLocMtDafAcu97hRfvKi0aVQhGCAUUgdc3agpukK7/0i3JaThszkBN4TRkHDAKOQ2lXlRFyMBfctmmp0KWSwGItgTV4W/vRZE1ou9xhdDkUA3QNMRNaJSImIbPZ3vYg8p33dpFedNH7ufg92VzfgS/OmICUx1uhyKAyU5jvg9ii8+ckFo0uhCKBrgIlIAQAopcoBuLzzfqzfJCI1AGr1rJfG5+3jF9F8uYf3ftE186cmY15mEnZ8XI/uPjZz0PjofQS2HoBLm64FUOLn+oeVUrO0YKMw1+9R+Pc/nsY3flOFHPtE3DnPbnRJFEa+tvIWHG/oQOm/H8DpS5eNLodMTO8AswFo9ZlP83N9wUinHSl8XOroxuP/70P86O1Pcd/iqXj9b1cg3sqR5+m6h4umY9uGpbjU2YMHfr4fv62sh1IcoYPGzhRNHEqpLdrRV5qIDD5qg4hsEpFKEalsamoyoEICgD9+egmrfvo+Dp9rw5YvL8HPHs1DUgKvfdHN7pw3BW998w7kTbdh886j+LsdR9DZ3Wd0WWQyegeYC0CqNm0DMHhcmZvWa00d67RlLQByBr+oUmqrUqpIKVVkt/N0ld563R788+9PYuO2j2FPiseeZ1bikaXTOeoGjSgjOQEvP3Ub/v6uW/FGdQPu//l+HD3vMrosMhG9A2wHrgdQDoByABAR2wjra73bAZgFoFKPQsk/51q68PB/VGDrn2vx+O0zUfa3KzB7SpLRZZFJxFgEz/zlHOz4+nL0uT348i8q8Pz7tfBw0F/yg64BppQ6DADaaUCXdx7AvuHWa8se0Y7Canz2IYPtrm7AfT97H2ear+A/vlqA75cuQkIsr3fR2C3NTsXvv3kH7pw7BT948yS+9sLHvFeMRiWRdvG0qKhIVVbyIC2Uunrd+N+7j+O3ledROHMyfvpoHoeJoqBQSuGlg2fxgzdPwjYhFj95NI8PQNWJiBxSShUZXcdYmKKJg8LHyQsdeODn+/HaofP473fOxo5NtzO8KGhEBE8sz0bZf1uBSQlW/NXzH+L/vPMp3P0eo0ujMMQAI78opfDSB3VY8+8H0NHtxitfuw3P3jMX1hi+hSj4FmQlY88zK/Fw4TT8/A+n8ejWg3C6rhpdFoUZfvrQqNq7+vA3Lx/C914/juJZaXjrm3egeDZP61BoJcZZsWVdLn76aB5ONXbivp++j73HGo0ui8IIA4xGVFnXivt+9j72nbyE79w3H79+cinSJ8UbXRZFkTV5Dux5ZiVmpCbib14+hH98/RiHoSIADDAahnc4qPVbDyLGIvivp4vx11/IgcXCe7tIf9npEwfeg3fcghc/OMthqAgAA4yGMHg4qDe/sRK5021Gl0VRLs5qwXdWL+AwVHQNA4xuwOGgKNxxGCryYoARAA4HRebCYagIYIAROBwUmROHoSIGWJTjcFBkdhyGKnoxwKJUV68b39p5FN94tQpzM5Pw+2/egXsXTTW6LKKA2BLj8MvHC/FPaxbiQE0LVv30fVTUNBtdFoUYAywKnWrswIP/dgC/PVTP4aAoYgw1DNX/5TBUEY0BFkW8A6U++G8H0H61Dy9zOCiKQN5hqNYVTMPP/nAaX/kVh6GKVPzkihLXhoMqO4blOQPDQa3gcFAUoRLjrPjRw7n4yfo8nGjo4DBUEYoBFgV8h4P6n/fNw7YNHA6KokNpvgNvfuMODkMVoRhgEWzwcFA7ny7Gpi/M4nBQFFW8w1A9tZLDUEUa3QNMRNaJSImIbPZ3/Wj70I3c/R44XVfxxK8HhoNatSgTe76xEnkcDoqiVJzVgu/evwC/3lB0wzBU3X39HIrKxKx6fjMRKQAApVS5iOSISIFS6vBI673rhtsnXCml0OP2DPzr69em+9Hdd+PXnj4Pur1fr213fXrEZT5fu33m3dqNnAmxFjz35cV4pIgjahABwJfmZeCtb96Bv/vNEWzeeRSbdx4FAMRbLYi3WpAQG4P4WAvirTFIGPT12nqfr/FWC+K907ExSBj0dbh9vNNsoBofXQMMwHoA72rTtQBKABweZX3aKPuMyN3vGTEAuocIgJsC4oYg8T+ExsNqkZve8HE+b/yUCbFISIr3+WW5+ZeuZH4GcuyTxlUHUaTxDkO1u9qJBlf3td/rnhF+r9uv9mnrb/4cGQ+rRW4Kv3g/w++mZbEWJFhHDuB4n30i4Y9avQPMBqDVZz7Nj/Wj7XODU42dKPz+u9feXO5xDisz5BtGe6MkxFpgmxB70xtmqDfg0K8zzJuMf5kRhVSMRbA2f9q4X0cphd5+zw2hNzgEhz6jMtwfwjf+Qd1xtQ/dff3oHeJsTDA+23zDz4z0DrCQEJFNADYBQEpWDlYtzhz90H+Yv1Z85+NiIuOvFCIKDRHRPmNiAOj71AZ3v+eG8LwhCP25BDEocPfrWn1w6B1gLgCp2rQNQIuf60faB0qprQC2AkBRUZH6Qeni4FRLRBSmrDEDZ2oS44Lzej95NDivoye9A2wHgCJtOgdAOQCIiE0p5Rpu/TDLiIgoiul64tPbPSgiJQBcPt2E+4ZbP8I+REQUxXS/Bqad7hu8rHCU9TctIyKi6GbO1hMiIop6DDAiIjIlBhgREZkSA4yIiEyJAUZERKYkkTYSs4g0AThrcBnpAJoNriFc8GdxHX8W1/FncV24/CxmKqXsRhcxFhEXYOFARCqVUkWjbxn5+LO4jj+L6/izuI4/i8DxFCIREZkSA4yIiEyJARYaHDnkOv4sruPP4jr+LK7jzyJAvAamExHZrJTaYnQdRBR++PkQmIh4Hli40wYiXmp0HUbTntsGALOUUt8ytBidicg6DDwuqCDaP6ii+X0wFH4+BI6nEEkX2i9puTYwc442HxVEpAAAlFLlAFze+WgUze8DCj4GWIiJSIH2wRXtcgB4P6xqtflosR4DR1/AwP89mj+0o/l9cBN+PowPTyGGXurom0S+QY/EKcDAw0ujhQ1Aq898mkF1GC7K3wdD4efDODDAxsnnfL6vWqVUOf+6upl2+uxdPpg0uvF9wKOvYGCAjdMoD9vMEZEcn+mCSP6FHSnMfeZLorCJwYXrf2nbALQYVkn4iMb3wWBR9fkQCgywEFJK7QSufbDbjK0m9EZ7craIbPJ+aIlISRT99bkDgHeooBwA0fL/HlIUvw9uEG2fD6HA+8BIF1q32WsYuBaUCuDhaPrg0j6kagHkjBb0kSza3wcUXAwwIiIyJbbRExGRKTHAiIjIlBhgRERkSgwwIiIyJQYYERGZEgOMiIhMiQFGRESmxAAjIiJTYoAREZEpMcCIdCAiBSJSIyKv+czbDC6LyNQYYET6KAFQCOCX3lH7lVIuQysiMjmOhUikI+2oK1UpVWt0LURmxwAj0on3lCGPvIiCg6cQiXTgfXChN7x8HmRIRAHiAy2JQkxECjDwQMtWESnHwPUwFwaeD0ZEAeIRGFEI+Zw23IqBpzGfAbCUD3EkGj9eAyMiIlPiERgREZkSA4yIiEyJAUZERKbEACMiIlNigBERkSkxwIiIyJQYYEREZEoMMCIiMiUGGBERmdL/B5xvzATa8jwpAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# To make a spline you need the spline knots, you can get those from the xval, yval values\n",
     "splx, sply, spln = qp.spline_gen.build_normed_splines(np.expand_dims(xvals,0), yvals)\n",
@@ -1247,22 +442,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAAEnCAYAAADILRbRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABUHklEQVR4nO3deXzU9Z348ddnrkwOcof7DIdcCibBEzyDiifWAK22VmqLdXdtd1cLdWu32127LVS77q/duqBdbK20SLS0aEUJKhi1Qoii4RBIuBHINSHnnJ/fH9+ZZBJyM5nJJO/n48EjM/M95jNhMu/5fL7vz/ujtNYIIYQQ0cYU6QYIIYQQvSEBTAghRFSSACaEECIqSQATQggRlSyRboAQon/btWvXUIvF8jwwE/nSK8LPB5R4PJ5vZmdnnw3eIAFMCNEpi8Xy/PDhw6dlZGRUm0wmSVsWYeXz+VR5efn006dPPw/cGbxNvk0JIboyMyMj45wELxEJJpNJZ2Rk1GCMALTeFoH2CCGii0mCl4gk//vvvHglAUwIIURUkgAmhOjXNm7cOOSqq66avHHjxiFPPPHEsMLCwrjAtqeeeiq9sLAw7qmnnkoHWLt2bcqCBQsy165dm/LEE08Ma3vs2rVrUzZu3Djk3nvvHVdRUWGO3KsSoaCklJQQojO7d+8+MmvWrAqA7+XvHnPgdG1cV8f0xJThQxp+njfreGf7zJgxY9qePXv27d271/bLX/4y49lnnz35xBNPDMvJyWlYuHBh7caNG4ccOnQo5rHHHqsYM2bMzOPHj5e0d+yjjz46+o033ih76qmn0idNmuRcuHBhbShfi+g7u3fvTp81a9b44MekByaE6PeSkpI8bR/btWtX/JQpU5wAU6ZMcW7dujURYObMmQ0dHTt+/HgnQFpamrdvWyzCQdLohRDd1lVPqa8kJSWdF3Cys7PrDxw4EDN9+nTXgQMHYrKzs+u7e6wYGKQHJoTo1zZu3DikpKQkrrCwMG7dunUpu3fvjquoqDA/+eSTZ4qKiuI2btw4pKioKO7JJ588E7xvR8fu3bvX9vLLL6e8/PLLqZF+beLCyDUwIUSngq+BCREpcg1MCCHEgCEBTAghRFSSACaEECIqSQATQggRlSSACSGEiEoSwIQQQkQlCWBCiKgQqG24du3alLVr16b0xXPs3bvXtmDBgkxoqcHYF88jQkMCmBCi31uwYEHmLbfcUrtw4cLapUuXVldWVppDFcSCzzN9+nTXiy++eBRg4cKFtVLFo3+TACaE6Nf27t1rO3bsWMzcuXObaxw+9thjFf/6r/866kLPXVFRYd6yZUti8HPt378/5kLPK8JDaiEKIXrk5zOPZ3e07dpHk45etjSxAmDH2nPp256uGdfRvt8rGbOrO8/30UcfxY8dO9bZ9vGamhpLRUWFubCwMG7VqlXDP/jgg4MPP/zwKIBnn332JLT0riorK82PPfZYxcaNG4esWrVq+PLly08XFRXFJSQk+Hbv3h23du3alKVLl1YDLF++fNQHH3xwsO3zBarfHzp0KOaKK65oCF6ORaraR4b0wIQQ/V5KSsp5Q3mBKvPBweORRx4pD9wuLCyMKy0ttS1durR67dq1GYF9a2pqLAsXLqy99957q48ePWobO3asMxC8pk+f7mpv2PDhhx8eFVi6pbS0NOall15KCZwvUBFfhJ/0wIQQPdLdntNlSxMrAr2xC3H55ZfXP/fcc+ltH6+pqbGkp6d7of2K83Pnzm2oqKgwb9y4cUjwkirtLc3SlSNHjsRUV1dbCgsL4yZOnOh84IEHqn/4wx8O/8EPfjB69erVRwFXT88pLpz0wIQQ/dr06dNd48ePd4HRq9q7d69t7dq1Kd/5zne+aLvvgQMHmq9fPfXUU+mHDh2KCfTQAkN+HSVmBK/03FZ2dnb95MmTnXPnzm144IEHqjdt2pT47LPPntyzZ8++zZs3D7nQ1yh6R3pgQoh+b926dUcDqy47HA4zwJNPPnkmsD07O7t+48aNQ6qrqy3bt29P3Lt3b/mkSZOcRUVFcYWFhXGzZs1q2LRpU2JKSoonsLzK5s2bh+zevTvuoosualq7dm3KHXfcca6wsDCupKQkbu/evbaqqipLYN8nn3zyzBNPPDEsEARLS0ttgetr9957b3VkfitCllMRQnSqPy6ncu+9947Lysqqf+CBB6oDw4hiYJPlVIQQA0J1dbX51VdfTZHgNbjJEKIQIuq88cYbZZFug4g86YEJIYSIShLAhBBCRCUJYEIIIaLSgLsGlp6ersePHx/pZggxYKxatYq9e/d2WBKqrx0/fpxf/OIX/Nd//VekmjAoOJ1Oz6WXXro70u3oiQEXwMaPH09RUVGkmyHEgLFv3z6mTZsWseefPn06l19+OcnJyR3uk5+fT15eXvgaNQCVlJREXTURGUIUQvRrZWVllJV1nHTocDjYsmVLGFsk+osB1wMTQvShN74Ppz8L7TmHXwwLftbpLitWrGDLli0UFBSwcuVKVqxYQXFxMbm5uVRVVVFUVNSqF7Zq1SqysrIoKysjNTWV9evXs2TJEsrKysjMzOSnP/0pK1eubL6fm5sb2tckwkJ6YEKIfi0zM7N5+DAQsHJzc8nLy2P9+vXk5uaSmZnZHLxWrFhBVlYWubm5lJaWkpeXR3FxMXl5eSxfvpy8vLzmoLVs2TIeeuihCL46cSHC3gNTSuUBDiBLa72qk/2WB7Z39xghRB/roqcUDqmpqZ1uLysrw+FwUFxczMSJEwHIysrqcP/MzMzmnpiILmENYEqpLACtdYFSKlMplaW1Lm5nv1xgTk+OEUIMDp0lcxQXFzNnzhwyMzPJysrqMCg5HI7m21VVVRK8olS4e2BLgMDV1jIgF+gqGPXmGCHEAFFcXExxcXFzMkfgfkFBAcXFxTgcDjIzM8nPzyc3N5fly5ezatUqqqqqzjtHoCdWVVVFcXExRUVFrFy5MlIvTVygcAewZKAq6H5a2x38PawCpdRD3T1GCDFwZWVlUVpaChjDfYHbWVlZLF++HOC8IBR4PCBwTECgh9bZ0KLo//pjEkfnA9xCRCHt8+HxSOH0/iDQc+ssNV9Eh3D3wBy0BKhkoDJ4Y6D31ZNj/MctA5YBjB07NlRtFeKCeLw+dh6pZsveMyR9+hxfdv2Jfx37W66ZOZ7504YxNNEe6SYOSoHsRBH9wh3A1gM5/tuZQAGAUipZa+0AMpVSgaupmf4EjnaPCaa1XgOsAcjJyZEVOkXEnahu4IG1Ozl0tg67Bd6P2USaqmbimc384OBcnthYwvduvoiHr52IUirSzRUiKoV1CDGQPejPMnQEZRNu9W/P11rnY/S4krs4Roh+6cCZWu559gPOnmviv788m0++7CPNWw7WOL6XWshb/ziPWy8ewarNn/Pk6/vw+eQ7lxC9EfZ5YP7eUtvHstvZZ01nxwjRH+06Ws03XthJjMXEy9++kqnDE+H334EhI2HuP6LeWM4UzwF++eVsMhJi+E3hYarrXazMuwSruT9ekhai/5JSUkKEyP7T5/jq8x8xLDGGFx+8nDGpcVBVBocK4LrHYfa9sPXfYefzmO7O4Ud3TCc9wcZTbx0A4BdLZkf2BXTX0yEe8ny08x5ocXExixYtIjc3l5UrV1JUVMSiRYt4/PHHycvLY8WKFWzYsCG0bQqhQPvz8vJ4/PHHO53H1hcC5bdCUS/y4YcfHpWWluZ58sknzwQ/XlhYGPeVr3wl8/bbb6++7LLLGnbs2BF38803n1u4cGFt222VlZXmtLQ079KlS6vbO7a0tNT2pz/9KXXPnj37umqPBDAheujMfhfVRzxMuj4WS4zxYX54RyM/e+kgUxuTeTxrKvU7YD8NZBx9jlRlRmXdDzFD8E5fhNq9jkOWJ/BZU8llFM5UE2+8/gV/PHeS2xcOJyHDDED5QReOYx7GXWnHFjd4e2eBdPeHHnqI5OTk5tJRy5YtIzk5meeee67DY/tDlfpA+5csWRKRivq5ubmsXr26033y8/OZOnVql+e67777qjdv3jyk7eNz585tmDdvXu19991XPXfu3IalS5dWJyYmzj537twnbbeBEQhTUlI8CxcurJ07d27DzJkzG4K3d9fg/asQohfqK738/stn2PRYJc5aX/Pjr/78DDO2DuWqD0ax7Ye1bHqskr8uP0XskXWcasqFxJEANE1eikk7Ofl/a9n0WCWbHqvE9zsbNxeP4/h/+yj9uOXvd89fGtj43Ure+++asL/OaNFZpfpoqlIfybb25LlTU1M93T1vUlKSZ+/evbb2tj3yyCPlP/jBD0a3t62iosKck5PTrUAmPTAhesBx3IPP/ydsthm9r31fnONvlDNzWgqXjk1u3ne05U3iYhwcHfoAo/yPmUbNpNKTzZyLN1Cb+RCB75DnGj0UHirntyXV/OKmSwBoqDLmjVUd7vZnxqAUqFRfXFzcqvoGcF6V+jVr1pCTk0NRURHLli3D4XCwZs0asrKyKC4uJjk5+bzq9cuXLyc/Px8wKngsW7bsvKr4gYLDGzZsYOXKlZ32tPq6on7b19hW29dSVFREUVERmzdvNs+cOROAJ554YlhOTk7DoUOHYh577LGKwP2ioqK47vyfVFRUmBMTE73Tp09vd42x6dOnu44fPx7T3rZNmzYlBoYXuyI9MCF6oKHK6HVNvNaOPdGE2+vjsQ27OTyrhu+8MJY7n05v/pc15WVIm8S0hxc0Hx+bbCZt8bdJMB3lzr8rad73q78ezszv23n17HHe+OwLALLuHeJ/TpkADcYHf35+Pvn5+c21DIMr1a9fvx6geYixbZX6VatWtaqRuGbNGoqKipqHJXfu3MmyZcvOq14fmPScl5fXPBTXUVX87OzsLhfU7cuK+u29xmAdvZbMzExuueUWLxjDezk5OQ0LFy6sLS0tjXnqqafSA/dvueWW2s5e2+bNm4ds3LhxyAsvvJCybdu2A53tW1tba2577L333juusrLS3NExbUkAE6IHGiqNYBKXavyNPf/eYfacOsdP7p5JSnzQaMnpz+D4R5DzDWg7z2v6XRCXBjt/0+rhb187kYtHJfHExhJqm9zEpRp/nvWVEsCA5g/8vLy8dns4jz/+OFu2bCE7O7tVsd6AnTt3NhftzczMZMuWLc29lkCvKCC4xFTgGlZBQUGrSvjBtwPn7apSfnvHtqe3FfXbe43BOnotwY4cORJTXV1tKSwsjJs4caKzuLg4fsqUKc7uvK5AoHvssccq0tPTO3zjVlRUmKdPn95qmPCWW26pXbdu3dFJkyZ167lAApgQPRIIJnFpJuqcHlZvL+WGqUO5ecbw1jvu/A1Y7DDrK+efxBIDl34VPv8r1Jxsedhs4id3z6Sy3sXvPjxKXJoRJBurfWiZK9alQBDatWsXBQWt6x0EqtQHrpeVlZUxZ86c5iG8QC+kPWvWrKGsrKw52AWC44VkE/akov7ixYvb3a+9ivrtvcbuvJaAwsLCuOzs7PrJkyc7586d2/DAAw9UZ2Vl1R84cKDd4b7eeuaZZ9Ife+yx0+1tW7hwYae9vGByDUyIHggMIcanmXnxw6M4Gtx858bJrXdqOgefvgwz8yCug2/a2Uvh/f8Hxb+F6/+l+eFLRidz/UUZPP9eGQ9cNZ6YIQpnrabpnI/Y5G6PrPStLtLeQy1QSX79+vVkZmZSVFREWVkZa9asITc3t1Wl+sD1ncBQXHtV6gPnDBT8zc7OJjMzk8zMTB5//HGKiopaVa/PzMxsdb+goIDk5OTzquKXlZWxfv16UlNTW63w3F77+6qifnuvMXBc4Fpd29cSGI7cvHmz+YEHHnDOnTu34YknnhhWUVFhBghcAwMoKiqKe/vttxMrKipa9bAKCwvjdu/eHQdGRmLbbe+9996QpKQkz8GDB2NKS0ttycnJrdLoS0pK4l566aWU1NRUT0fXzdqjtB5Y3+xycnJ0V2PQQvTWB8/W8Plbjcz5dgL37/iQi0cl8dtvXNZ6px3PwV8fg2+9DaOy2z8RwO/zjKHGfyoBs7X54eJj1Xzp1x/wL7dOxf6reJx1msXPZZA0KjLfN/ft28e0adMi8tx9bdWqVc3p+GVlZaxevTpqlldZtGhRSOe/lZSUNMycObPLuVeRsnv37vRZs2aND35MemBC9MBVDydx1cNJPLe9jKp61/m9L62h6P9gxOzOgxfAnAfhD182hhKn39X8cNbYFOZNTmfN9jLe+/0NxNr6Sc9rAAruUTkcDpYsWRLpJnVLcK9vMC/GKQFMiB5qdHlZvb2MuZPSyR6X0nrjsb/B2b1w5y+7PtHkmyBpjHG9LCiAAXz3xsnk/e+HrNtxjAfnTghh60Ww4KG+aCIV9Q2SxCFED7jqfaz76BgVdU4euWHS+TvsfB5ikmDmPV2fzGSG7K/D4W1QcbDVppzxqVyZmcb/biulye1loA31CxEKEsCE6CavW/Pfl5/kzCMmLhufyuWZbRYHryuHvX+G2V8BW3z3Tnrp/WCyGsOObXznxskM/zSBX119ksJfngvBKxBiYJEAJkQ3BSYUu81eHpzXzrDexy+Czw05D3b/pEOGwbQ74JOXwNW6es4VmakMTbajG1Tz/DMhRAsJYEJ0U0OlkULvivVyw9ShrTf6vLBrLYyfBxlTenbiOQ9CUw3sebXVw0oprrgkGYDTJ7s9t7N/eOcfjX8hEJjM+9BDD+FwOCgoKCAlJYVVq1ZRVlbGokWLQvI8faW4uJjs7GxWrFhBfn4+K1asaK6Q0dP2B34XgXOtWbOmeaJzd6xYsaI5zX4gkCQOIbrp+LFGAJKHWs9fu+vQVnAcg/n/3vMTj7saMqYayRyXfrXVpmuzM/gzVZw60dTbZke9gVCNPicnhyVLlpCVlUVeXh4pKSksXryYzMzMTtvf3rkCle0D88G6W/0DYMmSJedN8o5m0gMTopu2F1cAMG5c7Pkbdz4PCcNg6u09P7FSRsmpU8VwsvWC4xkjjfJUjVU+6pxS1LetaK1GH6jh2Fn7u8PhcJCbm9vtc4R7LbK+JgFMiG7w+jSf7DOWNQkElWbVR+HgW5B1f6sJyT0y68tgjYOi1vURAzUX7U4Lm3af6t25B7gVK1YANFe2CPwLVFkPVOcAo5RScXFx8xCew+Fg1apVFBQUsGrVKtasWUN+fj6LFi0iPz+/ebgtUEQ4cFxBQQHz589vPi4/P5+CgoLmYc6uBE+WDrS/7TmLi4s7OrxZYA5bZmZmp8cHXmPw76Lt7ysahT2AKaXylFK5SqnlHWzP9f9bGfTYSv/P89cGECIMth04i8e/LFcgqDTb9YLRi8p+oPdPYE+CixfBZ69AY8tKErZ4hSUGrF4T698/3vvzDwDRXo2+qKiIgoICFi1a1By0gtvf3jk7+12sWLGiVc+ro+MDy8UEaj4GtP19RaOwBjClVBaA1roAcATut9k+3789K2j7MqVUKdD7vrYQF2DdR8c5O7me+T9OJnOevWWDx2VkH05ZAEntrs/XfXMeBE8j7P5j80NKKeZ9N5mEe32UnKqh5OTgXdwy2qvR5+TkkJuby4YNG0hNTT1vqZOujg+Wm5vLypUrm9sZCGTtHb9r1652A1RXv69oEO4e2BLA4b9dBrSaBq+1LtZar/DfzdRaB/rAi7TWE/2BTYiwOl3TxNv7zzB/fgaz7xlCxpSgIcR9f4H6cpjzjQt/ohGzYFSOkcwRNHE55/4h3PuPIzHHKP6w49iFP88AFW3V6NsLNj09Z25uLg6Ho/l1tXd8dnZ2u9fIOvt9RYtwZyEmA8FLpqa1t5N/ePGhoIeylLGmUpbWeuDkgIqo8Nqnp/BpWJwz5vyNO38DKRMg84bQPNmcB2Hjw3B4O2Re2/xwUpyVW2YO5/XPvuBHd8zAZhk8l68HQjX6wFBloJ2Boc3AOQKPt1elPjgoBf8uysrKqKqqYvXq1WzYsKH5mLbHL1u2rNXr3rJlC8uWLTvv99XQ0HoeYjQIazV6pdRqYLXWulgplYsxXLiig303AN/SWjuCHlsJbGnbE/NfG1sGMHbs2OyjR4/21UsQg9BdvyrEp+GHCZdgjTVx8d3xWGIUnNkLz15ppM5f/d3QPJm7EX4xDSZcA4t/B8DZz12c2eviSEwtj2wvZu0Dc7i+7Ty0PtSravSBOWDXPxPq5oRUNFejD7VorEYf7q9xDiDQb04GKoM3KqWCr3uVYVz7ylNKBSZyVALn9fO11mu01jla65yMjIw+abgYnI5W1rP7RA23zRzB9mdqKHiyGhX4qyn6PzDHwOyvdnqOHrHGwuz7YP/rUGus97f/jQY2/7CalKOxJNolGzGUAj2qQI8lWqrRC0O4hxDXAzn+25lAAYBSKtnf08oFAte9koGdGIEsMIA7EVgdprYKwWuffgHA/PHDeNVbTUyiwmxV4Kwzki1m3A3x7Y6E917ON+DDX0Hx7+Da5c0rMzdVa26ZOZy/fnaaJrcXu7UfL7PSz3teAdFajV4YwtoDCyRl+IcPHUFJGlv9P9cAmYEel9Y637/PYv9jpUHHCNHnNu0+RdbYZJJ8xorq8f5gwmcbwFVrXLMKtbSJkHm9kZ7v9RCfZvyZNlR6uf2SkdQ5Pbz7eXnon1eIKBP2UlJa6/NyR7XW2f6fDowgBpDf2TFC9LVDZ2vZf7qWH90xvbmYblyq2b9o5W9g2MUwek7fPPmcB2H9V+Hgm8Sl3QgYtRhvnZhOaryNTZ+e4paZw/vmuYWIElILUQwOT6seH7Kp/l4UX+a297OpOjoX+B/iKl+Fn/8DNMRDTCP8oo8GMTSgEmDDYuKco4EC6g+WYHnmRm71Pswrn95Iw6mriFO9KPL7qKwtJgaGwZOLK0QPaA2bnPO43FrCUHM19U3pAMTZK8BlBTRY3X3XAAVYXeC1kGA3hgsbGo0Epdtj3qMROwXOy/vu+S/Q2z+r5u2fVXe9Yw8El0MKLokUSsHV4QOlmUT/JQFMiHbs9U6gzDuGO2K2A6C1CbvNQVL8CfBYjeDV805dz1jdgMauGlHKi8drx+uzMMe6l2GmSjY55/VxA/qPRYsWNU84zsvLo6qqKmRBLPg8wdXhc3NzB1zx24FGhhCFaMdrTddgxsuCmA8AyJnxG3Jm/AbttIHLbvSO+ppJg8WD8lj4zr0zsVrrUf6geWtMIS813so5XxyJpuibgNoTgUm+weWdli1bxsSJEy94qZRAxfrAecrKynA4HK2eS/Rf0gMToh1vua7gcmsJqaZzLQ9qUG4bmD1g9oWnIVYXaBM25WoOXgC3xryPCyvbXNnhaUcEFRcXt1vmqaqqqnmBy8BQ34oVK5oL5ULXVeTXrVt3XsX64OODBYYwAxXto72S+0AgAUyINso8Iyn1jmG+7W+tN3jNoE3h6X0FmL1g8vqvu7XIsuwnVdWwxdV/r4OFUnt1AwOPBc/leuihlgp03akif/To0VYV64OrwwdbsWJFc0X30tLSAVHJfSCQACZEGwX+oDA/piWAvbBxM0eO3IgPwBLGhSUVxrUwn4U/b1nN54dvA8CsfNxg28E7rhzcuh9PaA6BrKysdovRVlVVNQeb9oJOd6rId1dgaLG4uJiJEycOiEruA4EEMCHa2OK8gmnmMkabWyYLezyxjB26A2329X3yRltWF16fhfFDd1BT17Jky/yYj6jVCexwzwxzg8IrUGgXWnpV+fn5PP744+ftGxzoelpFvrMFJOfMmdO8ltjixYsHRCX3gUCSOIQIUulLZJdnKv8Q17KYoMsdx/Qxr6PQqJj68DdKQWX9WKaNfY2/ld7f/PA828fE4GSL63Kutu0Of7vCaPXq1RQUFDT3hIDmavJgBJiCgoLma2KBiu/dqSI/ffr05or1wdXhAz2uQOX6VatWUVVlLKbRXuV7EX5hrUYfDjk5ObqjFVHFINbNicwbmm7ke7X/xGvJ32WmtRSA6nNjsTZZqKzNZNzEyHzbLj08n4npH1Fy/DZmTv9D8+PfrPkh+zzjKUx9sFWSR6d6OJG5N9XoA3PAbvh+So+O666HHnqI7OxsFi9eLKnuISLV6IWIclucVzDCVM4MS2nzYz6XnYTYCspOR27elbK6+aJqBmPSdhlVOvxybR9x0jeMfd4JEWtbJFRVVbFhwwYJXoOcDCEK4dekbbznupQ8e0Gr3kysqYGa+pFUN46KWNvi7JV8/NmDLMj5VyMb0mLUZrwxZgeqzscW5+VMtxyOWPva6queV8CGDRv69PwiOkgAE4OW1lC8b2nz/QOesUxuGsXF9gx2WZYydsT7ZCQeIs56ju37lxJnr+zkbH0rPrac/ccXcP2sVdgtbrA0srf0LhqdqSxo8LGXe9kVF9u8f0bKfsaO+DBkz6+1RnV7jFKI0PL5fAo4b/KlBDAxqJyrG4nJ5CHOXoFSPt7+6Metts8DjvItjgI3XfV9MmKPojXEDvmCkUlHItFkwOiBTZ+4kcr6cYyy1oJPseOzhymvnk5g8PBtZjfvP3vqbxk74kO0Vni8NkzKh9ncu9qNdrudyspK0tLSJIiJsPP5fKq8vDwJKGm7TQKYGFRe3PQaDU3p/N2Xs4izV5A1bS1gXFZa3zSf4aZKrrMZ6dTpyfvBbUNZ3cy5+PkIthrMZjc3X70CvCZoSAC3lWmZf2FMw0c4fAlsdF7PFdZPmWo5CsDoYTsAKPjbf/DJ/vvJveIHXDrtxV499+jRozlx4gTl5bIG2UB2+vRpi9frTY90O9rhA0o8Hs83226QACYGFY/XWJjSYm5CKbjxih8B8Jl7Ilsc2fxiyC+40f6OsbPLCs7Y8Fbe6IrZZ5Syctu4/OJfgzKGQv+76jlsluP8fdK/t97dbCy3EnjdvWG1WpkwYXAliQxG06dP/0xrnRPpdvSEZCGKQcXjsQNgMbdeR+tdl/F3e40taDKr22aUcTJ7w9a+bvHXR8RrfP9UCq6z7eID1yU06dYlpyzNAcwe9mYK0dfCHsCUUnlKqVyl1PIOtuf6/63s7jFCdIfPZ8anrYAPk6n19aB3XdlcYjlAuqnGeMBrAp/ZCBb97bKPxQPK16o+4nW2Ihqxs9M9o/Wu5iYAvBfQAxOivwprAFNKZQForQsAR+B+m+3z/duzlFJZXR0jRHcFhtGslqZWafIOXwIfey7iOtuulgddNvp80creCtRH9FrAZ7yQK22fYcPV3JMMCPTA3B7pgYmBJ9w9sCWAw3+7DMgN3qi1LtZaB9YyyNRaF3d1jBDdFQhg5jbDh9tdWfgwc20ggGnCt2hlbwWuy7ltAMQqJ5dbS3inzfIqgQAmPTAxEIU7gCUDVUH309rbyT9UGFgXoVvHCNEVb3MCR9vrX9kkq3PMthwwHnDbANW/kjfa8i92idvaXJnjelsRZd4xHPcOa97NYjGGEOUamBiI+mUSh9Z6FfCQUiq5O/srpZYppYqUUkWS6is6Yo+pJu+mr7Jg7qPNj/m0Yrsri2tsxZiVzwgGLiuYwrhoZW8Fkjk8RjLHdTajBui7Qb2wMcP+xoJ5/8QlU/7Q7imEiGbhTqN3AIHFeJKBVqUNgq53FWMMFy7r6hj//muANWAU8w11o8XAYLU4mTBqe6vH9ngyqdApLde/vGbQZohpjEALe8jsNZI53DawephgPsVY0xe868rha7F/BSAl6QgpEZyALURfCncPbD0QWL40EygACOpp5dI6WJV1dIwQoXBe+rzbZgQFSz9M3mhLATaXkczhNXWaTi/EQBTWAObvWaGUygUcgfvAVv/PNUCmUirPv39+J8cI0SPV58axfddySg62rN/0jiunJX3ep4zhOEs/Tt5oy+oGdHMyRyCdPrDIZV3DMHbtXcq+sjsi2Egh+kbYK3H4h/vaPpbt/+nAPxQI5Hd2jBA95agdy0ef/gPjRm5n5uR8HL4EPvFM4R/iXjZ2cFsBZfRqooXSRsB1WyGmKSidPptrbB9TUzuatz/6MSMzipiWuSnSrRUipPplEocQfaFtFY73XJe2pM9rjF6M2WNk+EUTmxtQ4LY2p9Nv8ydySCUOMZBJABODhtfbJoC5LyVR1THLcsAYOtSm/p063xGT1/jntoGGa23FlHrHcNKbEZRGL/PAxMAjAUwMGsGFfLU2emBXW3djCWTyKZ8xtyraKIzA6zODz8w828cAFLpmBxXzlR6YGHgkgIlBI/AhbjY7KfWO5gtfBvNsxeDzF8btj3UPuyuQzOGyMsV8lKGmSra7Lw0aQpQemBh4JICJQcMTVIlju8soqTnP9om/KG4/rXvYXYH6iB4rSivmWT/mfddslMkYEvVILUQxAEkAE4OGxdzEkPiTxNqreM99KRPMJxljOmMMH1qiMHmjLauLQDLHNbaPcehEPmckZpMTsymKg7MQHZAFLcWgMXvqS8ye+hJObeHBij+yyF5gFO3t73UPuytoscurY43rYB94Z/LPX58c4YYJ0TekByYGnV3uaTRiN65/uaz9c9HK3vLXR0zX9cywHGK7+9JIt0iIPiMBTAw677mysODhKtNn4LP072VTeiqw2KXbxjzrxxS7p1Hni410q4ToExLAxKCx9W8/5lfrPubzsjvJsu4n3qsxkjcGwPBhQHMyh4Vc6048WHhxcz7P5W+nriEj0q0TIqQkgIlBo8mVRKMzjZPeYdxo2WGUXxpIva8Af0CerQ9jp4lzdaNx1I7H45WemBhYJICJQSOQRu81aW4zf8SASd5oy6TB7MHiMXO1bTf1JiNXS1LpxUAjAUwMGoEPcJu5jlHeGn/yRj9ftLK3bG7QJu4zb6HRZAZkMrMYeCSAiUEj8AF+W8IWlDZFV9X5njIbyRxXqAN4/fPbpJyUGGgkgIlBo84zBIAFCQWAjo5FK3vLXx8xzudh+JDPARlCFAOPBDAxaJzzpBAfU8F429HornvYXf76iNeO3gCAW4YQxQAjAUwMGicmlDF8znOYlPavoTXAmTRYPFw6/E32TTpGRWyUl8oSoo2wBzClVJ5SKlcptbyD7cv8/1YGPbYysC1c7RQDi0ebKBhl5frhG/2LVg7Q5I22rC5sJhcZM/7Ep/FJkW6NECEV1gCmlMoC0FoXAI7A/aDtuUCB1noNkOm/D7BMKVUKlIWzvWLg2O2ZQo46QAr1AzN1viNmY7HLBy2vU+iaFenWCBFS4e6BLQEc/ttlQG6b7ZlBj5X57wMs0lpP9Ac+IXqs0DWbZZ53cflseAfTwLmCBl88U9QpVF0STdoa6RYJETLh/lNOBqqC7qcFb9Rar/H3vgCygKLA7c6GHYXoykH3OC6LLWbn/gfx6cG1CMOuA/fjcsfxdV8hxe5pkW6OECHTL7+L+ocWt2itiwG01qv8va+0oGHF4P2XKaWKlFJF5eXl4W6u6OfqnB4u9h1DaxOfluU1r1I8WCiTj73Hbmde0rvsdM6IdHOECJlwBzAHkOq/nQxUdrBfrtZ6FTQnfeT5H6+kZVixmb/nlqO1zsnIkIKlorWdh74gz7KdQ19cR6MrGaUGVzaexezkk7Il2EwuEryDIPtSDBrhDmDraQlAmUABgFIqObCDUmpZUPDKxbgWFrj2NZGWYUUhuqV65wbSVC2flC7BPMh6X2CsRF1ecxEn6zO5QX1KdV1TpJskREiENYAFhgT9gckRuA9sDXp8pVKqVClVHXTMYn8vrDToGCG6ZcrxlznjS+Xo2SsG3fAh0Pyaj1TMYYLpNJ//7fUIt0iI0Aj71eygJI3gx7L9PwuAlO4cI0R3VBzdx0zvPj7wzgJMWCyDr/dhMRuvuaZ6MjVj44gpWQ+590S4VUJcuH6ZxCFEqJz5cB0Adp8XYFD3wDyeBHYzgYsc28DdGOFWCXHhBlc+sRh0Ug6/xsdMZVbq35hx3wx8PnOkmxR2E0a/yzfuvh57TA2FvouI8zVRXvwaGZcvinTThLggPQ5gSqnxGHO0UjEyCcswrme9HdKWCXGB9Jm9jHSWUZjxHS5t2oHZVhvpJkVEjK2WGP9rn+iOobwxkYaPXwYJYCLKdXsIUSn1PaXUW8BKjGxABdT4b9+klHpLKfWsUmp2n7RUiB6q2vFHvFphu+TuSDel35hoOcm75qsZcWYbOAdnQBcDR5c9MKXUBOAh4I9a6593sW8SRt3CHK318yFqoxA9pzWWfX/iQ990cmZO5eSmbAo/foxRw3Yy99JfRLp1YeWoHUNh8WMkxJ3hujn/yZmxt2E78ga+/W9gmrU40s0Totc67YH5g9eNWuvva60/6epkWusaf5DbqpT6ZojaKETPfbGbpIZjfBh7HaNT4qhrHMqxL66mouqiSLcs7NzuOPaV3c3hE9cDMPqS6zilU6nbtT7CLRPiwnQawLTWh3vTk+rtcUKEivezfNzajGvKbQB4vMZqxIMzjd6fhehf0PLqyUN5zXsl8cffhcbqyDVMiAvU4zR6pVRiXzREiJDRGs+nr7DddwnZU43CL17/h/dgTKM3twlgGUNi+Cz5RszaA/tlUrOIXr2ZBzYxOFFDKTVBKXVD6JokxAU6sZOY+lO87ruCKzPTAfB4jA/vQVlKyt/rDPRCAYZedAXH9FC8n+VHqllCXLAeBzCt9cfAHH86PVrrw0CKUuqnIW6bEL1T8gourJwafiNJccb6V81DiObBO4QY6IUCzJ2SwV+8V2I6vB3qZAUHEZ16M4S4HigFqoOGEwuAZaFsmBC94vPiK3mVt32Xkj1lTPPDnkE8hBh4zW6PHe0vxH/5hFTe0FehtBf2/TmCrROi93ozhJgNFGmtawDlT53PBX4W0pYJ0RtH38dUf5a/eK7g6knpzQ+nJZVy0fjXyEjdH8HGRYbJ5GXM8A8ZN7IQrY1KJHE2CwljLuGoaSyUvBrhFgrRO70pJbUIo7f1lNa6xp9qn9LVHDEhwqLkFZymWD405/Bf41rqQl804XUumjB4Exa+vGDJeY/Nm5JB/vHL+Oejr6DOnYLEkRFomRC916trYFrrp4LuHwZ2SQUOEXFeN+z9C++Z5jA7cwQxlsFX97An5k3O4DXflSg07NkY6eYI0WMhqUbvT+w4HIpzCdFrZdugsYo/Nsxh3uTWK3PXNQzDUTsWlzs2Qo2LLLcnhkZnUqtixjNHJVEdO5YT9slQ8koEWydE74RsORX/NTEhIqfkFVyWIWz3XcI1U9JbbXpnxxM8l1/IoWM3RahxkfXbP2/mV+s+o/rc+ObHzCbF1RPT+ZP7CjhZBNVHItY+IXqjy1JSvSkJ1dvjhOg1dxPsf42iuKtJTRzCxIyEVpsHcyUOOL8aR8C8yemsb8gx7kgyh4gyXZaSwqhr+L/dmayslEpUSn0Po35iu6WklFJ5SqlcpdTyDrYv8/9b2d1jhOBQATjP8btzOcybnI5SqtXmwZxGD+3PBQOYOzmdEzqDM0mXSAATUafLLER/EPu2UupbSqnvAxooBir9u6RhrAs2EWN+2Cr/MedRSmX5z1mglMpUSmVprYuDtucCBVrrMqXUBv/9qs6OEQKAklfw2FPZ4riI/5qScd7mllJSg7QH1k41DoDRKXFkZsSzxTSXr575NZQfgIwpkWiiED3W7WtgWuvntNY3AYsxJi4fxlgPrAhYo7W+SWv9cEfBy28J4PDfLsOYPxYsM+ixMv/9ro4Rg52rHg5sZm/KDfiUmbmT0s/bxeMJVOIYnD2wtvUQg82blM7qiovRKNgjvTARPXo8D8yfrLG1l8+XjL9H5ZfW5txrgu5mAesxJk53eIwQHNgM7gZecV7OzJFJpMbbztsl8ME9GGshQkvPMxDIg82bnMFvP0zi3MjLSSp5Ba5dAW2GYIXoj3qVhaiU+qZ/9eVv9kV1ev9Q45buDhX6r5kVKaWKysulrtugU/IqvoThrDs9knmTz+99QcvQmVWSOM7bdsXENCwmxYdx10LFAThTEu7mCdErvamF+DNgEsbw4WLgsFLqwW4e7gBS/beTabmO1lau1npVd4/RWq/RWudorXMyMs6//iEGsKYaOPgWx0fcgtunmNtBALvtmu+y6Kb7GBJ/KswN7B+ypr3Andc9zOhhO8/blhBjIWtcCr9zXALKLHPCRNToTSmpnVrr5ne4UioZ+L5S6kta664G0NcD/pxdMjGupaGUStZaO/y3lwWClz+Jo91jhACM9ay8Lt5UVxFrNZMdVD4q2IiM3WFuWP8yatiuTrfPm5TO01uqcE29FlvJK3Djj2QYUfR7FzyRWWvt0Fp/n25cmwoMCfoDkyNoiHBr0OMrlVKlSqnqLo4RwugtJI9l3YkMrshMlfJRvXSNP3OzJDUXHMfgZOcBT4j+oDc9sDKl1E5gObBLa33O/3hHw4GttEnUCDyW7f9ZAJz3Fbq9Y4SgvhLK3sUx+9sc+aCRpXMzO9z17R0/xGJyMS97FUrpMDayfzh5JpsTZy5j5NBdjGln+8WjjOSXDXWzyDLbjDlho3Pa2VOI/qM3PbAlwMvAw8ARpdROpdSbQKZSagiAUupLIWyjEO3b9xfwedgecw0A17Yz/wvA59Hs2vMtdpR8G2Ma4+Bz9Iur2b7rcY6cvKbd7SaT4prJ6bxV2oieNN9Ip/f5wtxKIXqmNwGsFNigtV6stU7FWFqlALgJOKqUOgis7OwEQoREySuQNpmNp1IYnxbH+PT4dnfzuIygZTE7B+1lnc6yEAOuvSiDynoXx0beArVfwLEPw9U8IXqlN8upPAekKKXG++9/rLX+uX8icypGD00q04u+VXsajhTimX43H5ZVddj7AvA4AwFscKbQQ9A8MO/588ACAhX8/+qcDdY4yUYU/V6vkjj8QetIB9uKgRUX0ighurRnI6D5JOkGGt1err2okwDWZASwwTqJGcBiab8WYrD0hBguGZ3E1tI6mHIL7N0IXk+YWihEz4VsOZVg/vXBhOg7Ja/AsIvZfDoJm8XEFZkdJ8F6g4YQB6vu9MDAuI5YfKya+ikLoaESDm8LQ+uE6J0+CWBC9CnHMTixA2Z+iW0Hyrl8Qipxto4Tat1NMoTYXAvR03EPDIwA5tOw3TcLYhKlNqLo1ySAieiz508AnB57KwfP1nV6/QtAmSA16RBJQ46Ho3X9ks3SQIytpnkosSOzxySTaLfw9qEamHo77NsEnsHbcxX9W2/mgQkRWSWvwKhs3j4dB3ScPh+QMdnGg1/qcjm7AW3C6G18576L/fce6XA/i9nEvMkZbDtQjl50N2r3Oih9Gy5aEJ6GCtED0gMT0aXiEHyxG2bew7YDZxmVHMukoQldHye67dopGZytdbI/LhtiUyQbUfRbEsBEdNnzKqBwXXQX7x+q5JopGeetviwuTCCj891DDph+F+z/K7gaItsoIdohAUxEl5JXYNxV7KyyU+f0cF0n6fMB+zc38MyL+9lcuKrLfQcqR+1Ynsvfzh/++nKX+w5LtDN9RCJv7z8DM+8Bdz0cfDMMrRSiZySAiehxZi+U74eZX2LrvrPYLKYO1/8K5mnSuD1x+HyD95Kvwoejdjzn6kd1a/8bpw1l19FqqtPnQMIwozaiEP2MBDARPUpeAWVGT7uTrfvPcNXEtE7T5wOaK3EM0sUsITiNvvN5YAE3ThuGT8O2Q1Uw4244+BY0nev6QCHCSAKYiA5aGwFswjWUNcZxtLKBG6cO7dahLaWkBm86eHdqIQa7ZFQS6Qk2tu4/CzO+BJ4m+PyNvmyiED0mAUxEh1MfQ/VhmHkPW/edAeD6HgewwdsDC/Q+u6rEEWAyKa6/aCjvfn4W98hsSBoj2Yii35EAJqJDyStgssK029m67yxThw9hdEpctw4NBLDBXAvRbHIB4PPZ8Hm7t6TMjdOGUdvkoehojTGMWLoVGqr6splC9EjYA5hSKk8plauUWt7JPllt7q/0/1zW1+0T/ZDPZ1TfmJRLjU6g6Gg1N07rXu8L5BoYgFItPdBAbciuzJ2cjs1saslG9HmMyhxC9BNhDWCBwORfednRNlD598kFnmvz8DKlVClQ1vetFP3OiR1w7qQxeflgOV6f5oapw7p9+MRr7Vw35z8YO/yDPmxk/zdn5mqunPXf0M1pcwkxFi7PTDWug42YBakTpTai6FfC3QNbAjj8t8uA3LY7+INb23GKRVrrif5tYrApeQUssXDRArbuO0NavI3ZY5K7ffiYHDtzZj7HiIxP+66NUWBu1tPMzXoaq737f/a504ZRVl7P4coGoxd2eDvUne3DVgrRfeEOYMm0Dk4dr4HRWlZXw45igPJ6jOHDKTfhscTx7uflXHfRUMwmqb4RDjf4E2W27jsDM78E2gd7/xzhVglhiIokDq31Kn/vK80/xCgGi6OFUF8OM++h+JiDmkZ3j65/ARz9qIm9pXdRW9/9YceB6IvyWZQdvx5nra/bx4xJjWPKsAS27jsLQ6fB0OmSjSj6jXAHMAeQ6r+dDFR2dYA/6SPPf7cSyGxnn2VKqSKlVFF5eXmImir6hZJXwJYAk2/irT2nsZm7V30jWNFva3l9+y85U3lx1zsPYFs+/AmvFPyW6qM9W2U5d9owdhypwtHgMnphxz6EmhN91Eohui/cAWw9LQEoEygAUEold3JMWWA/YCJQ1HYHrfUarXWO1jonI6Pr2ngiSnhcsPcvMPU2tMXO5j2nmTs5nSF2a89OI1mIQNBkZmf3shADbpk5HK9PU7DPP6kZmtdkEyKSwhrAtNbF0Jxp6AjcB7YG9vH3tnICvS7/Pov990uDjhEDXdk70OSAmfew59Q5TlQ3cvOMng8DSiUOg7mXAeziUUmMTLKzueQ0pE2EkZfKMKLoF8Je3VRrvaadx7KDbucD+V0dIwaBklfBngyZ1/PW24cxKWM4q6cC854GcyUOAGugGkcPA5hSiptmDOcPO45R7/QQP/MeeOsJqCqD1PNG9IUIm6hI4hCDkLsR9r8O0+4Ai43Ne05z2YRU0hK6V8svmKdJemDQ+x4YGMOITo+PbQfKjaocIBXqRcRJABP908Et4KqFmfdQVl7HgTN13DJjeK9O5XHJNTDo/TUwgDnjU0mLtxnDiEmjYcwVEsBExEkAE/1TySsQnwHj5/HmHqN47029DWByDQxoGULtTQAzmxS504bxzv6zOD1eY1Lz2T1wdl+omylEtymte/5m7s9ycnJ0UdF5iYoiUp7uxYRjDdQNAasb7E3cVf00oPhzyj/3qglerxWP147NWodSA+v93hP1jWl4vTHYY6qxWRt7fPw7zhyWnvs31ib+iOutxVCfADYXxPTii8Gjg/f/ob9SSu3SWudEuh09IT0w0f94LIACi5tT3nR2ey7i5pje1zE0m93E2GoHdfACiI+tJDHhVK+CF8BVtk9IUA286boKTBrMXnBbjC8cQkSABDDR/3isoHxg9vKW6woAbrEN7kK8/UGM8nCDbQdbnJfj1SawuEGbwScfIyIy5J0n+heN0QOzuEHBG86rmWw+SqblVK9O5/HaeOm1V9nw1u9C284odPDofP60dQ2fHVjc63PcEvMhlTqZj9wzjCFetPGFQ4gIkAAm+hePFVBgdXPam8YO9wxuj3mv96fz2DlVnsMX5ZeGro1RqqZuLIeO3cLZqum9Psf1tiLiaGST8xpjWRazB9xWGUYUESEBTPQvbv/wocnHa865aEzcGbO916fzeO3A4F6NOaA5jd7b87l0AbHKyfyYj3jDeTVubQarB7QJfOZQNVOIbpMAJvoPnwKv2RiaUrDJeS0XWw4yoZfDh9DyYW0d5FU4IGhF5gsIYAB3xGzHoRMpdF1qDPWijWQOIcJMApjoP4KyD494R7DbM4U7LqD3BdIDC9bSA7Nf0HmusRWTpGr5S2AY0eIxhn5lGFGEmXxtEt1ybEcTw2fasMUZ33kOvdtIzYn2l+VIGmVh0vWxALjcsXx28MsdnnfimK0kDzkGgLMxBZ/Xyt7Pv8R2ZxaXuNOYFDeKXaalWC2NXDLlj83HfXpgCW5PXLvnHJH+CSOHfgxApWMSIHUQAcz+38HnR24H/q758d2f39vhsOLIjF3NK1lXnxtH2YkbALi7qYkSz0L+Fl9LRtwRJqZ/hMdlxxJjPMfBozdxrn5Uu+dMHnKUif7bzjofJRvrO2zzpBtiSRppfEyd2esicZSZ2CQZrhQGCWCiS001PjYsK+f+l4eRMcUGwKf5dZS+235QyLzGHhTAhvD2Rz/u8NxJCSeMAOZT2FQT7x/4Jh/u+zYA84BdGItwx8eebRXA3v/4Ueoa2q/MceXsZ5oDmNOVBIDddq4Hr3hgssfUtPv4e7uW0+hMbXfbvKyVzQHsbNX05v/LeOBy4D1+iMXcyN/fcQ3KpMAfwD7Z/zWOnLq23XNOHvfX5gDWVOPj7Z85Omxz6gQLSSMtNNZ4+fytBrxuuP57yV29VDFISAATXWqo8uLzwOYfVvG19UbQmHhtyzfjttImtaRVWy2NZE1b2+G5kxKM3hceK0qByVbPhIvy+bPzOq6wfspUy1EAbNbaVsddPHk9Tldiu+ccmf5x8+0RGcVkT/8N0ydK3b5RQ4u4Jvun5w0hXjLlDx32Zoelf9p8O3nI0eb/Sx+woWk+GaYqbrDtoqpuHMOS9xnDiAomjX2L1KSyds+ZkboXeAgAW7wi696EDtucONx4jx15v4mSjfWMmXNhw59iYJFSUqJLX3zm5PdfOcvwGdbmANZt3S0lVR8HKIivZ1Xd/axuvIcdaV8jzSQ9p/7q3+qWsa7xForSvkqizwWNcRBbDxZv1wf3sJRU6bZGXv37CjLn2bnnWVm0ti9IKSkxILnqjQ8bW0IfvV18CnzG5GWtYZPzGq62fiLBq5+7M2YbLmxGtRSzByMbsW8mNcf433vOel+fnF9EJwlgokvOWuNDwxbfR2+XwIee1U2RZzrHfcO5y76tb55LhMylls8Za/qCPzXd4M9GdPdZNqIt3ujJu+oG1oiRuDBhD2BKqTylVK5Sankn+2T19BjRdwI9sJiEXlSW7w6PFUweMGlebppPgmpgQcz7ffNcImSUgjz7Vt53z+a4d6i/tJTyT4cIrUDv31knPTDRIqwBLBCYtNYFgKNtoPLvkws815NjRN8KfGj0yRCi11/FweqhzhfL601zuSNmO3FK5m1Fg3vsW1H4yG/KNarTK1+f1EYMfHmSHpgIFu4e2BLA4b9dBuS23cEfqKp6cozoW/FpZkbnxJA6vg+SVj0WQIPFzV+dc2kgljx7QeifR/SJUeZy5lo/Ib8pFx/KP6k59Eus2OJNJI+xkDxWEqdFi3C/G5JpHZzS+ugYEUJTF8QxdUH7adYXRGN8Wzd7/cOHuUw0HyfLsj/0zyX6zGL7Fh6pXcEH7kuYaykBt80IYtb2J7r3htmq+NYbI0J2PjEwSBKHiByff/jQ4qbUM4oizwwW27eg+uhSm+gb82P+RqKq4+Wm+X06jChEW+EOYA4gMOU/GagMxTFKqWVKqSKlVFF5efkFN1K05qz14W70EfI5gx4rxvChhw1NuZjxcrf97dA+h+hzduVmYcy7bHZeRY2O92cj9s1KzVprtE+ugwlDuAPYeiDTfzsTKABQSiX39JhgWus1WuscrXVORoZMcgy111ZU8syckx2WjuoVjZE+b/biUYpXnTdwva2IoSZH6J5DhM1i+xZc2IwCv1YPRjZiaHthf/j6WZ6edYIze90hPa+IXmENYFrrYmjONHQE7gNbA/sopfKAHP/Pzo4RYdI8kTk+hGN7PpOxjpTVzTZXNmd9aSyybwnd+UVYzbCUMs1cxvqmm8HkH0YM8RIrSoH2yWRm0SLsKT1a6zXtPJYddDsfyO/qGBE+gTT6mCEh/L7jDgwfuvldzW0MNVVyg21n6M4vwkop+Ersm/xr3cN87JnCpdaj4LIZVVZMoRnyszWn0ksAEwZJ4hBdctWHuBJHIPvQ4qHMO5Jt7hzus7+BVXWjhp7ot74U8zYJqoHfNt7hX+gytJOam8tJyVww4ScBTHQpMHk0ZJU4vGZj+NDi5ndNt2PFzVdiN4fm3CJiEkyN5NkLeN05l7MMMYYSQ3gdLDCR3iVDiMJPApjolNY69JU4/NmHdSYr+U253B7zniRvDBBft7+GGyvrmm41JjV7zcYwYgjESD1E0YYEMNEprwt8HjBbwWILwQeRxhhWsnh4xXUjdTqOr8e+duHnFf3CBMsprrMV8VLTAlwWH6EcRrRJRXrRhtRlEZ1SJrjrmTS8rhB96/UPH/osTn5bezuzLJ8z23ogNOcW/cLX7ZtYeu7HvOG+irtMRUbCju3CU9/HX2XHFq8YPtMWglaKgUACmOiU2aqYkhvCMlL+4cNC3wzKvKN5ZshToTu36BeutRUzwXySFxrv4K64D8FlD0k24vAZNobPkOAlWsgQogifwORli5v/a1pIuqrm1pjCSLdKhJhJae63v8bHnqnsYbTxoJSWEn1AApjoVPUxDx+uPseBLQ0XfjKvBVAcUem868rhgdhN2FToCr6K/mORvYAkVcszTV8xshFDsFJzQ5WXko31fB6K96IYECSAiU5Vlrop/GUNJRvrL/xkbivg4+fOexmi6rhfkjcGrARTI0tj/8IW15WcMQ8xijb7Luzj5twXXt54ooq/rTkXolaKaCcBTHQqZCn0/uxDh9nO665reCD2NRJN8k16IHsgdhMJqoH/5/oSoC+4tJQsainakgAmOtVSheMCU+g9xvDh7z3zicP4di4GtmRTHV+zv8465y00miwXfB0sUAlGJjKLAAlgolMtVTgu8K3iseJB8YxzMV+N/SupJhkGGgwejNtIDC7+6r3MGEb09v591FwLsV56YMIgAUx0KiR1EP3Dhx9xESY034z7U2gaJ/q9dFMN98ZuZqXzPmN5sAvohVliFCYLeJwar1uCmJAAJrrgrA9BHUSPFVA841zEV+xvStmoQWZZ7J9wMISDjDASeXoZe5RSMowoWpEAJjplMkNMorqwpVTcFqp0Anv0OB6Oy+96fzGgDDdX8tXY1/mN+zajiPMFZCPGJBi9MBlGFCCVOEQXbliRwg0rUnp/Ag0+r5WXvdfxzbiNDDdXhq5xImo8Eree25uewaNNWC5gTtg3No3AbDV6Y0JID0z0Ke22YgLe883gobhXI90cESEpploeiHuNd3yzaXLHga93Q4AWm5LgJZpJABN9qtKVTplvOLfHbiNeNUW6OSKC7o/dxAd6Gna8eI99FOnmiAEg7AFMKZWnlMpVSi3v7nal1Er/z2Xhaqcw/P6+M6y55RQ1J3te8snlOE2Kr4EP9TQWxRb0QetENIlRHnLsn9KkrZS9+7teneP9/6nhhS+d5tA7jSFunYhGYQ1gSqksAK11AeAI3O/G9mVKqVKgLJztFVBzwkPNCS/mnq4F5m7i6B//GbPSTI4pxaIka0zArfb32aUnM+zIn6k/9H6Pj6+r8FJ+wE1dubcPWieiTbh7YEsAh/92GZDbze2LtNYT/YFNhFEg26tHlTiqj+J8bj6TT7/Oa/oy5thL+qh1ItooBan2s1TpBOy/vwM+/DXo7mcUxgTS6OvkC5EIfwBLBqqC7qd1c3tWZ8OOom943RpPk0aZwBrbzQB24E306mvwlJfyiP4e2fEfI9fcRbBpMWWsn/0iBd5L4c3HYcPXoal7lVmkGocIFhVJHFrrVf7eV5pSqm2vDaXUMqVUkVKqqLy8PAItHJhcDYFCvt3I/PJ5Yet/wLrFOGzDWdD0JJct+BojJG1etOOR27L5j/h/YbXt6+h9r8Fz18OZPV0eF+iBOaUHJgh/AHMAqf7byUDbT7fztvuTOvL8j1UCmW1PqrVeo7XO0VrnZGRkhLjJg1dzHcSuykjVnYUXF8J7T9F48Ve5+dwTDB83jfsuG9v3jRRRKc5m4T+/dAk/PXczf5z+P+CsheduhE/+0OlxLT0wCWAi/AFsPS0BKBMoAFBKJXeyvSywHzARKApHQ0U3l1I5+iGsvgaO70Df9T/8U8M3cHgs/PSeizGZZOxQdOyaKRnkZY/miY+T2Hfn6zA6BzZ+GzZ9F9ztT7kIvBedsqSKIMwBTGtdDOAfBnQE7gNbO9ruf2yxvxdWGnSM6GNxKWau/vtEZuXFn79Ra/jgV/DCbWCNhW8W8LvGuWzec5pH509hYkZC+Bssos4Tt01j6JAYHtp4gnOLN8Dcf4JdL8D/3QTVR87bP2WshUsWxTPhanvY2yr6H6V7kAEUDXJycnRRkXTS+lTTOfjz38O+v8DU22Hhr9ldrsn73w+4ZnIGz92f09L7elp6YaIdj7Z87uw6WsWS1X8jd9ownv1qFurzN+BP3wYF3L0GLrolcu0cRJRSu7TWOZFuR09ERRKH6EfO7IE118H+1+GmJ2HJ76nxxfF3LxUzdIidpxfPkqFD0SPZ41L5/oKpbN5zmrXvH4Gpt8JD2yB5HPxhCRT8GLw9n0gvBj4JYKJD1UfdHHqnkarDbuOBT9YZF9pd9fDAa3DVI/g0PLphN2drm/jVvZeSHGeLbKNFVHpw7gTmTx/Gf/51H8XHqiF1Ajy4BbK+DoW/MJKE6s7i82hO73FxotgZ6SaLfkACmOjQwbcb+dMjFXy2oQL+8ghsfNi40P7Qdhh3FQA/27yfgn1n+Jdbp3Hp2AuoWi8GNaUUT+XNYkSynWW/K+JoZT1Y7XDn/4OFz8KJIvjfeXhL3+fFJWfI/7ZMlxESwEQnXPWapPjjZLvyoPh3MPef4WsbYcgwAJ5/r4w128u4/8pxPHDV+Ii2VUS/pDgrax+4DK9Pc///7aC81t/Lmn0vfLMAbPFY/ngnOVNewN3gw+cdWNfvRc9JABMdGlLzFvffuAS77zh8ZT3k/gjMxhJyGz8+yZOv7+PWi4fzoztmyBIXIiQmDU3gNw/M4cy5Jpa+sIM6p//a1/CZsOwd1NRbuf6Sp7jryn/EVeWIaFtF5EkAE+fzeqDg35jl/iaO+tEcnLy5VSbY2/vP8NiG3VyRmcovFs/GLEkbIoSyxqbw6/uy2PdFLQ+9WESjy1+4154Ei1/kg7IVTBrxLtYXb4DTn0W2sSKiJICJ1mrPGBfMC/+LI84vs+6dFzGljm/e/OdPTrLsd7uYOmIIa+7PwW41R6ypYuC6YeowVt1zCR+UVvK133xETYM/kUgp9tcs5Y/b1oK7AZ7PhY9fimxjRcRIABMtjrxvVNU4UQQL/5cdFf+B1xfTXL7nhfcP890/fkL2uBT+8K0rSLT3fml4IbpyT/ZofvWVLHafcLBkzYecOWdU57DFmzhZmcXZawpgzGXw578zkozcskbYYCMBTBhVNd7/b/jtHWCLh29thdlfaa74bYlT/PzN/fzbpr3cNH0Yv/3GZQyR4CXC4LZLRrD2gcs4VtXAPc9+wKGztc1L+zR5042konmPGklGv5kPVbJk4GAilTgGu0aHUVVj/2sw/S6481dgTwSMgqlfnGniibc+470jFXx5zhieXDgTi7kH33ukEodoz6M9+9zZfdzBN17YSYPLy79dPYPcKcNJHGHGGut/Lx54E15dZnwZu/tZmHpbHzR6YIvGShwSwAayroKH1wSNcaAVxDjB6jLK9/j9zTWT79R+jxpfAj9OWM0S+1uytpeImDPeVB6p/R473BfzZfub/FvCauzK1bKDTxnvZ58ZbE7jX1fv1x4G0oEsGgOYDCEOVm4rNPiL9MY2gK0leNX6Yvlx3be4t+YnJKhGNqY8ypdjJXiJyBpmrmJd0g/4+7j1/LHpZm6t/n+875rVsoNJQ1y98UXMFeMPZvKmHcgskW6ACDMNOO3gtoHZA/ZG4w8fY/TlNec8/qP+m5R7U1i2I5nJ9gqm3ngkok0WIsCifHyp6hTph6p4M3UU9438CXfGvMsTCc8z1OQwvoTZm8DshSa78SXN3ggWb6SbLvqA9MAGE58y/qDdNmN4JbYBTBqtYZsrizzHKh6pXcEwUxX58T/EUj6eE19cKT0v0a9U1WRSceQ6HnQW8Z24dWx2Xs31VWtYVXc/VT7j+i1Wt9EbQxs9MafN+PImBhQJYIOF2wL1CeAzGYErxokHE286r2Ch4xd8vebf+cKXzk8SfsXG5EeZwhkAYmx1EW64EK3ZrMZ70ueO45/j1/Fmyt9zva2IZxvzuLry//jPuqWc9GaA2Qfx9WDxgMsOTbESxAYYGUIc6DTgjAF3DJi8ENvAYd8IXq6bzyvOGzjrS2OM6TQ/Tfgl99i3YlNG6R6newgANmttBBsvxPli/AHM6TIWTZ1gOcWvElfxj551/KphCc83LuS5xruZa/2EJfa3mB/zN2LMXuPvoD7B+AJn9kXyJYgQGXgBrPZ4ZJ//nX80fl7/TCRbYbTDp4xvnV4LFeZYXvJdz2bHVezzZmLCyw22Ihbbf831tiKsqvU1Apf/wyHwYSFEf2GzGV+qAl+yAiZZTvBM4tM85v0dG5rms6Epl3+o/T4JqoFrbUUstrzNPN/nmBriIaYJbG7j7ySSf6v96PNiXApjItuIngt7AFNK5QEOIEtrvao727s6RgA+H7hqodFBXU0FXxw+y6j6NMzax489X2Nd03xMeMmx7uUH9t9wZ8w2hpmrOjyd020EMJsMIYp+JjCEGPiS1dZoczn/FL+O78T9kUL3bDY7r6LAdRmvO68hDQfP2Z4my1nKMdcoLGdqGH5mP6a4FIhNBktMGF+JuFBhDWBKqSwArXWBUipTKZWltS7ubHtgW0fHDChBQYgmh/Gzsbrltv+nbnLgra/GU1+NbqzG5KzB6q7FhDEskgBMBkp9I/iJ9ytkWCv5RdzTXG8rIsXUvSFBlwwhin4qxv+edLXpgbVlVj6utRVzra2Yn2jFp57JbHNl8V/uhVzpOcDfWTbB/leNf35uUwweWxLYkzHHp2KJT8EU6w9u9uTOf0rwC7tw98CWAFv8t8uAXKC4i+1pXRzTittp5eTH7a/Wmj7JSswQI2+l5qSHujOBZcp1q58WGwybZmu+f+rTJrQP0BqNBozMPYUmYZiZ+KEmfFrTUOnBcSADY3L4fkxuB8rlQLmqMblriE85h8lZA40OPJXVqKYaLJ4azJ4arJ5zWL3nUHQ8Nu/RZupJoMabwDlfPLW+BCrMo6lSF1FvSiDGnEa8NYOEIekkNxwgteJD/kNtAjdYzE5S0luC0amzl6J1+zk8iQkniI8tZ8r41xmZMTC/K4joFWt3MDKjiOTEowCcrrgYr7f9lcAT4k+TlHASk9JM9Z0mo+4geRzEi6Ko6TIcKbM5Zx9NQ20ldaock6uGJFc96TWNJFPHENNpksz1DFH1xKmGTtvlUXY8lkQ8liQ8liS8lmRUcjLmxGSwp+DyJNLkTMRnTQZrEj5bCvpgMigr5oQKhs+woZQJpeDsfjfaDYEUYBXIt1OKhKFmkkYapdyaajWVpW5aUoVb/xw2IwZLjHG76rCbRkf7ny+xZ6NzMdpwB7BkIHjcKq0b27s6phWr6zQj/jTCuKOMAKT8gUiplhSkJP+/7hjZzf1igOa3wemft7uPW5upIR5fQzKepmSa3Ek0ucbS5EqkyZ2I05XIkXgLH45t4pyOw9oYy9XvX06TKwm3N5a2pQUuyV3OzSO3MNRUxbad/0LRnvv8W24GHmneLyWxjG/ec13z/ZfffAm3p/0hmGtznuSyi9cwetjObr5yIcInIe4M993+peb7f3nnWWrqxra77+UX/w/X5KwE4HTFLDa81XHl+m/lXU1M8lmOeYez/d1VOI5f2Wq7Uh7s1lpqhx2nePZe4pSbNE8jC/YnYrfVYLedI8Z6DrvtHHbrOey24+j43VgtdQxRXRQafn0VvN5yd1QXv4MAe1f7/qXlZiqgtfH5oQOfI833o1NYS0kppVYDq7XWxUqpXGC+1npFZ9sxAliHx/iPWwYsA7CZucTl5dMwvaTzjEthTK2T2KoGDkSqDYF2ABytJiRZLSnW0a0u8Fa7T3R53v72uzhXNxroXts7Evg99PQcYxJGTq9z15urnTU9WsCqt8/X0XkSE04AoXtf9EZP3hfBrz9Uv4vgdkD0/C76uh0V9STWOXVsJNvRU+HugTkwvgiAEZgqu7m9s2PQWq8B1oSqkRdKKVUUbTXF+or8LlrI76KF/C5ayO+i98IdwNYDgf+oTKAAQCmVrLV2dLS9g8eEEEIMYmGtxBHIHvQPBTqCsgm3drS9k2OEEEIMYmGfB+Yf7mv7WHYX2/vN8GA3RVt7+5L8LlrI76KF/C5ayO+ilwbcemD9lVJquUzCFkK0Rz4femfglZLqh/zDn3Mi3Y5I82eLAkxsm0k60Ek1mRaD+X3QHvl86D2pRi/Cwv9HWuAfDs703x8UgivMAI7gCjODzWB+H4jQkwDWx/ylryRz0sggDXxYlfnvDxZLMHpf0FJNZrAazO+D88jnw4WRIcS+l9r1LgNfm0ScLIwpE4NFMj2oJjOQDfL3QXvk8+ECSAC7QEHj+cHK/MWH5dtVG/7hsy0yHWJwk/eB9L5CQQLYBeoixT9TKZUZdHvgVtKn82AedD93ECYxOOiimswgNBjfB20Nqs+HviABrA9prfOh+YM9ObKt6XtdzddTSi0LWuMtdxB9++yowsygNIjfB60Mts+HviDzwERY+LPNNmBcC0oFFg2mDy7/h1QZkBmFE/NDZrC/D0RoSQATQggRlSSNXgghRFSSACaEECIqSQATQggRlSSACSGEiEoSwIQQQkQlCWBCCCGikgQwIYQQUUkCmBBCiKgkAUwIIURUkgAmRBgopbKUUqVKqQ1B95Mj3CwhopoEMCHCIxfIBlYHqvZrrR0RbZEQUU5qIQoRRv5eV6rWuizSbREi2kkAEyJMAkOG0vMSIjRkCFGIMAgsXBgIXkELGQohekkWtBSijymlsjAWtKxSShVgXA9zYKwPJoToJemBCdGHgoYN12CsxnwYmCOLOApx4eQamBBCiKgkPTAhhBBRSQKYEEKIqCQBTAghRFSSACaEECIqSQATQggRlSSACSGEiEoSwIQQQkQlCWBCCCGikgQwIYQQUen/AzyO77rhKDGgAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig, axes = qp.plotting.plot_native(norm_dist1, xlim=(-5., 5.), label=\"norm\")\n",
     "qp.plotting.plot_native(hist_dist1, axes=axes)\n",
@@ -1298,18 +480,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This object represents 2 pdfs\n",
-      "The input and output shapes are: (51,) (2, 51)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is a trivial extension, with the number of pdfs as a member of the `scipy.stats.norm_gen` distribution.\n",
     "loc = np.array([[0],[1]])\n",
@@ -1323,40 +496,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "For an input vector of shape (51,) the output shape is (2, 51)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print (\"For an input vector of shape %s the output shape is %s\" % (xvals.shape, yvals.shape))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.39894228, 0.24197072, 0.05399097],\n",
-       "       [0.35206533, 0.35206533, 0.1295176 ]])"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# In this case we return an array were the rows are the evaluation points and the columns the different PDFs\n",
     "vector_pdf = qp.stats.norm(loc=[0., 1., 2], scale=1.)\n",
@@ -1365,21 +518,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.39894228, 0.24197072, 0.05399097],\n",
-       "       [0.35206533, 0.35206533, 0.1295176 ]])"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is the same, except we use `numpy.expand_dims` to shape the input array of evaluation points\n",
     "vector_pdf = qp.stats.norm(loc=[0., 1., 2], scale=1.)\n",
@@ -1388,22 +529,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.39894228, 0.35206533],\n",
-       "       [0.24197072, 0.35206533],\n",
-       "       [0.05399097, 0.1295176 ]])"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# In this case we return an array were the rows are pdfs and the columns the evaluation points\n",
     "vector_pdf = qp.stats.norm(loc=[[0.], [1.], [2]], scale=1.)\n",
@@ -1412,22 +540,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.39894228, 0.35206533],\n",
-       "       [0.24197072, 0.35206533],\n",
-       "       [0.05399097, 0.1295176 ]])"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is the same, except we use `numpy.expand_dims` to shape the input array of pdf parameters\n",
     "vector_pdf = qp.stats.norm(loc=np.expand_dims([0., 1., 2], -1), scale=1.)\n",
@@ -1443,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1465,29 +580,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The shapes are:  (51,) (100, 51)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEJCAYAAACUk1DVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAleUlEQVR4nO3dd3Sc1Z038O+dGfUujYotWZZV3bBBkg1YuCIMC2RDwOBsOkkwqezZvBuSN2VPztkUQnb33WRzAphsypJCMSEJSwnINrLlLssYN1ldlixLGpVRL1Pu+8c8Y8uybLWZ5075fs7x0cw8o5kfYma+89z7PL8rpJQgIiIyqC6AiIh8AwOBiIgAMBCIiEjDQCAiIgAMBCIi0phUFzAfZrNZZmVlqS6DiMivHD9+vEtKmTz5dr8OhKysLFRWVqoug4jIrwghmqe6nUNGREQEgIFAREQaBgIREQFgIBARkYaBQEREABgIRESkYSAQEREAPz8Pgcib+kZs+OvJNgBA8eIE5KfGwGgQiqsi8h4GAtEktR0D+M3BJrx24iKGxx2Xb48JM2HT0hR8/4GViIsIUVghkXcwEIgmeKWyBU+++gFCjAZ8ePVCfHpdFmLDQ1DZ3INjTb3YdbwF1Zf68ZvPrkV6fITqcok8SvjzimnFxcWSrSvIU946dQlf/kMVSnLN+OlHb0FiVOg19zlY14XHXziOiFAjfv3oGqxYGKegUqL5EUIcl1IWT76dk8pEAMprLHjixRO4JTMBz32yaMowAIB1uWbs+uI6GA0Cjzx7CKda+3SulMh7GAgU9Kou9OLxFyqRmxKDX31mDSJDbzySWpAWg9e+VIKY8BB87eX3MWpz3PD+RP5C90AQQmwTQpQKIZ6c5n433E7kCWN2B/755ZNIjgnD/3x27Ywni9PiwvGjh25Cbecgfrq71stVEulD10AQQhQCgJSyDIDVfX2K+5UCWKNnbRSc/ruiEQ1dQ/jXD69EckzYrH53c0EKHinOwHPl9Xi/xeqdAol0pPcewnYAVu1yA4BSnZ+f6LI26wj+a3cdti5PxaaClDk9xnfuX47U2HD88ysnOXREfk/vQIgH0DPhetLkOwghCrU9CCKv+v4bZ+GUEt+9f/mcHyM2PARPPbQKdZ2D+PmeOg9WR6Q/X5xUTlRdAAW+itouvHmqHV/ZnItFiZHzeqyN+cn40OqF+NWBRvQOjXuoQiL96R0IVlz5wI8H0D1x40z2DoQQO4QQlUKISovF4pUiKbA5nRLfe/0MFidF4rEN2R55zCe25GJ43IFfH2j0yOMRqaB3ILwEwP0OzAZQBgBCiHj3bdpRSNu0y9dMOkspd0opi6WUxcnJ16wRTTStsnMdqOscxP/ZWoDwEKNHHjMvNQZ/tzINvz7YhP5Rm0cek0hvugaClLIKuHwUkdV9HcBubfsuKeUuuPYi4vWsjYLHL/c3Ij0+AveuTPPo4355cy4GRu144dCU65cT+Tzd5xC0b/hlUsqdE24rmuI+ORMCg8gjTrZYcbSpB4+WZMFk9OzLf2V6HDYXJOOX+xswPG736GMT6cEXJ5WJvOb5/Q2ICTNh+5pFXnn8r2zJQ++wDX84csErj0/kTQwEChqtvcN463Q7/uHWTMSEe6d9ddHiBKzLScJz+xowbnd65TmIvIWBQEHj1weaIAB8Zl2WV5/nsfXZsAyMYfe5Dq8+D5GnMRAoKPSP2vDSsRbcv2oBFnp5HYMN+clYEBeOF4+1ePV5iDyNgUBB4S/vt2FwzI7P3rHE689lNAg8XJSBfbUWtFlHvP58RJ7CQKCg8OrxVixNi8FN6fosaPNwsWvS+pXKVl2ej8gTGAgU8Ootg3i/xYqHCjMghNDlORclRqIkx4yXK1vgdPrvqoQUXBgIFPD+VNUKgwA+fPNCXZ93+5pFuGgdwYH6Ll2fl2iuGAgU0JxOideqLmJDfjJSYsN1fe6tK1IRHxnCyWXyGwwECmiHGrrR1jeKhwozdH/uMJMRD96SgXfOtKOHXVDJDzAQKKC9WtWKmHAT7lqequT5t69ZBJtD4vWTbUqen2g2GAgUsIbG7Hj7dDvuX7XAY11NZ6sgLQYFqTF444NLSp6faDYYCBSw3jrdjuFxh5LhoonuvWkBjjX3oLN/VGkdRNNhIFDA+uvJNixKjEDR4gSlddy3Kg1SugKKyJcxECgg9Y3YcLCuC/euXKDbuQfXk5vCYSPyDwwECki7z3XA7pS4x8OL4MyVe9iog8NG5MMYCBSQ3j7djrTYcKzOiFddCoAJw0anuJdAvouBQAFnaMyO8hoL7lmZBoNB7XCRm3vY6M1TnEcg38VAoIBTXmPBmN2Ju1f4xnCRG4eNyNcxECjgvHW6HUlRoVi7JFF1KVfhsBH5OgYCBZRRmwN7znXgruWpMPrIcJHb5WEjHn5KPoqBQAHlQF0XhsYdPnN00WR3LU/F8eZeWIfZ24h8DwOBAsrbp9sRE27Cuhyz6lKmdOeyFDicEuU1FtWlEF2DgUABw+5wouxcB+5cmoJQk2++tFdnxMMcHYqyc52qSyG6hm++a4jm4ESLFb3DNty13DeHiwDAYBDYXJCC9853wuZwqi6H6CoMBAoYe6o7YTIIrM/3zeEitzuXpWJg1I5jTT2qSyG6CgOBAsbe6k4UZyUgNjxEdSk3tD7PjFCjAbs5bEQ+hoFAAeGidQTV7QPYsjRFdSnTigoz4facJOw+1wEppepyiC5jIFBA2Fvt+rbtD4EAAKXLUtDUPYx6y5DqUoguYyBQQNhb3YlFiRHISY5WXcqMbFnmWtJz97kOxZUQXcFAIL83anPgQH0XthSkKF/7YKbS4yOwbEEs5xHIpzAQyO8daujGqM2JzX4yXORWuiwFlc09PGuZfAYDgfze3upORIQYcVt2kupSZmVTQQqcEqio61JdChEABgL5OSkl9lR3oiQ3CeEhRtXlzMrqjDjEhptQfp5tLMg3MBDIr9V1DqK1d8TvhosAwGQ0YH1eMvbVWnj4KfkEBgL5NXeTuE0F/hcIALAxPxkd/WM43zGguhQiBgL5t/IaC3JTopEeH6G6lDlxt9ngsBH5AgYC+a1RmwNHG3uwIS9ZdSlztiAuAgWpMdhXy0Ag9RgI5LeONvZgzO70+WZ209mQb8axxl4MjdlVl0JBTvdAEEJsE0KUCiGevM72Uu3fj/WujfzLvhoLQk0G3LbEvw43nWxjfgrGHU4cbuhWXQoFOV0DQQhRCABSyjIAVvf1Sdvv0rYXTt5ONNH+2i6szUpERKh/HW46WXFWAiJCjNjHVdRIMb33ELYDsGqXGwCUTtwopaySUn5Du5otpazSsTbyI+19ozjfMYD1ef49XAQA4SFG3JadyGU1STm9AyEewMRVQabc19eGkx7XoyDyT+5J2A35/juhPNHG/GQ0dQ+juZvdT0kdn5xUllI+DeBxIUT85G1CiB1CiEohRKXFwm9UwWp/bReSY8KwNC1GdSke4Q42DhuRSnoHghVAonY5HsBVs2hCiInzBg0Adkx+ACnlTillsZSyODk5ML4d0uw4nBIVtRaszzP7TXfT6SwxRyE9PgL7a9nXiNTROxBeApCtXc4GUAYAE/YESnF1YDToWBv5idMX+9A7bMPGABkuAgAhBNbnmXGovht2h1N1ORSkdA0E9ySxEKIUgHXCpPFu7edOANlCiG3a/XfpWR/5h/3a/MEduf4/oTzRHXlmDIzZcbK1T3UpFKRMej+hlHLnFLcVaT+tcIUCADAMaEr7aruwMj0WSdFhqkvxqJIcM4QAKmq7ULQ4QXU5FIR8clKZ6HqGxuw4caEXd+QGznCRW0JUKFYujENFHSeWSQ0GAvmVo009sDlkwA0XuZXkmnHighWDbGNBCjAQyK9U1HYh1GRAcVZgDqmszzPD7pQ4wjYWpAADgfzKgTpXuwp/Wx1tpooWJyDMZODhp6QEA4H8RufAKKrbB1ASoMNFgKuNxdoliVxnmZRgIJDfOFjnGkYJ1PkDt/V5ZtR1DuJS34jqUijIMBDIb1TUdSE+MgQrFsaqLsWr3EdQHajjPALpi4FAfkFKiQN1XSjJMcNgCIx2FdezNC0G5uhQVHAVNdIZA4H8Qr1lCJf6RgN6/sDNYBAoyTWjoq4bUkrV5VAQYSCQXzigTbIG+vyBW0muGV2DY6jpGFRdCgURBgL5hYq6LmQmRiIzKVJ1Kbpw7wnxaCPSEwOBfJ7d4cTh+m6U5Pr32smzkR4fgSXmqMt7RkR6YCCQzzvZ2oeBMXtA9i+6kZLcJBxp6IaN7bBJJwwE8nkH6rogBHB7TvDsIQCu+ZKhcQdOtlhVl0JBgoFAPu9AXRdWLIxFYlSo6lJ0dXu21g6bw0akEwYC+bThcTuqLvQGxeGmk8VFhmBVehznEUg3DATyaUcbA7vd9XTWae2wh9gOm3TAQCCfdqDO1e56TVbi9HcOQHfkutphH23sUV0KBQEGAvm0irpuFC9OCNh219Nxt8PmPALpgYFAPqtrcAznLvUH5fyBW3iIEWuyEjmPQLpgIJDPOlgfHO2up1OSa0Z1+wA6B0ZVl0IBjoFAPutAbRdiw01YmR6nuhSl3IF4qJ7tsMm7GAjkk6SUqKjrwu05STAGeLvr6SxfGIv4yBAuq0lex0Agn9TcPYyL1pGgHy4CAKNBoCTHjAN1XWyHTV5lmu0vCCGyABQCSAQQD6ABgFVKucejlVFQcx9VE8wTyhOV5JrxxqlLqLcMITclWnU5FKBmvIcghPi6EOIdAD8GkANAAOjTLm8VQrwjhHhGCHGzVyqloFJR23W54yddmUfg0UbkTdPuIQghlgB4HMCLUsqfTHPfOAA7hBDFUspfeqhGCjIOp8TB+i7cszINQgT3/IFbZlIkMhMjsb+2C59el6W6HApQN9xD0MLgTinlN6WU70/3YFLKPi00dgshPu+hGinInLrYh/5RO+7IC65219MpyTXjcEM37GyHTV5yw0CQUjbO5Zv+XH+PCMDlxeVLgqzd9XTuyDVjcMyOk619qkuhADXro4yEELHeKITIbX+tq911UnSY6lJ8yrqcJFc7bB5+Sl4yl8NOcyZOHAshlgghtniuJApmQ2Oudtd35PHooskSokKxciHbYZP3zDoQpJQnAKzRDj+FlLIRQIIQ4kcero2CULC3u55OSa4ZVRd6Mch22OQFcxkyeglAPYDeCcNHZQB2eLIwCk4VQd7uejrr89ztsNnGgjxvLkNGRQAqpZR9AIR2qGkpgKc8WhkFpYraLqzNSgzadtfTcbfD3lfDYSPyvLkEwsPQ9ga0UEgEkDDdOQpE0+nsH8X5jgHOH9xAeIgRt2YnYb92JBaRJ81pDkFK+W8TrjcCOM4zlGm+3O0qOH9wYxvyzKi3DOGidUR1KRRgPNLcTptobvTEY1HwqqjrQmJUKJYv4JHNN7JeO2GvgnsJ5GEe63aqDR8RzYmUEvtru1CSa4YhyNtdTyc/NRqpsWGcRyCPm7Z1xVxaUNzo94QQ24QQpUKIJ6+zfYf278ezfV7yX+cuDcAyMIYNnD+YlhAC6/OSUVHXBYeT7bDJc6ZtXQFXX6JnZ3LymRAiVgjxdbj6H13TukIIUag9bhkAq/v6hO2lAMqklDsBZGvXKQiU17iGPzbms3/RTGzIT0bfiA0ftFpVl0IBZNpup1oofEEI8ZgQ4psAJIAqAO4DoZPgWhchB67zE57Wfmcq2wG8q11ugOtw1aoJ27O1fzu17dmz+Y8h/7WvxoKlaTFIiQ1XXYpfuCPXDCFcbT5uyUxQXQ4FiBkvkCOlfB7A89p5B8VwhUAiXJPJDdrE8nTiAfRMuH5V9zJtz8CtEMBLM62P/NfQmB2VzT34bMkS1aX4jUStjcX+WgueuDNPdTkUIGa9Ypo2ebzbC7Vcpg0lvSulrJpi2w5o50FkZmZ6swzSyeGGbtgcEhs4XDQrG/LNeLa8Af2jNsSGh6guhwLAnI4yEkJ8Xlsd7fOz7H5qhWuvAnDtLVzv/PtSKeXTU22QUu6UUhZLKYuTk/kBEgjKayyICDGiOItDH7OxPi8ZDqfEoXq2sSDPmEsvo6cA5MK1fOYjABqFEJ+b4a+/hCvzAtlw9UCCECJ+wuPvcIcBJ5WDw74aC27PSUKYie0qZqMwMwFRoUbsq+H5COQZc9lDOKatoPZNKeVWuCaT84QQD073i+4hIO2D3jphSGj3hNt/LISoF0L0zqE28jMXuofR1D3Mw03nINRkwO05SSivsUBKHn5K8zfrOYTJpJRWAN8UQjw2w/vvnOK2Iu1nGQCOGwSRcu1sW84fzM2mghSUnetEvWUIuSnRqsshPzeXPYQGIcQxIcTmSfMHHMikWSs/b0FGQgSWmKNUl+KXNhW4gvS9852KK6FAMJdA2A7gZQBfBNCkhcPf4DqRLAYAZjJ8RDRud+JQfRc25idDCLarmIuMhEjkpUTjvfOcR6D5m0sg1AN4RUr5iJQyEa5DQMsAbAXQLISoBcC2EzStyqYeDI07eHbyPG1emoIjjd0Y4ipqNE9zaX/9PFxLZmZp109IKX8ipdyqBcR2sPMpzcCe6k6EGg0oYbvredlUkAybQ3KtZZq3OZ2HoIVA03W2VQH4xnyKouCw53wnbs1ORFTYvI9tCGrFixMRFWrEezz8lObJY+2vJ5phGwsKYk1dQ2iwDOHOpSmqS/F7oSYD7sgz473qTh5+SvPilUAgms6eatdRMVuWpiquJDBsLkhBW98oajoGVZdCfoyBQErsPd+JnOQoZCZFqi4lIGwqcO1p7eXhpzQPDATS3dCYHUcaerCFw0UekxYXjqVpMTwfgeaFgUC6q6jrwrjDic0MBI/avDQFlU296B+1qS6F/BQDgXS3t7oTMWEmrMlKnP7ONGNblqbA7pQo50lqNEcMBNKVlBJ7z3difb4ZIUa+/DypMDMBiVGhKDvXoboU8lN8R5KuzrT1o6N/DJsLOFzkaUaDwJalKdhb3Qmbw6m6HPJDDATS1e5znRDiylEx5Fl3LU9F/6gdRxt7pr8z0SQMBNLVO2fbUZSZgOSYMNWlBKT1eWaEmQx49yyHjWj2GAikm5aeYZxp68fWFTwZzVsiQ024I9eMd8928KxlmjUGAunG/a116/I0xZUEtruWp+KidQTnLg2oLoX8DAOBdPO3M+0oSI1BFhfD8ao7l6VCCPBoI5o1BgLpomdoHMeaejhcpIPkmDDcsiie8wg0awwE0kXZuQ44JXD3Cg4X6aF0eSpOXezDpb4R1aWQH2EgkC7eOdOB9PgIrFgYO/2dad62LnftiZVxL4FmgYFAXjc8bsf+WgvuWp7KtZN1kpMcjezkKLx5ql11KeRHGAjkdftqLBizOzl/oCMhBO6/aQGONHbDMjCmuhzyEwwE8rq/nelAfGQI1rKZna7uXbUATgm8fYZ7CTQzDATyqlGbA++e7cBdy1JhYjM7XRWkxiAnOQpvfnBJdSnkJ/gOJa9677wFg2N2fGj1QtWlBB0hBO7jsBHNAgOBvOp/P2hDYlQo1uUkqS4lKHHYiGaDgUBeMzxux+5znbj3pjQOFynCYSOaDb5LyWvKznVixObAh1ZxuEgVDhvRbDAQyGteP9mG1NgwLpWp2H2rFnLYiGaEgUBe0T9qQ/l5C+67aSEMBp6MplJ+ajRykqPwxgdtqkshH8dAIK9450wHxh1OfGj1AtWlBD0hBP5+dTqONPagzcreRnR9DATyitdPtiEjIQI3L4pXXQoB+Mgt6ZASeO3ERdWlkA9jIJDHdQ+OoaKuC/evWsjeRT4iMykSa7MS8aeqVq6kRtfFQCCP+/P7bXA4JR4sTFddCk3wYGE66i1D+KC1T3Up5KMYCORRUkq8UtmC1RlxyE+NUV0OTXDvqgUINRnwp6pW1aWQj2IgkEedvtiP6vYBPFy8SHUpNElseAi2Lk/FX0+2YdzuVF0O+SDdA0EIsU0IUSqEePIG9ynUsybynFeOtyDMZGDvIh/1UGEGeodt2Hu+U3Up5IN0DQT3B72UsgyAdaoPfiFEKYDn9ayLPGPU5sCfT1zE3SvSEBcRorocmsL6PDPM0WEcNqIp6b2HsB2AVbvcAKB08h20sOjRsSbykHfPdqB/1I6HizNUl0LXYTIa8MDNC7GnuhM9Q+OqyyEfo3cgxOPqD3u2wAwgrxxvxcK4cKzLMasuhW5gW3EGbA6JV49zL4Guxkll8og26wj211rwUFEGjGxV4dOWpsWieHECfnekGU4nz0mgK/QOBCsAd6ezeADds30AIcQOIUSlEKLSYrF4sDSaj1cqWyElsK2Iw0X+4JO3L0Zz9zAq6rpUl0I+RO9AeAlAtnY5G0AZAAgh4mf6AFLKnVLKYillcXJysucrpFkbtzvx+yPN2JCfjMVJUarLoRm4Z2UakqJC8bvDzapLIR+iayBIKauAy0cSWd3XAex230cIsQ1AsfaT/MDbZ9rROTCGR9dlqS6FZijMZMQjaxah7FwHG97RZbrPIWjf8MuklDsn3FY04fIuKWWClHKX3rXR3Pz2YBOykiKxMZ97bP7kY2szIQG8ePSC6lLIR3BSmeblVGsfjjf34lO3Z3HdAz+zKDESmwtS8MdjLbA5eOYyMRBonn5zsAmRoUZs47kHfumTty2GZWAMf+NqagQGAs1D1+AYXj/ZhocKMxAbzjOT/ZHrQIBIPL+/kW2xiYFAc/fi0QsYdzjx6XWLVZdCc2Q0CDy2PhsnW6w43MAGAcGOgUBzMmpz4LeHmrE+z4zcFLa59mfbijJgjg7DM+X1qkshxRgINCcvHWuBZWAMX9qUq7oUmqfwECMeLcnCvhoLzrRx8ZxgxkCgWRu3O/FseT3WZCXgtuzE6X+BfN4nbluM6DATni1vUF0KKcRAoFl7taoVl/pG8dUteVwzOUDERYTg47dl4o0P2tDcPaS6HFKEgUCzYnM48Yv36rB6UTzW57GraSD5XMkSmAwGPLePewnBioFAs/KX99vQ0jOCJ7bkcu8gwKTEhmNbcQZ2VbaipWdYdTmkAAOBZszhlPjF3josXxCLLUtTVJdDXvDVLbkQAviPd2tUl0IKMBBoxl6ubEFD1xCeuJNzB4FqQVwEHi1Zgj+/f5FHHAUhBgLNyMCoDf/+znmsyUrA3StSVZdDXvTFTTmIDQ/B02+fV10K6YyBQDPyzHv16Bocx3fuW869gwAXFxGCr2zORXmNBQe5gE5QYSDQtFp6hvHLikZ85JZ0rF4Ur7oc0sEnb1+MhXHheOrtavY4CiIMBJrW0387D4MAvn53gepSSCfhIUZ8bWsBPmjtw6tVF1WXQzphINANHW/uwesn27BjfTYWxkeoLod09OAt6ShanIAfvHEWPUPjqsshHTAQ6LrG7A5889VTSIsNx+Mbc1SXQzozGAR+9OBNGByz4/tvnFVdDumAgUDX9V+761DbOYgfPXgTosJMqsshBfJTY/CFjTn4U9VFVNRygjnQMRBoSqda+/BMeT0eKszAZp6EFtS+vDkXS8xR+PafT2HU5lBdDnkRA4GuMW534uu7TiIpKhT/cv9y1eWQYuEhRvzggZVo7h7Gv7/DcxMCGQOBrvHzPbWobh/ADz9yE+IiuTQmAetyzfjEbZl4fn8j9lR3qC6HvISBQFfZV2PBz/fW4cHCdJQu5xnJdMV37luOZQti8bWXT6LNOqK6HPICBgJd1tIzjCdePIG8lBh8/4GVqsshHxMeYsQvPl4Im92Jr/7xBGwOp+qSyMMYCATAtUbyF353HA6nxHOfLEJkKI8qomstMUfhhw/ehOPNvfg3zicEHL7rCVJKfPu10zjT1o9ffaYYWeYo1SWRD/vwzek42tiD58obsCQpCh9dm6m6JPIQBgLhP8tq8WpVK/7xzjxsWcp5A5re9/5+BVp6R/Ct107BHB3G+aYAwSGjILdzXz1+ursWDxdl4B/vzFNdDvmJEKMBz3y8ECvT4/CVP1bheHOv6pLIAxgIQeyFw8344ZvVuH/VAjz10CoYDGxrTTMXFWbCrz6zBmmx4fjcb49xQZ0AwEAIUn84cgHf/fNplC5Lwf/bfjOMDAOaA3N0GP7ns7ciIsSIjz53GIcbulWXRPPAQAgyTqfEU29V41uvncKmgmT8/GOFCDHyZUBzl5kUiVe/uA4psWH41K+O4u3T7apLojniJ0EQGbU58JU/VuHZ8np87NZM/PJTxQgPMaouiwLAwvgI7PrCOixfEIsv/f44fnOgkQvr+CEGQpBosAzikecO4a3T7fj2vcvwgwdWwsQ9A/KghKhQ/OGxW7G5IAXfe/0svvT7KvSN2FSXRbPAT4QAJ6XEC4eacO/P9qO5exjPfaIIj23I5rrI5BWRoSY8/6li/N+/W4p3z3bgvp/tx4kLPALJXzAQAlhT1xA+/etj+O5fzmDtkiS8808bsHVFmuqyKMAZDAKPb8zBy1+4HVICDz1zEP/yl9OwDnPVNV8n/Hmcr7i4WFZWVqouw+f0Do3jZ3tq8bvDzTAZDPjWvUvxidsWc6+AdNc3YsN/vHMeLxxuRlxECL5+91I8UpzB4UrFhBDHpZTF19zOQAgcloEx/P5IM/67ohFDY3ZsX7MI/1Saj5TYcNWlUZA729aP7/31DI429SAzMRI7NmRjW1EGD2pQhIEQoKSU+KC1D7891IT/PXkJ4w4nSpel4sl7CpCfGqO6PKLLpJR452wHfvFePU62WGGODsXH1mbiwcIM9s/SGQMhgEgpcaatH2+euoQ3Tl1Cc/cwIkONeLgoA59el4Xs5GjVJRJdl5QShxt68Ny+epTXWCAlcEtmPB64OR1blqZgUWKk6hIDns8EghBiGwArgEIp5dOz3T5RsASCwynR2DWIyqZeHKzvxsH6bnQNjsFoEFiXk4T7Vy3APSsXIC6Cq5uRf7nUN4K/vN+GP1W1oqZjEACQbY7ChvxkFGcl4OZF8UiPj+D8l4f5RCAIIQoBZEspdwkhdgColFJWzXT7ZIEWCGN2By5ZR9HYPYSmriE0WIZw7lI/zl7qx/C4a3Hz5JgwrMtJQkmOGXcuS0FSdJjiqonmT0qJhq4h7KuxoLzGgsMN3Ri1uRbgMUeHYcXCWOSmRCM3JRo5ydFIT4hAakwYJ6fn6HqBoHf76+0A3tUuNwAoBVA1i+0+R0oJm0PC7nTC5pAYtzsx7nBizObAqM2JEZsDI+MODI/bMTBqx+CYHQOjNvQO29A7NI6e4XFYBsbQ3jeK7qGrD8uLCTNh6YIYPFK8CCvT43DzojjkJEfz2xIFHCEEcpJdH/aPlizBuN2J6vZ+vN9ixfsXrKhuH8CRxishAQBGg0BabDjMMWFIjg5FUlQYEqJCERcRgtgIE2LCQxAVakREqBGRoSZEhBgRZjIgLMSAUKMBISbXT5NBwGgQfF9B/0CIB9Az4XrSLLdf5Xz7ADb+ZC8A4Ho7OhJXb5Dy2vtK6bqXlK77u35qt0vAKSWc7p9OCYeUcDoBu9MJ5xx3sCJDjUiIDEVSdChSYsKwelE8FsSGIy0uHEvMUcgyRyEpKpQvUgpKoSYDVmXEY1VGPD51u+s2p1PionUEDV1DaLOOoM06gou9I7AMjuGidRQnW/tgHR6HzTG3N6XJIGAwCBiFKyAMwnVOhUG4LgMCQgAGAQjtsvvdOfl9OvHq5LewgLjuNtX8boEcbShpBwDELszGLYviJ26b+nemuMH9P8X9K0K7fPl/tHA9nvt//uQXh8louPzCCTEKmLRvGmEmA8JMRoSaDAgzGa76dhITbkJ0uAkx4SaEmXi4HdFsGAwCixIjbzjpLKXEmN2J/hEb+kdtGB53YGjMtYc+ZndizO7AmM2JMbsTNseVvXqHlHA4nbA7tS99TvcXwau/FAJXrru/WLq/TF6uAVddubq+SbWqsu86t+sdCFYAidrleACTe+VOtx1Syp0AdgKuOYT//Ogtnq+SiPySEALhIUaEhxh5/s0N/PQfpr5d7xmZlwBka5ezAZQBgBAi/kbbiYjI+3QNBPcRQ0KIUgDWCUcQ7Z5mOxEReZnucwjakM/k24putJ2IiLyPB/ESEREABgIREWkYCEREBICBQEREGgYCEREB8PP210IIC4BmxWWYAXQprsFX8G9xBf8WV/BvcYWv/C0WSymTJ9/o14HgC4QQlVN1DQxG/Ftcwb/FFfxbXOHrfwsOGREREQAGAhERaRgI88czq6/g3+IK/i2u4N/iCp/+W3AOgYiIAHAPwSuEEE+qroGIfJMvfz743QI5vk7r1LpGdR2qaQsZAUCOlPIbSovRmRBiG1xrexRKKZ9WXI5Swfw6mIqvfz5wD4E8TnvRl2mda7O160FBCFEIAFLKMgBW9/VgFMyvA3/FQPAgIUSh9kEQ7LIBuN/8Dbiy6FEw2A7X3gHg+m8P5g/BYH4dXMMfPh84ZORZidPfJfBNWtOiEK6V8IJFPICeCdeTFNWhXJC/Dqbi858PDIRZmDAeOlGDlLLMH9Jfb9pwybtc+S648XXgH3sHAANhVqZZzS1bCJE94XJhIL8BbhSOE66XBuGkqhVXvgnGA+hWVonvCMbXwWR+8fnAQPAQKeUu4PIHZbzaarxvuqVOhRA73B8CQohSf/h25CEvAXD3qskGECz/3VMK4tfBVfzl84EnppHHaUeTvALXWHoigIeD6YNAe9M3AMgO5jXCg/114I8YCEREBICHnRIRkYaBQEREABgIRESkYSAQEREABgIREWkYCEREBICBQEREGgYCEREBYCAQEZGGgUDkYUKIQiFEvRDilQnX4xWXRTQtBgKR55UCKALwnLsrrJTSqrQiohlgLyMiL9H2ChKllA2qayGaCQYCkRe4h4i4Z0D+hENGRB7mXgjFHQYTFkYh8mlcIIfIg7TlIosB9AghyuCaT7DCtT4CkU/jHgKRh0wYJtoJ12ppjQDWcFEY8hecQyAiIgDcQyAiIg0DgYiIADAQiIhIw0AgIiIADAQiItIwEIiICAADgYiINAwEIiICAPx/GorJJgUmIakAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "vals_n = ens_n.pdf(xvals)\n",
     "print(\"The shapes are: \", xvals.shape, vals_n.shape)\n",
@@ -1505,21 +600,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Making hist\n",
-      "Making interp\n",
-      "Making spline\n",
-      "Making quants\n",
-      "Making mixmod\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "bins = np.linspace(-5, 5, 11)\n",
     "quants = np.linspace(0.01, 0.99, 7)\n",
@@ -1532,7 +615,7 @@
     "#print(\"Making spline from samples\")\n",
     "#ens_s = ens_n.convert_to(qp.spline_gen, xvals=bins, samples=1000, method=\"samples\")\n",
     "print(\"Making quants\")\n",
-    "ens_q = ens_n.convert_to(qp.quant_gen, quants=quants)\n",
+    "ens_q = ens_n.convert_to(qp.quant_piecewise_gen, quants=quants)\n",
     "print(\"Making mixmod\")\n",
     "ens_m = ens_n.convert_to(qp.mixmod_gen, samples=1000, ncomps=3)\n",
     "#print(\"Making flexcode\")\n",
@@ -1548,21 +631,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Making hist\n",
-      "Making interp\n",
-      "Making spline\n",
-      "Making quants\n",
-      "Making mixmod\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Making hist\")\n",
     "ens_h2 = qp.convert(ens_n, \"hist\", bins=bins)\n",
@@ -1596,22 +667,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAasAAAEnCAYAAAAXY2zOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABVFUlEQVR4nO3deXzU1bn48c+ZNZnsC/sedkSQJCCbChhBrVpaUax2kVuL1V5vvZVCbW1/vbd2kWpvbzcrtrVq9RahShcVIaJoFIQQRMNOwr5mm2yTzHp+f8ySSUgghMlkmef9evFi5rvNMyHMM+d8z3mO0lojhBBCdGeGrg5ACCGEuBhJVkIIIbo9SVZCCCG6PUlWQgghuj1TVwcghOg+duzY0ddkMv0BmIh8mRXR5wOKPR7PfTk5OefCd0iyEkKEmEymP/Tv3398nz59qgwGgwwVFlHl8/lUWVnZhDNnzvwBuC18n3xzEkKEm9inT58aSVSiKxgMBt2nT59q/C375vu6IB4hRPdl6O2Jas+ePZabbropC2DdunVJM2fOHN3VMYkmgd+/83KTJCshRK/33HPPpQUfT5gwwfXiiy8eBVi4cGFtSkqKt+siE+0lyUoI0auVl5cbN27cmBx8vmfPHsu+ffusXRmTuHQywEII0aafTzye09a+6x5JOTptSXI5wLbnajI3P1U9rK1jv108ZEd7X/OBBx4YtGDBghqAQ4cOWUeNGuVcuXJl/w8//PDgAw88MAjg6aefPglNLaaKigrjsmXLytetW5e0cuXK/suXLz9TWFhou/HGG2vLy8uNu3btsj333HNpS5YsqQJYvnz5oA8//PBgy9d+7LHH+uXm5joOHTpkXbZsWXl7YxadT1pWQohu48knn8zMyMjwLFy4sBbAbrcbg48BHnroobLg44KCAltJSYllyZIlVc8991wf8HfrVVdXmxYuXFh79913V7300ktpCxcurB06dKgzmKgmTJjgaq3r74EHHhiUm5vrWLhwYW1JSYm0vLoZaVkJIdrU3hbRtCXJ5cFW1uUoKipKePDBB8sAxowZ4ywsLLQBtJZcZs+e7SgvLzeuW7cuKSUlxRPcHv74Uhw5csRaVVVlKigosI0cOdLZ0fcgOoe0rIQQ3UZ2dnb91q1bbQAHDhw4r3UTvu3JJ5/MPHTokDXY8iovLzdC64ktqKCgwNbWvpycnPrRo0c7Z8+e7bj33nurLud9iMiTZCWE6DaWLVtWXlJSYl23bl1SsFUF/kSybt26pKqqKtN7772XvGfPHsuoUaOcdrvdWFBQYJs8ebLjn//8Z/K6deuSiouLbQUFBbaXX345bdeuXbby8nLj8OHDnc8991zauHHjnAUFBbbi4mLbnj17LMHHBQUFtscff/zs+vXrk9atW5d0oaQmuoaS9ayEEEG7du06Mnny5G4xsKCgoMC2fv36pMcff/xsV8ciomvXrl2ZkydPHh6+TVpWQohu6aWXXkrbtGlTcrB7T8Q2GWAhhOiWgsPThQBpWQkhhOgBJFkJIYTo9iRZCSGE6PYkWQkhuo3wiuhChJNkJYToNsIrorclvIK6iB2SrIQQ3cbFKqK3rKAuYocMXRdCtG7dN4Zwbk9kKzn0neBg4W+PX+iQYEX09lZQD6+UnpGR4X3llVfS7rzzzqqSkhLLyJEjXU8++WT/H//4xyeCFdzDC+OKnkNaVkKIbiO8Inp7Kqi3rJS+ZMmSquLiYtuSJUuqHn/88bNLliypGjp0qHPhwoW1y5YtK3/ooYfaXMZEdG/SshJCtO4iLaBouFgF9dYqpU+cONHR1vFDhgxx7tmzxzJhwgRXpGMVnUuSlRCi27pYBfXwSunjxo1rdVmP6upqY9hjkySqnkmSlRCi2wiviH7gwAFrsCL6+vXrk1pWUL/11ltrZs+e7Xjsscf6hdcPDJ4ze/ZsB/gTVEFBgW3r1q22H//4xye67t2JyyFV14UQId2p6nqk3HTTTVlvvvlmaVfHIdpPqq4LIWJKcH2rPXv2WLo6FnF5JFkJIXqthQsX1h4/frxY7lP1fJKshBBCdHuSrIQQQnR7kqyEED1GNArdPvDAA4Mee+yxfp35GuLS9ejRgJmZmXr48OFdHYYQvcbKlSvp379/V4dxQTU1NSQnd155wD179rBlyxa++tWvdtprdDWn0+mZMmXKrq6Ooy2tjQbs0fOshg8fTmFhYVeHIUSvsXfvXsaPH9/VYbSptLSUxsZGJkyY0GmvERcXR2lpaae+RlcrLi7ucQNOpBtQCNFt5Ofnc8MNN5Cfn8/KlStZu3Yt+fn53H///djtdgBWrFgBwNq1a0lLS8Nut3PHHXewcuXKdp2/atUqioqKWLVqVbPXDp6/du3aaL5l0U49umUlhOg8T2x7gn2V+yJ6zXHp41gxbUWb+/Py8lixYgV5eXlkZWWxYsUK1qxZQ2lpKYWFheTl5ZGamgrAokWLAHjllVe4//77ycvLA7jg+UVFRWRnZ5OdnU1lZSWrVq1i6dKlrFq1iuzsbPLy8khPTyc/Pz+i71tcPmlZCSG6lfT09NDjrKys87aFW7RoEc888wy5ubntOn/79u2hbVlZWWzcuBGAHTt2hLaL7klaVkKIVl2oBdSZgi2n9sjPz+fZZ59lxYoVPPPMMxc9f+rUqZSWlpKVlUVpaSlTp04FICcnJ7RddE+SrIQQ3UZ+fj5FRUUUFRWFHpeWlrJ69WrS09NJT08PbcvPz2fNmjVs3LiR0tJSVqxYwQ033HDB85955hlWrlwJQFFREcuXLwdg6dKlzbZv3LiRpUuXXlLiFJ2rRw9dz83N1TIaUIjI6e6jAUVkFBcXOyZOnLi3q+NoixSyFUII0SNJshIxT2uN19fmGn9CiG5AkpWIWVprPjj5AXe9fhfz187nQNWBrg5JCNEGSVYiJhWXF7PkrSV8Pf/rVDurAViyfgm7yrptBRohYpokKxFzqhqr+OpbX+VI9RG+e/V3+efCf/L8Tc+TYk3haxu+xtbTW7s6RCFEC5KsRMx5fvfzNHga+NOCP/GFcV/AbDQzOGkwz9/4PIMSB/Fg/oPsrei2A6WEiEkyz0rElKrGKl7e9zI3Dr+RrNTmE0D72Prw3ILnuPnVm/nDp3/gqTlPdVGU3chTKrLXe+TCU2WKioq44447yMvL44knnqCwsJA77riDRx99lEWLFoXKJ3VXwfgXLVrEo48+GvV5Wvn5+TzxxBOhyhyX44EHHhiUkZHhefzxx8+Gby8oKLB94QtfyLrllluqpk2b5ti2bZttwYIFNQsXLqxtua+iosKYkZHhXbJkSVVr55aUlFhee+219N27d1/026EkKxFTXtjzAo2eRu6ffH+r+1PjUrlz7J08t/s5jtUcY2jy0ChHGNuCdfvuv/9+UlNTQzX+ghN0n3322TbPXbt2baheYFcJxr948eILJqrOijUvLy9UyeNCrz1u3LiLXuuee+6pWr9+fVLL7bNnz3Zcc801tffcc0/V7NmzHUuWLKlKTk6+qqam5uOW+8Cf9NLS0jwLFy6snT17tmPixImO8P3tJd2AImbYG+28vPdlFgxfwMjUkW0ed8/4ezAqIy/seSGK0YmLKS0tpbS0tNV9drs9Iq2JaOjKWC/ltdPT0z3tvW5KSopnz549ltb2PfTQQ2Xf+973Bre2r7y83Jibm9uupCUtKxEzXtjzAg2eBu6f1HqrKqiPrQ+3jbyNdYfW8cDkB8iIz4hShOJiVqxYwcaNGykqKqKysrLZvsLCwmYtllWrVpGbm0thYSFLly7FbreHqqsXFRWRmppKeno6q1evZvHixZSWlrJ8+fLQEiGVlZUsXbo01LW2YsUKioqKyMrKIjU1lTVr1vDEE09csAXV8ty8vDwqKyvPi3XlypVkZ2dTWlp6XkxZWVn89Kc/5Yknngg9D1aYb/keW2r5XgoLCyksLGT9+vXGiRMnAvDYY4/1y83NdRw6dMi6bNmy8uDzwsJCW3v+TcrLy43JycneCRMmtLpG1oQJE1zHjx+3trbvn//8Z3Kwi/BipGUlYkK1s5qX973M/OHzGZU26qLHf3bEF3B6Xcz/40+Y9bNNfPOvO3lxyxGOlNdHIVoRXFdq7dq1oXWogkkCYPXq1QChbsLg3+Ef/llZWWRnZ5OVlcWqVasoLCwMdS1u376dpUuXsmjRIoqKili0aBHLly8P1RIMVnMPvkZlZSV5eXksWrSI1atXk5eXR05OzkUXf23r3PBYV6xYEVqepKSk5LyYFi1aFHqPS5cu5f7772/zPYZr671kZWVx4403esHfRZebm+tYuHBhbUlJifXJJ5/MDD6/8cYbay/03tavX5+0bt26pD//+c9pmzdvvuAkxdraWmPLc+++++5hFRUVxrbOaUmSlYgJG45uoN5dz1cnXnip8ppGN99es4vFvy3FXTMBb2IBVw6OY0tJBd//+25u+J/N/P3jk1GKOnYFP9wXLVrUasvl0UcfZePGjeTk5ISSWbjWlgIJtkaCrZ2g7OzsZo+zs7PJz89vttTIpSxb0tLFjistLcVut1NUVMTIkSPPi6mlYMX4tpY7udh7CXfkyBFrVVWVqaCgwDZy5EhnUVFRwpgxY5zteV/BpLZs2bLyzMzMNkvAlJeXGydMmNCsq+/GG2+sffnll4+OGjWqXa8FkqxEjNh8fDODEgcxLr3tG8sNLi9f/fN2Xtt5ksW5Q3hq/jfxKgezs0v56LvXs/nbc8gZlsY3//oxT79bQk8uAt3TBRPOjh07zlsosaioKLQUCBBaCiTYDRdsXbRm1apVlJaWhhJbMBFezqi+C50bjDXYQrrzzjtbPS48IVdWVpKVldXqe2zPewkqKCiw5eTk1I8ePdo5e/Zsx7333luVnZ1df+DAgVa77Drql7/8ZeayZcvOtLZv4cKFF2y9hZN7VqLXa/A0sPX0VhaNWYRSrQ/Fdnl8PPDSDgqPVvGru6Zw6+SBALx06Er+UfIPvjjhiwzLSOD5f5vGsjWf8MT6fZyyN/DD267AaIjw8O7u5CJDzSMtuLzH6tWrycrKorCwkNLSUlatWkVeXl6oa6u0tDR0PybYnZaVlcXatWvJy8tj+fLlrS4FkpOTQ1ZWFllZWTz66KOh1YODKwhnZWU1e56fn09qauoFlx0JJoO24m95rt1ubzXW8Htw4TGAP0EVFRVRWFgYahW29h6D5wXvrbV8L8EuxfXr1xvvvfde5+zZsx2PPfZYv/LyciNA8J4VQGFhoW3Tpk3J5eXlzVpOBQUFtl27dtnAPzKw5b73338/KSUlxXPw4EFrSUmJJTU1tdnQ9eLiYttLL72Ulp6e7mnrPldrZIkQ0eu9c+wd/uOd/2DVDauYMXDGefu9Ps03/7qTf31ymp9+/kq+MK1puPrzu5/nycInef1zr4eGsft8mifW7+OZ90p55IYxPHT96Ki9l87Wm5cIWblyZWgIfGlpKc8880yz7sDu7I477ojo/LKeuERI1FtWSqlFgB3I1lqvvMBxyy+0X4j2evfEuySaE8ntl9tsu7POx9Zna9hWWkn5Mc1/Zl3BwA+S2fyBHYCJtyUwf9h8nix8ktXvv860A18InTuTAdRXGNj66xqGf1zGrY/0Ce3b8kwN1kTFlC8konpzq6uHCW8p2e12Fi9e3NUhtUt4ay6WVzKOarJSSmUDaK3zlVJZSqlsrXVRK8flAVPPu4AQl8infWw+vplZg2ZhNpqb7XM3aLb9sRYwk0NfXCWwjaYu9EFTrIwaOYBJfSbxzpl8+OMtzc5PwcZV2Nh1qo6bHs7AZPTfAi74tb8wbuZoM0OnxXXuGxTtFt5d15MERwnGumi3rBYDwSErpUAecF6yEiJSdpfvpqKxgjlD5py3z2yD07NqOF3dwH3XZJFobf7fIWOE//n8YfN5suxJxj5cSz+az23cd6aWtZ+e5Zn3vHxjbvMh8TWnZY0sISIl2skqFQifyXfebMtAaytfKXXhmZtCtMM7x9/BqIxcM+ia0Laz+1yc3OHkiK2WV9OO8P++PIHrZ7U9vDjYFXju6g+57cr7mu27mmS2vXSW/80/yA0T+jGmXxK5X0mk8Pk66iskWQkRKd1x6Hr7Ji8I0Q6bT2zmqr5XkWJNCW07trWRt39q562XyhnbL4kvTR92wWsMSPR3BW44sqHV/f/12StIjDPxw3/sBsCW4Z/n6JBkJUTERDtZ2WlKRqlARfjOYKsqyjGJXupU3SkOVB1g7pC5zbbXl/sAKKOR//rsFaF7TRcyf9h89lbu5VjNsfP2ZSZaeXDOSD4sqWDH0SoSAskq+Dq93jsP+/9EQHBi7P3334/dbic/P5+0tDRWrlxJaWkpd9xxR0Rep7MUFRWRk5PDihUrWLt2LStWrAhVlrjU+IM/i+C1Vq1aFZo03B4rVqwIDW3vDaLdDbgaCA7JygLyAZRSqVprO5CllAoOd2l1AIZSaimwFGDoUKmILVoRWNbi3bh0SBzIdRuWwvp7Q7ur3vsNcBujE3Yz/bWr23XJ+QYzT6aPZcNfcrivofy8/XdrK79Vf+K3f/wl3697F/iLdAN2QG+oup6bm8vixYvJzs5m0aJFpKWlceedd5KVlXXB+Fu7VrCCe3C+VXurZgAsXrz4vAnTPVlUW1bBxBMY7WcPS0RvB/av1Vqvxd/6Sm3jGqu01rla69w+ffq0dogQAGwxJzLE62S4r/m8w9L6sQDckrK+3dca4HMzye1gQ1h3YjibcvJv8f9gk2sa5+I1WdfGMeiqiBYCiHk9tep6sKbhheJvD7vdTl5eXruvEe21tDpb1OdZaa1XtbItp5VjzjtOiPbyAR+bbcx1Na/m4tQmKh2DSAXGJO6+pGve4KrmqYQBnDKYGehzn7f/y/H/YlXD53nBNJPf/k6+SHWGnlZ1HWg28TgYf2vV2C9UDxAIVaBITU294PnBCu5FRU2dUi1/Xv3797/4D7ub6Y4DLIS4bEeMVuwGE1Pczauk/8N5HRanv8WTEF92Sde8LpD43rOctx4dACmGer4U9zpvOGdx6FxdB6IWQT296nphYSH5+fnccccdrFix4rz4W7vmhX4WK1asaNaiauv8YDIO1kAMavnz6okkWYleqcjkX4on291U7Flr+GP9QozKi1IebHEVbZ3eqhFeF8O8Tja3kawAvmpbRzJ1/PUfWyg74MLdGCODLCKsp1ddz83NJS8vjzVr1pCenn7e8h0XOz9cXl4eTzzxRCjOYNJq7fwdO3a0mowu9vPqCSRZiV5pp9lGus/D0LD7VR+4J7PPN4Kxn3+Ab315NAbDpQ+AuNZVyzZzAg5aL6OU4avnnbhlLD96D39dfIDK0nYvtiouQU+rut5aYrnUa+bl5WG320Pvq7Xzc3JyWr2ndaGfV08hVddFr1RkTiDbXd8spfyh4XP0MVRym3UzBtWxkXrXuWp5MT6TrZZE5oXfD9OAMw7cFpKpx2TUDO//AfUV7R9qLHpH1fVgd2MwzmD3ZPAawe2tVWMPT0DhP4vS0lIqKyt55plnWLNmTeiclucvXbq02fveuHEjS5cuPe/n5XC0ayX5bkWqrote59z/mLk+fRzfrjvNlxv9XX2HPIPJq/o9y2wv8O8Jr3T42m4U16aPY4Grmh/WnfJv9BihMR60ArMLrE7q7EM5enI23lufYdLnEyPxtqKiQ1XXg3Os5v4y0uFEVE+uuh5pUnVdiG5gZ/B+lafp2+OaxjxMeJh62siqnQVcMepvzJryP5d8bTOame463jMn4dNgaIwDjwUMXohvAKO/xXaK2YzoX8AbB6uZRM9JVr1ZT626LvwkWYleZ6fZRrz2MdbTAIBXG1jnnMscSyE4UqmuG4rLbevw9a9z1bLBmsJedzpXeNxgcfr/hPU56n4LsFX8C/uRrcDtl/mOurlu3qIK6qlV14WfDLAQvU6ROYFJbgfBBUE+dE/irC+D2+M2Ud+YCUBC/PlVKNrFp7imxo3Sms22eLDVg7V5ogLQQ67Hpw0MdG+mtvH8OVlCiEsjyUr0KvXuevYb45gS1gX4auM8klUd8yzbcDT4J+te6hwrNOA2gSOBNJeBya5GNifEgbH1oenx/TM4VXEVV6Zs4V+fnO7o2xFCBEiyEr3KrrJd+JQKTQau88Wz3jmTW6zvY1Ue6gPJynYpycqn/AMoGm2gNNjquc5TzR5zPOcMrfek95tgIWHmTQxJOsCGrR9f7tsSIuZJshK9ys5zOzFozeTA/ar1rhk0EMftcW8DhJJVu1pWGnCboT4RPCawNPq7/Yw+rg0MW99sbn2CcFyygbTrPwNAn7Pvsf9MbavH9QabflbFpp9VdXUY7RZe/Tw/P58bbrihiyMS7SHJSvQqO8/uZKy3kQTt7557tfF6hhlOkW3aB4CjoZ33rHwKGuL9LSqDFxLqweoK3Zsa7XUyyOviXWvb1SzoOwFv0kCuN37M3z8+ednvTXRccI4R0Kz6eV5eXq8r+NpbSbISvYbH5+GT8k+YEiixdNLbhy3uK/l83CaU8pdbmjrxGXIm/JF4a2XrF9GAK9Ca8prA2gg2Bxia35tSwFxXDVvNiW1Ws/joj7WctF/HtYZiNn5yjJ48p7Ena1mR/XKrn4uuIclK9Bql1aU0eBq4MjC4Yp1zDhoDn4t7BwCl4OpJTzPv6v/CYGhlYIRPQYMNnPH++VIJdWBxnTfSL2iuqxaXMrDF0vo8qn1vOSjcOpN4Guhj38me0zUReZ+93YoVK8jPzyc/P59Vq1Y166pbsWJFqDAsECp2G6y9Fzw2Pz+flStXhipKBCuyh79Ga1auXBl6XdG9SLISvUZxeTEAE93++1VvOGeRbdrLUOPZC5/YrDVlBGsDxDvAcOGW0BR3PUk+L+9Yklvdn5Bh5Ni5q/EpK9cbP+aNT2VU4MWsWrWKjIyMZrX5wudH3X///aHHl1IhPbwie3j183ArVqwIVSwvKSnpxHcpOkKSleg1isuLSTInMdTn4ri3H7s9o7jJ+mFof3XdIA4cuZHyqjFNJ/kMYa0pT6A15W6zNRXOjL+w7XuWJFqrNJiQacDttVGfMIObrJ/wxqdnpCvwInbs2BFKTuHFZltLLu2pkH4pSktLsdvtoeXkRfciyUr0GsXlxUzInIABeMs5A4AFYcnq2KlZ/P2dVWz79OuB1pQF6hP8ram4Bn+5pIu0plqa46qhymBil+n8ihgJGUYAyg1zGeg5gbeilL2ne++owEgIXyOqtftK4ds6UiE9fEHClqZOnRpaA+vOO+/sQPSiM0myEr2C0+vkYNVBJmZMBGC9cwYTTCXNugDrG/3D1vuk7AdHgr9KuinQmjK3rzXV0mx3HSbt451W1riyZfqT1amGOQBcb9wpXYEXsXTpUkpKSkKVxIOmTp1Kfn4+drud/Pz8UDXzYEso2MIKr0a+du3aUDXyYEX28Krq4ZXPg5XZg9eQAtndj9QGFL3C/sr9eLSHiZkTOedNY4dnPP9pe7nZMQ5HOjPG/56cEav9FdLjHP5k1YEkFZSofUxz1/OuJZlHHM3vjYVaVhWDYcRoFtbt5j8/Pc0j88eg1GW8aC8XrISenp4eWnspuMQHNF8SJNiqCl9AMXi/KTs7O3Rey8UWw+9JhT8Ofx3RvUjLSvQKocEVmRPZ4JqOxsCNYV2AeA3kjHiF2Vf8hlpnH//kXvPlJaqgua5ajpisHDZamm1PHmik7zgzKQNNMHo+E92fcrq8gn29eIJwJK1evZqNGzf22JVtRWRJshK9wu6K3WTEZdDP1o+3nDPIMp5gtPFYYFFEKzgSsBgdvPbBr7C7+17yvakLmePyD0lvOSpw0FVWvrK2P3OWpcKY+Rh9LmYbd/e6rsB530lj3nfSIn7dJ554go0bN8qkXQFIshK9RHF5MVdmXkl1g5st7kkssGxB+Yz+e1MuK5jcrP3wNxw6Pe/S6gK2Q3+fhwnuBja2MYQdgKEzwZLInSl7eWv3mYi+fqTJiEXRlXw+nwLOmwgpyUr0eHWuOg5XH+aKzCt4e+85THhZYngLHDb/van4eohvxF47AuhAxfV2uNllp9hs46iheVeg1pqGai8+ZYasOczw7uDA2VqOV3bPZcXj4uKoqKiQhCW6hM/nU2VlZSlAcct9MsBC9Hh7Kvag0UzMnMgHr29ko/Vx+nod/hF+1sbQfakH7srF0ZBBvNUe8RhudFbzlK0/r8el8qDjXGj7szedpvqEl6VvDSBlzAIS9/2Lceo4m/ad4yszh0c8jss1ePBgTpw4QVlZ5BO66D7OnDlj8nq9mV0dRyt8QLHH47mv5Q5JVqLHK67wfwkbGT+MKSdvx6WM/taUqflUXZPRRXJi59wv6ufzMM1dzxvWFB5wnAuN24hPMVB9wkt9uZeUUf6SQbcn7ebtfTndMlmZzWZGjBjR1WGITjZhwoRPtda5XR3HpZBuQNHjFZcXMyhxEOc+/oAE1cgJc/J5iSoabnZWc9RoZbcpPrTNFhi+Xl/hg+QB0H8SCyyfsLWkgnqnJ+oxCtFTSbISPd7u8t1MzJxI4+71OLSVMZbz67odOz2Dl1//G1t3faPT4shzVWPWPl63poS2JQQmBteXB5LnmAUMqf+UOG8N7x+8yDIlQogQSVaix9E+TV2Zl7oyL8dPlHGq/hSjreMZVlHA/oQcrAYPHq+FOkff0J+zFVdw8txUqmqHd1pcydrHda5a3rSm4PH5W00JGf7/YvbjHrRPw+j5KO3jFuNe3t1+LvQ+wv80VrdSEV6IGCf3rESP8+o3yil9vxGAEyO2wyI4+3Mv/a8s42jWg3B0PSfP5vLKW38979yEuM5tzdzsrCbfmsK209uYOWhmqGW1/blaZixNxjooB2wZ3HVsP289lcbTT5067xpjF8Rz21Pd8d63EF1HWlaixzm1ywWALd1AbdYh0IqrbUcBGD79swAYjW4S4s81+5OWXMroYes7NbZrXbUk+by8fvh1AEZcE0fGSBMJmQb/qESDEUblMTptCw5rI5Y0RUKmodkfa7L8txSiJWlZiR4neZARa7JiyWv9+daW44yoGc6Q8Zsp8Yxg5GD/0g6D+23nwbuiP9jJiibPVcNbR/P57tXfJW1oAv/29wHNDxo9n/hPVrNrwevMnnMT35w/9rzrnPrEiateMyTXitEsdQSFkK9wosf5ypr+LF0/EHO8gT0VexidNJIxzt2c639dV4cGwKLGShweB68efLX1A0bOA2Xg7rR9vL3vXKuHvPZQOWu+VkZDldy/EgIkWYkerLyhnHOOc2RWuTApH6lX3dLVIQEwydNAdt9s/rLnL6GBFs3Y0mHI1VyndrL7VA1nqhvPO8Qc529NeZxSSUIIkGQlerA9FXsAGHb6KHYSGT1lTpfGE+7LV3yZU/WnyD+W3/oBo2+gT90++lDFewfPrxZhskqyEiKcJCvRo9Sd8/I/OSf4462n2V2+G4XiuspdHEyajsls7urwQuYMnsPQpKE8X/x863X2Ri8A4LaEYt470EqyCrasGiVZCQGSrEQP427UeJwar1uzp2IPg6x9GaRrYMwNXR1aM0aDkS9P+DLFFcUUnWtlKfV+V0DyID5r203BoXK8vuZJKdSyckmyEgIkWYkexhv48DZZFLsrdjOkwYBXK7ICQ9a7k9tG3UaqNZXndz9//k6lYPQNjG/YQb2jgU9PVjfbbbRKy0qIcJKsRI8S/PBuTKmkrKGMK6rPsd88jow+Ay5yZvTFm+JZPHYx7x5/l8PVh88/YPQCzJ56phr2s3l/865As9yzEqIZSVaiRwl+eJdlHgLgmoZTlA2Y04URXdhd4+4i3hTPU4VPnX/vasS1YLRwZ/Ke8wZZ5D2Wxn1v9GfYdGsUoxWi+5JkJXqUYLI6l3YAhWKcy0XKpM90cVRty4zP5MGrHmTzic1sOr6p+U5rIgyfzTUU8fFxO9UN7tCu5AEm0oaaMcfLf1EhoAuSlVJqkVIqTym1vI39eYE/T0Q7NtH9BZPVmeQDDPKYqPalM/6qGV0c1YXdM/4exqSN4acf/RSHu8UKwaMXkNF4lEH6DB8ekirsQrQlqslKKZUNoLXOB+zB5y323xDYn91yvxAZI83MXZ7KuYwDTGqoZX/SdKzm7l01zGQw8f3p3+es4yxP73q6+c7R/lGMN1k+adYVuOf1ev7xSDmH3mmIZqhCdFvRblktBuyBx6VAXvhOrXWR1npF4GmW1rqVMb8ilqUNNTF0UQN2XyWTXA68I/MuflI3cFXfq7h99O28uOdFDlQdaNqRMRIyRnGbrZjN+8tC97XKD7jZ/1YD5YfcbVxRiNgS7WSVClSGPc9o7aBAF+H90QhI9Dy7y3cDMLrRy/Bp3fd+VUsPZz9MsiWZxwoeo8ET1mIavYBxzl1UVdspKasDwiYFy2hAIYBuOsBCa70SuF8pldpyn1JqqVKqUClVWFZ2/sx/0buVHXSxecsuDBoaPWPIGti3q0Nqt9S4VH4060fsq9zHDz74QdPowNE3YPS5mGnYzeYD/vtWMs9KiOainazsQHrgcSpQEb5TKRV+n6oUWNryAlrrVVrrXK11bp8+fToxVNEdlbzTyI79H5HldlHVbw5K9azlM64bch3fzP4m64+sZ9Unq/wbh80CSyKftRXzQWCQhcyzEqK5aCer1UBW4HEWkA8Q1oLKo3kyK41ibKIHcLt8lPc7yBVOF0lX3tTV4XTIv038N27JuoXffPwb3j76NpgskDWHa9VOtpaW4/b6mlpWkqyEAKKcrIIDJpRSeYA9bADF24G/VwFZSqlFgePXRjM+0f2Vuc5QF+dkSL2NKZNzujqcDlFK8cOZP+TKzCt5tOBRdpXtgtHzSXWfY4j7CB8ft0vVdSFaiPo9q0A3Xr7WelXYtpzA3/bA/rVaaxlgIc5zWO8EwFw3ibQESxdH03FWo5VfzfsVmfGZPJD/APv7jgJgnvFj3j9YTlI/I0NyraSP6N7D8oWIlm45wEKItpwxbMKsNVbjzV0dymXLjM/k2fnPEm+K5/4Pv8exAVdwS/ynfHConKHT4rjrz32Z+fWUrg5TiG5BkpXoUY5b9zDG6SFxcPdYwv5yDUocxLM3PItP+/hagpd03wFKj5+gtlHmVwkRTpKV6DF8Pi+H46oZUpnJyEHpFz+hh8hKzeL3N/yeanx8s18G01URWw5V4Kzz0Vjt6+rwhOgWJFmJHuNIaT4Oo8KbPJrxeQldHU5ETciYwMrrfs5+i5mqge+wpaCCX00/yV+XnOvq0IToFiRZiR6jcM+rAAwefgtGc8+aX9Ue1w6Zw7esw9md6ODtRv+CjTIaUAg/SVaix/j0TBFWH+RNntvVoXSaL1/xFT5XW0dV2pscHrtZKlgIESDJSvQMjkoO6RoG1qaw+3tu7Mc9XR1Rp1CjruexCjv9HYlsXfBrqk2ybIgQIMlK9BCuAxvYbzWTcfpKTuxw4fP00haHLR3z4Gl8t7wBn8FDwbSnL36OEDFAkpXoEXbtfhW3UiSenAk0VSXvjdSY+cz1Hian8DaOjCpg07FNFz9JiF5OpseL7s/n5UBZEaTF0+/ceACMlm6erJ66jPi8BiCRz55M4kDZMH6S/yBX2w+SoDswjP2RXtoCFTFHWlai+zu5g30mLxavBVtFPwDMvbhlhcGHR0Hq2HyuPz2McwYTv7H1nKVQhOgMkqxEt+fbv55iq5U082h8Tv+2YKHXXkmByeQiJ6GQ0wkp3NlYyUtxGZQarV0dmRBdRpKV6PYq97xBidnM+IzJaB8YTGAw9eJkBWD0kKCceDxWltaXY0Xzp/jMro5KiC4jyUp0bzWnKHGUohXMHzGNiQttjP+Mrauj6nwmD15t4Lbq45TWTuH2xkpet6Zy2mDu6siE6BKXPMBCKTUcyMa/SGIq/gUS7VprGbIkIu/gRnZZ/d1f12blkvJ4jFQhV3C68kpmWwv5S/U8vpKyk9VxGTwfn8F36s90dXRCRF27W1ZKqW8rpTYATwAjAQVUBx7PV0ptUEo9rZS6qlMiFTHJu/8tPopLJNkwiBRrjCSqgNNVE8lIPswpd18G+Nx8xmnnb3HpVCpjV4cmRNRdtGWllBoB3A/8VWv984scmwIsVUrlaq3/EKEYRazyOPGVvsMnA/tyVcYk3I0+qo56sCYaSBnU+2ddnLOPA2CgsYwGbeXfGsr4hzWVl+IzeMghBW5FbLlgyyqQqK7XWn9Ha/3xxS6mta4OJLS3lVL3RShGEauOfsBx5aLR6GPe8KlUlnp4/vazrPtmbJQganCnUFk7jOlxRWx3TyDL6+J6Vw3/F5dBnZLbzSK2XPA3Xmt9uCMtpI6eJ0QzBzdSZPUPprh6YA7uQFFXY28eth7GZGqk9My1TLF+yjbnFQDc11BGrcHIa9a0Lo5OiOi65K9nSqnkzghEiJa8+9ezwdoXi0pgeMpwvC5/sjLHSrIyNlJ6+losBjcObyIAV3gaudLtYF1catcGJ0SUdaQvYWT4IAql1Ail1LzIhSQEUFGCsaqUYquZsakTMShDaLmMXj0hOIzVUktZbRYun5ksfZYqXxIAtzrtHDDFs88Y18URChE9l5ystNY7gamBIexorQ8DaUqpn0Y4NhHLDrxFjUFRa61n1pAcADyBllVvLmIb7oYZ3+cbd02l3mRkjnEXW10TAbjJWY1J+/i7tK5EDOlIN+BqoASoCusSzAeWRjIwEeMObiDfOgiAnP5TAGKuZRWUZK5msCrngHsEAKnayxxXLW9YU3F3cWxCREtHugFzgEKtdTWgAsPV84CfRTQyEbucdeijH/Avc38UBq7MvBJoWuI91pKVyeQCIM7bVHX9NqedSoOJDyxJXRWWEFHVkWR1B4FWVCBhpQNpF5uDJUS7lb6L8rrYE2dkaGIWCeYEAEbNi+fuF/sydUlsfEDv2n83z6z5gC2ffoMKErlKlXLc66++PttVS7rPwz+sqV0bpBBR0qF7VlrrJ8OeHwZ2SOUKETEH36LOkEB9fBXTBk4JbU7IMDJoipX04bFRH8/tiaembgiOhkyUyU2OOsD2wBB2M3Cz0867liSqpaKFiAERmVkYGHRxOBLXEjFOa/TBjbxqGg+GRqb0nXLxc3opk7ERAI83jjRzJSblo9qTGtp/W6MdtzLwZoyVoRKxKWLT4ANdgkJcnjOfompP87rJvxzG5D6TQ7v2b3SQ/5Mqjn7U2FXRRZXJ6F+8y+ONQxm91GsrfXx1+LT/nt04byOjPY38U7oCRQy4aLmljpRN6uh5QnDwLQD2xWky4/oyJGlIaNeJ7U52vlxH2YHYGANnMgVaVp44UFBhSGC6YS/7PMMAfyXpG53VfGK2UaZ6f61EEdsuWm4Jf52/37dn4q9SKlkp9W389QSl3JK4dAc2UGoZjU46wdUDp6JU08i/0DyrGBkN2NQN6F8iJclcTaaq4YArK3TMXFcNAO9YY2PQiYhdF/06FkhYX1dKfU0p9R1AA0VAReCQDPzrWo3EP/9qZeAcIS5NfQX6xHZeNt2MNnzK1H5Tm+2OtXlWoZaV11+pIs1ix+tMBk/Tf9tRXidDvE42WZK5s7GqS+IUIhra3XegtX4WeDYwryoXf4JKxz+wojQwyEKIjit5G4XmbbN/rvnU/i2SVWCelTlGKlikJh1j2pW/Iz251L9BaU6qDEbp0zi1CavyoIB5zlpeik+nThlI1L4LXlOInuqSO7oDAyne7oRYRKw78Bb15nTO2GoYEN/8fhU0taxipep6atIxrsttPtfeaVRM5Cg7XKPJse4FYJ6rhudtmRSYE7kx0C0oRG/TodGASqn7AqsC3ydV2EVEeD1wKJ+txilYE48ybUDz+1UQuxUswg0wnwagzN0ntG2yx0G6z8Mmi/xXFL1XR2oD/gwYhX9J+zuBw0qpr0Y6MBFjTmyHRjsvNQ7Da6g5734VQPJAIxlZJuKSY2PhQY/HypGT13Dk1OzQtkSTgwqdRLLXGdpmBK5z1fK+JQk3sZvIRe/WkfGu27XWfws+UUqlAt9RSn1ea/1qxCITseXgBnzKyHarBTj/fhXATY9nRDuqLtXoSmbNhpewxZXxjS/4K8+j4JRK5UoOY/cmkmqsA/xdga/FpbHdbGOmu74Loxaic1z25AyttR1/svra5YcjerSnLuNbfX0CR/UAfLaj9Pe6GfLssMjF1UOFTwoOF2+uI8ndyFbXSKbH7wJguquOeO1jkyVZkpXolTrSn1KqlNqulJrb4n5VRZtnCHEhPgU+I295c7AklDDVXd9qZ5bWUY+sSzUNXbc22z7cchyXNuHyxIe2xaGZ6arlHUsyMfZjEjGiI8lqMfAK8ABwJJC43gKylFJJAEqpz7d1slJqkVIqTym1vI39SwN/nuhAbKInCswb+qvhKjymRqa20TL43epCfvHCAeobMqMZXZcxGlyAD5/Pgs/X9F/VZPBxiAEM0RXNEvhcVy3njGb2yArCohfqSLIqAdZore/UWqfjXy4kH5gPHFVKHQRaTTRKqWwArXU+YA8+D9ufB+RrrVfhT355HYhP9DReE3VYORnvT1JtJSuPJx6vNy7UPdbbKQXmNlpX9UYTI9RZjrkHhLbNctUC8KGscSV6oY4sEfIs/mXshwee79Ra/1xrPT+QvBbTdgX2xYA98LgU/6KN4bLCtpUGnoveTAMeE4V6NIkJe+nrdTPE52r1UI/H32IIliGKBeGV18MNspwC4LS7f2hbpvYy3tPAB5bE6AUoRJR0aAxwIEEdaWNfEbCijVNTgcqw582Gd2mtVwVaVQDZQGFH4hM9iNcIKFZ75qASSpnurmv1fpXPZ8SnzYAPgyE2CtkCGIODLDzNk9VAcxnHdSYJXk+z7bNcdewy2ahTsTG8X8SOTvmNvtzSS4HuwY2BxNdy31KlVKFSqrCsrOxyXkZ0Bx4TXhTvmPvjNrqZ5apr/bBAN5jZ1IiKoalEd3/m83z9zqkk2s6et++4ymA0p3D5mgb1znTV4lGKjwKrKwvRW0T765cdfz1B8Ley2hpBmKe1XtnajkDrK1drndunT5/WDhE9hQY8Zo7SB51YgtKaGe62klXsdQECpCSeJCnhLAbD+TX/LKYG4pSbw86hoW1XeRpI8Hn50CxdgaJ3iXayWk3Tfags/AMzghOLCTxeGkxUMsCil9MG0AY2eHNJTvyEiZ4G0rS31UM9Hn/LKtaS1YWMsZRSr600eJoSkxnNNHc9H1iSZAi76FWimqyC3XqBJGQP6+Z7O2z7E0qpEqWUrHfQ2wWGrL/gvQZnXBmz2mhVAVgttdww47vMyn4qWtF1Cx/sfJhX8//Iucrx5+1LNjrYrYcxUFcRnplmues4abRw1GCJYqRCdK6oLy8aNoAifFtO4O98IC3aMYku4jFRg5VzCdXEq6ah162xWuq4atxfohhc93CqLJsjJ+dw1bgX6Zu+97z9tUYLfXU1Vd5k0kz+iuszAz/HDyyJDI9msEJ0IhkyJLqGBrxGdjCa+MTdJPu8TPQ0dHVU3U7L1YJbGhgYwn7COSi0bYjPzTCvkw9kvpXoRSRZia7hMQGKV9xzsCTuZ7q77oLN/Nr6/uza/wUOn7wmWhF2C6Y2hq4HjTUfZb9vEPHe5gMwZrnq2G5OwOmNjQnUoveTZCW6htc/ZD3fNBSXqZHZF+gCBCirGseGD59gx+77ohRg99ByafuWDEpzTGUynLN4w0oyzXLV0qgMFJ09b/aHED2SJCsRfYGqFYdVX0goAWDmBQZXQFPLwhgjpZaCQt2AbbSsAOJMDkzKx1FX08rKue56zNrHh6c+7PQYhYgGSVYi+nz+IevrvVNJSdrFaE8j/XyeC54SbFkEa+XFiraWCQl3pXU/VTqRBnfTRGAbmqvcDj46/VGnxyhENEiyEtHnMaHRPO+Zizv+9AVHAYZOCQwwiLWWVWbqAUYM2kRK4ok2j0k11vGpHsYgXdlsCPsMdz17K/dS1SizQETPJ8lKRJ/HhF3ZqEoow6c017UnWcVgEVuAK8e8wqL59zJ2xOsXPK7BaCJVOajypIS2TQ90rUrrSvQGkqxEdAUWWvzINx5b0sek+TxM8TguelqslltqryGWE3i14rSrqQr7BE8DSeYktp7e2oWRCREZkqxEdHn9Q9afd1+PIekAc101GNtzmtdfjSFW1rIK8ngt1Ddk0uBMueBx48xHKNYjmlVhNwLTBkxjy6kt6FhbZln0OpKsRHR5TLgxsD0+Hq/BwzznxbsAAWZc9Wse+cpwZk75ZefG183sLf0sv/trEe9s+8EFjzMozUmVyjBVhtfblP6nD5jOqfpTnKht+56XED2BJCsRPYEh6/sZhClpD/E+X+i+SnsYDD6MhguPGuxt2jN0PSjR7E/8R12DQ9umD5gOwJbTWzohOiGiR5KViJ7AQov/8E4nLulTZrtrsUpt8Atqa6Xg1lxl2csZnYrTYwttG5Y8jP4J/eW+lejxJFmJ6PGa0MDLpgl4TQ1c76pp96nv71jGi//8B6XH53ZefN2QyXTxeVZByUYHe/UQhujy0BB2pRTTB0xn25lteH2tL78iRE8gyUpEj8fEOZWMO6kEo9Zc244h60FVNVmcKb8Kpzu2FhW8lG5AAG3ykqicnHL1DW2bPmA61c5q9lXt65QYhYgGSVYiOgJD1t/1TsSa9AlXu+tI0uevftuW4KTgWBu6frGq6y2NtR7CpY2UuZuS1dUDrgZg6ynpChQ9lyQrER2BhRafVTPQFvsldQFC2DyrWCu3dJFCti0NMpVTrIeT4asPbcuMz2R02mgZZCF6tKgvvihilMeEAzPHkiqJ0zDnEroAoakbzBxj86xSEk/y2XlfI97a/pJJ1cY4snUFdk8yqYFt0wdMZ/W+1TR6GokztS/xCdGdSMtKdD4NeE0U6lFYk3eS466n70UK17YUbFkYY6wb0GKuZ8ywtxjSf1u7zxlgPg3AYefQ0LbpA6bj8rnYeW5nxGMUIhokWYnOF6ha8QdDLlgrudlpv+RLhO5ZxVg3YEeMtRzhuO6DyatC23L75WIymGQIu+ixpBtQdD6Pf6HFwiQPZg03XOL9KoAxw9+gtn7nJXWH9QY+n4GPPvkGXm1m9pRftOscpeCYyiBHl9DoqCXOloTNbGNyn8mSrESPJS0r0bkCVSsOMABD8qfMcNWTqi99vs/sKb/gptnfJtFWFvkYuzGlfBTs/DZbPn4YrdXFTwhIMNUQp9wc2PpGaNv0AdPZW7EXe6O9EyIVonNJshKdK7DQ4h9MV6LMNdzqquzqiHoUpZru03kCxXzbY5y1hGptw7rzT6Ft0wdMR6P56IwsGSJ6HklWonN5/T3N7yRaMPlgbjsL17Z0umwy5yrHE4vFw9uzWnBLcQY3m5jE2NqteA++DcDEzIkkmhOlK1D0SJKsROfymDhNEq6kg1zjcmCj/ROBg7RW/OVf/+T5v7/VCQF2f6Fk1c4qFkE2SzXHfH1ofP274PNiMpiY2n8qW07JfCvR80iyEp1HA14jf7KORZkcLHR17H5TePUK1f7bNr3GpRSzDXeddSe/5B4S7Pvg45cBf1fgybqTHK89HvE4hehMkqxE5/H4h6y/kZCI1Wdgtqv9y4E0u0yMlloKaqpi0b6SS0FxyoVr7G18whj0psfBWceMgTMApCtQ9DiSrETn8ZgoVxaqk46T11iLpYPLgQS7v4wxVr0iKCH+HEm2U3AJowGDPjNpID903o2qOwMf/prhycPpZ+snXYGix5F5VqJzaNBeE8/YslAGB19wnenwpWK1LmDQ4hvv7vC5c8b25Vum8XyaMpcrP/wVKudepg+Yzrsn3sXr82I0GC9+ESG6AWlZic7hM6C0gTeTrGS4TUzyNHT4UsHuL3OMdgNejniLkXnj+/JY3SK01w3vPM6MgTOodlazt3JvV4cnRLtJy0rgqve1OSTcaFGYLP7uJ69b43G23ZVn0Qql/Pu9rjiOmkxUx1fxNXs9LlfTOlQGgwdzoJWktcLlTmjzmiZTY6gbMFZbVgBujxWfz3zedqU0FnNThXWXO6H55OE6Hwuy+vPIjrOcyvkSg3Y+x4wpd6NQbD5cwOi4Ca2+nsWmUAb/ddwNPtpat9FgBHO8/zuv9mlcDv+/vyVBoWJxNIzoNJKsBM/efBpHRetDymc+mMysB1MAOFzQyGsPlbd5nQcWZ4YqTFTbs3gp04ryubG//Bq/qk8PHTdyyEY+n/dVAOocffn9K9vbvObn8+5l6IAP+fJtN2EwuC/5vfUGG7f8iI/3faXVfbb4c3zjrtzQ8z++uok6x4CmA146CcBSJvKyqy/fHvwa6e+uZKRlHH/b8A6OJZ9p9bpfzx9AUn//x8O/lldw6J3WvyhkXRPH7U/3AaC+0sfTc04BMP5mG7eszLi0NyrEBUiyElhsBjyNrbeYjOamb8cGo/8bc1uCrSp8iuTEY6xPG82gw9mkuMxgbpoMHD6qTymwmNueKBxshfXL2N3et9PrDO63nf2Hb8XbSsvKYnI0f26ub/7ztCQD0Oj2Ulyu8H5hOcYNj3L1uK/w8sDN6PQ6rM6k81807J/ZZFVt/rub4pq2K8BsU7gdmqNbY7cVLDqH0j24JEBubq4uLCzs6jB6pL9/qxx3g+amx9NJyIjQTfanAh9cbjPvqTS+0b8vP7af5TZPbNXz61Ye8f//3rD7DEtf3MFzX5rE3Ldv42OzkS/ZnDx53ZMsGL4gYi/nbvTxy9yTGC3wraIhEbuuiCyl1A6tde7Fj+w+ZIBFjDq21cnh9xtRnfAboD0mViemYfJauMnTdrehiJ45Y/uSZjPzt11lkPdfTDx7kCSDlQ9OfhDR1zFZFQYTeF3gcfXcL8Ki+5FkFYO01jjr/feorIkR/hXQUOaLoyDBzDSHAXMH51aJyLKYDNw6eSAb9pylZsSNmIbOZIajng9Ovk8ke1eUUqHfKVfdpZfWEqItkqxikLtBo73+b8Hh96Qiwmvkn0k2fAr+w70/stcWl+Xz2YNxeXy8WXwG5j/O7NpqzjWUc9B+MKKvY0n0/045JVmJCJJkFYNc9YHhxYmRH1rc4IljTVISmQ3JXOHrWIV10TkmD04hKzOBvxWdhME5zBp6PQAFJa9H9HWu+1Yqt6zMwJYmE45F5EQ9WSmlFiml8pRSyy9wTHY0Y4o1ztpO6gIENpvSOGk2cWdjbK3o2xMopfh89iC2Ha7keKWDvvN/zBiXmw/2/S2irzN2vo3xN9uwJsl3YRE5Uf1tCiYhrXU+YG8tKSml8oBnoxlXrAl2z1gj3bLyKf6VbCXeY+Krnn2RvbaIiM9eNQiAdTtPQupQZqVfQZHHTv0xqRUourdof/VZDNgDj0uBvJYHBBKZLCfbiawJBsbfbGPYjEtbcuJiir19eC8+jqvqbViUDKzojoak27h6RDqv7TyJ1prZuf+ORym2bfoekVrZ8ti2RrY9V8PZva6IXE8IiH6ySqV5IpIp7l0gY6SZW1ZmcO3DqRG97t/i01HAN1yRvWEvIuv27MGUltdTdKyKKYNnk2Aws7n2MOx/MyLXP7Cxgc1PVXOyKDar5IvOIZ3KIiIaHVVsSlSMd1iZrGQScHf2mUkDSLSaeGnrMcxGM7OHzOHdxER8G78P3ssvaWWV0YCiE0Q7WdmBYJG4VKDiUi+glFqqlCpUShWWlcmHYkfUl3upPOwODbSIhBfefopKk5G8+jYqnopuI8Fq4nNTBvGvT09TVe9i3tA8KgzwSd0x2PHny76+JTBwx1krXcEicqKdrFYDWYHHWUA+gFIqtb0X0Fqv0lrnaq1z+/TpE/kIY8DHr9Txx1vPsP35yAwt13VlbDjzGoNcPu5Glp3oCe6ZPhSXx8faHSe4ZvA1mAwmNg0YA+/+FBqrL+vawVGmwYnnQkRCVJOV1roIQiP+7MHnwNvBY5RSi4DcwN+iEwS7Zy5UlLbdvB62rb6L/RYD42r6YjPITfWeYFz/ZHKHpfHSR0dJMCUytd9UNiXY0I5KeP+py7p2cP6eK4ItdyGifs8q0DLK11qvCtuWE/Z4rdY6TWu9NtqxxQpXnb97JiLzYN7+If/nPILZa+Yb3j2Xfz0RNV+cPowjFQ4+LKlg3tB5HHWc4fDE22Dr76HqaIeva00ItqykG1BEjgywiEFN86wu85+/+G8c3/Y0b9ts9DEuYLTxXASiE9Fy05X9SU+w8JetR5kzZA4Am4ZN9q/b8vZ/d/i61iQDpjiFQT5dRATJr1MMaqpgcRndgGd3w9//nWf7ZqEx8h+5rS8OKLovq8nIHTmD2bj3LHhSmZgxkU3ndsCMf4fitXBiR4euOyjbwn8WDubzv5V7yiJyJFnFoKbagB3852+ogr/eQ3VcMn+3+Ih35nDzhLERjFBEy91XD8Xr07y87Rjzhs7j0/JPOZt9DyT0hQ0dmygsy9mLziDJKgZdVm1Anw9eXQrVJ/j9hM/jUy7uGvtF+YDqoYZlJJA3vi8vbjnCjAHXAvDu2e0w97twbAvs/WcXRyiEnySrGHTLzzO449k+pAzqQFXsd38KBzfgXPA4r5wrgIZRfH3GNZEPUkTN168bSZXDzfb9ZoYlD+PtY2/DlC9Bn3GQ///Ac2kjPLVP86fPnub3eafQPhlkISJDklUM6jfOwvAZcZjjL/Gff9/r8N5KuOqL/Mlkw4WdOf2+QILV1DmBiqjIHZ7O1OFp/KHgCHOHzGPbmW1Uumtg/uNQWQrb/3BJ11MGRc0pL7VnvLgbJFmJyJBkJdqn/CC8ej8MnIL7xp/x3O4/4WsYxvfm3drVkYkI+Pp1IzlpbyDRfTVe7eXNw2/CqDzImgubn/Dfp7wEwWkRkaySImKbJKsY43L42PDflXzwu0uoUuCshb/eAyYL3Pkif9n/Bg26gpkZd9I/Jb7zghVRM3dsX8b0S+S1j7yMTRvL66Wv+4ewz3/cX9HivScv6XrBCefOOmlZiciQZBVjGuw+dr1Sz6ev1rfvBK1h3QNQcQju+DOe5AE888kf8DUO4vvzbu/cYEXUGAyK+68dyb4ztYxPmsOn5Z9yuPow9J8IU+6Bj57xdwm2U6hlJcVsRYRIsooxlzzHquAX/hFhN/w3jLiWNXv/Rb3vDDnJixiakdCJkYpou+2qgQxMiaN4/0gMyuBvXQHMfQyMZsj/YbuvFRxp6pJkJSJEklWMuaQ5Vofy4e0fwcTbYcY38Gkfv9n5e3yN/fjB9Xd2cqQi2sxGA1+fM5KdR3yMSZ7Cv0r/hdYakgfArG/Cnr/DsY/ada1gfUCpvC4iRZJVjAm1rC5WF7DyMKz9KvS7Am77NSjFmn3/oMZ7kokJtzOqb3IUohXRdtfUoQxNt3H21BWcrDvJx2Uf+3fMfAgS+7d7ovDoefFcfV8SaSNkpKiIDElWMSZUF/BCFdddDlj9JUDD4hfBkoDL6+IXhb/C1ziQH91wd3SCFVFnMRl4ZP4Yjh0fidlg5Z8lgUnBlgSY9xic2A67X73odSbcksC1D6fSb5ylkyMWsUK+9sSYYMV1S1stK63hn/8BZ4vhnrWQ7l9+7Lc7XsThK2NW+qOM6ZcSrXDF5Xrq0iuL3KoVzxh/yRn7cN7a91e+8+EPsaBBA4YE+Nu9sH4RtPfSj0hXoLh80rKKMWabInO0mZSBbXxP2fo0fLoG5n0PRucBUOuq5YU9fwDHaH5yk4wA7O0MSrM84Xmq7bOoMRh52xLo8lWAtRG0AdwXbjHVOfpy+OQ1nK2Y0PkBi5ggySrGXHFrAkte68/0r7Vyz+lIAWx4DMbdArMfCW1+/P2n8ag67hh5P5mJ1ihGK7rKdeYicl0N4Erjhfiw6ukmLxjd4LSCr+2m1eETc1i74SWK9vxbFKIVsUCSlfCrPglr7oWMkbDwaYKLEZ2pO8ebx1djashm+dy8ro1RRI1S8N2EP+OsnEWxOY5PTWGTv61O/9+utltXFksdAE5XUmeGKWKIJKsY4/O2cv/A44RXvgTuRlj8EsQ1tboeyf8pPjx8M/sh4swdKHwreqzJ5oN8rrES7bXyG+uwph1GH5jd/q5AX+sfIVZzLQBOtyQrERmSrGLM3x8u5xdTjlOyuaFp4xvL4OQO+Nzvoc+Y0OaNJVv4pDqfTO98vjI1pwuiFV3tu7aXMFVfyYdxZk6psJaUJdC6crbeLWy11ADgkmQlIkSSVYxx1mq8bjDFBe43FD4HRS/ANctg/C2h41xeF997/7/Q7jR+f8t3ZL2qGJViqOdbzv1o4PumaU07DNqfsDxm8Jzf4raYg92AiVGKVPR2kqxijLM+bOHF49vhjW/7q2vP/W6z4x7N/x0N6iS3DX6Qcf0yuiJU0U18ybSFtPoBfJTg4rA3s2mHxQXKB844/7D2MFaLdAOKyJJkFWOCFSziDOf896lSBsHtfwBD07fjT88eYcOpF0nwTOZH8xd3Vaiim1AKvuPajTI5eFDdgk8HWtkK/2ALnxE8zadCWAL3rFwuqXQiIkOSVYxx1WsMyk3S+/f5l35Y/BLEp4X2+3w+vrH++2g0v8j7fxgN0v0n4GbfSfq7zBxLLeHXjrC5diY3GLznta7Mpgbuu/0a7r9zevSDFb2SJKsYorXGWetjzqSfYzy1xV/zr//EZsc8/MYzVPEx12Z+iZnDRndRpKK7UcB/OQ5gsFTx27gstrmuaNoRnCgcNpRdKUhLPootrrJL4hW9j5Rb6i3aUVbH67EybuBT5Ix+GcxO2HAHbGja/6r3Sjb1MZHWmMmvy74FB77ViQGLnmamp56rnQ62ZW7iodKHeNO0nHRDjX+isMkNLqt/SLtByiuJyJOWVSzRcNPUx6h1ZjRN7Aw46s3kh8n9MGgjLzgKMUrvn2jFMscpMDRQk7aL/6z5Fh4d+AgJDmV3NQ1l31z4HdZueJ7KI+4uiFT0NpKsYoVPYXKaMRg8JKUfaVaEtFGbucd8Azr+DCtqyhlBXZeFKbq3cd5GPuOsxprxPu/pUfyg7gH/iiGhicJm8Po/Vk6dy+HwybnUl3m7NmjRK0iyigUaaIwHrSDe0aybxq2N3O25F3taMdPrzdzjPdJlYYqe4SHHWQz4mDTgWV5uvIlfO+7y72gxUTg016pOugXF5ZNkFQtcVvCacBDPzgP3cOTUbAC82sDXnF/lQL8dDHCZ+VXDx10bp+gRBvrcfLGhgtLECq5LfYVfOL7I6oYbmiYKe/0ThYNVLJyytL2IAElWvZ3bFLjx7eJERTb5W3/Mzr1fQWv4VsNX2d6vmCSfj/+r+4T4ljM7hWjDg45zjPQ0cqzvNmZaP+S7df/O3xuvbTZR2GqpBiRZiciQZNWbeQ3+7j+DB6yNuNz+0jdmcx3L67/Oxr5HsBrreL52L5na08XBip4kDs0TtSeoNhhIH/Qy2ebdPFy7jBcaP+Mfyu4zMiSjCABXrXwJEpdPklVvpYGGeFAa4htAgTNQTeBd4wj+1eckJutp/remlDFe54WvJUQrxnob+abjLJutidze7xdcb9nOD+oe4H+cd6ANXrL6bMFkbAiV+BLickiy6o2CiUobIK4hNKCi3NUXZ1wt713zR8y2w/ys9jjXeGTkn+i4LzVUcLWrjl8k9uWRtCe53ZrP/zbcw9O+W7CYGliQ+wPSh8t0TnH55LeoN3JZ/Te5rQ3+CZvAJmcuL7mu48ji7+BKPcova48yz1XbxYGKns4A/LjuBHenjOSB1KH8iacZUFvOSseXmGQ5xswhb2LIqwOk+rq4PNKy6m08gQEVJheY3Ti0le/VPsh9zq+x79qV1Kae4pE9wyVRiYjp5/PwbM1hNIqlKcP5QtJq/pzyA37uvhOPNnLs/x5G15zu6jBFDyfJqjfxGfzdfwYv2trIu+5sbq76X16JSyVpxG8wm+q5Yc1PyHV0daCit8nyunim+ggOZeC+lBGMj/uE36f8hLfcMxh66k3UL8bh+sVk+Ps3YOdLUHkY/2xiIdpH6R78C5Obm6sLCwu7Oozu4UkFjgTQioOWdP7bcR8FvjGk91+NK/kgs121/KT2BKk+H1obMBikqoCIvE9M8XwteTiJ2sejJ03sXP0Gg8YWc2rSm0z27mGW+QA2r3/+FUkDYdgMGDYThs6EPuPAIN+fo0EptUNrndvVcVwKuWfVG2gNjfFon5Ff61v5n+rbSUp/j/Q+P8GrvDxcf5YlDeX+ZrQCpSRRic4xydPA89WHeSR5CMuGwKRpa0g6sZivLsvj5xv2c/+2I1xhOsPXR5xlbvwhbEc/hOK/+U+OT/MnrWEz/Ums/2QwykeU8JOWVU/l9UDtKRrOlXJy698YVfoCP3LfxSsJ/Ujq+wa1ZiezXLUsrz9DlgxNF1FWpwz8IH44G202Bp2Ywv8+8D3Gpo/l4Nlant5cwj8+PgXAjVf0455xmmlqH8bjW+Doh1BZ6r+IJRGGTGtKYINywBzXhe+q9+iJLauenazG9tOF+892XQDvPOz/e+4vI39traHuLNiPQdVRsB8J/H0UX+VRqDmJITCRt9xo4GeJYyhIdlJv8jLC08iy+jNc624+LP3/3ngFt8fG7Td8hYT4isjHLEQYj8/EAx//hh3XPoc7rp4bh9/Ig1c9yIiUEZyocvDHgsO8tvMkdoebzEQrt04ewLxxfZmW6cJ68iN/4jr6IZzb7b+g0eJPWMMCyWvI1WBNal8wnfl/tb26QwwA7zzM8Nv/99yRSt2vawO5NFFvYyulFgF2IFtrvfJS9/caWkNDlT8Z2Y+GElHob/sx8DQ2O6XOnM4J3Zf9zoEUm8azN8VHeXotpziJxsEsVy13V1cw213X6siZc5VX4HInYTK6ovMeRUwzGTxMKJ7LsH3XkPC7jfzfoZfYcHQDV/e/mptG3MR/Lrie79w0jnf2lfFq0Qle2nqM5z44QrzZyIyRQ8gd/nWmLHiUSRk+Es4WwtEP4OgWKPglvP8UKAP0nwTDZvm7DYfOhISMrn7bopNENVkppbIBtNb5SqkspVS21rqovft7HFd9WMuolYTkrGl2uNeaQoNtMBWWIZzKyOGQK50dNUnscps4Y9ZoazlpaafxWo7S4DsJwNi0sdzvHcHNR99ihLftJKS1wuX2fws1m+o77z0LEcZiqcXT0JevbfgpX04o5+X4DN44sZkfnN7Cjz54jGy3g8keB190O/hhupd9zit415XL+wensGnfIAAMeBluPMVoo2aUaRBjjB7GqJMM0pUknivEcHonbP2t/wUNXjB6wejx/x2+EGT2N7vgJyAiJdotq8XAxsDjUiAPKLqE/c24nWZO7mxxP0ZrQJORZSIuSQGa6lNu6s568Jd20KjAMaAxmhX9xpnQ2of2aU7vcaI9XrTWoT8APu3DlqmIT1d4tabB7qF6dyr6aD7G9dMwKhdm5cFscGI2NGI11WPCh0eBF4VHgQMzFb5EKnQKp/VITutUjhuSOGRN5KRKwqU0CfUufK4alOUMButePIPt+Ay+0D9UhtfJJIeDMfUWrqxIo7/7SGDPlZwMPDIaXfTP/DT0IzldNhlnIFFZzLUYDFL+RkSH1VyLo6EvTlciaXHlfP7wED6H5kCcZnOKj10JSfwhPhGfzX98kq+eod4NTHa9zdUNybhdadS7+lLt7sNRVz8+rr8Wny+O8iQP+MworRhd7WGK6SBXmfcz3nKIkcbjxBtcKKBO26g0xFNriMO7rxbvyb9iMhoxGEwYjAYMBhNGgxGDwUjqcAumOBMGg5H6s+BuMKCUAaWMKGVAKyPKYMCSaCZjuAVlNKJ9Bs7u84IyopUBlBEwgDKglYG04VZs6WZQBmqrEqmpSobU8+8hKyMMnNS0cOWZ3S68rtZv0ST2M5Iy0P+J0Fjjo6Kk7cUt+02wYLL6F6+rPOymwe4j/mxax/4xu1i0k1UqUBn2vGWb/WL7mzmoKrhlV07rOz+5hKg+vvDu0K9MSdNzDegkBRPDj1RAXOBP6gWu6AEqAn+aWACf20J8fTrx9WnEnx1PUnV/kisHkVw5mC9N+jGT+38A+Fdh3fTpg61ePSXxGEvvmB16vnbDizS6/PFYzTIZWETP/JnfRWsDSQmncbkTefmN10L7EoFZwDRzAxX9D9B/5kqcfQ5xzGjlE5VOVTJ4LGeAM+ddN7wexqnAn9dDW/qfd7zSGsVH4PkIFajZfN5i2JUtN1xAez9fils8NwK7Xmj92M7oQ9rVCdfsIlEdYKGUegZ4RmtdpJTKA27QWq9o7/7AMUuBpQAWI5Nc3ktKSxE1LI0htU7iKx0c6KoYgnEAHK3i+MWOTTMPHgJQ5T5xPPxxJGLo7J9Fe+K90M+iI++3I+cMS2NIjSMlFV+SvaM/20j821zK78Xlauv3qif+H+nMGLrLz6K8nuQ6p47vyjguVbRbVnYgPfA4lZZNi4vvR2u9CljVGcF1hFKqsKcNAe0s8rNo4v9Z2OVngfxehJOfRcdFe7r4aiAr8DgLyAdQSqVeaL8QQojYFtVkFRzZF+jis4eN9Hv7IvuFEELEsKjPswp047XclnOh/d1cT4u3M8nPoon8LJrIz6KJ/Cw6qEdXsOiulFLLe/WEZiFEh8nnQ8dIlcgIC3RhTu3qOLpaYNQmwMiWIzp7u5ipwtIOsfx70Br5fOg4qccvIi7wHzI/0KWbFXgeE8KrsAD24PNYFMu/ByLyJFlFUKA8lIxg9I/kDH4wldI0wjMWLMbfqoKmKiyxKpZ/D84jnw+XR7oBIyv94of0fi0GyWTjn5IQK1K5hCosvVmM/x60Rj4fLoMkq0sQ1v8erjRQeFe+NbUQ6ALbKFMQYpv8HkirKhIkWV2Ciwyrz1JKZYU97tkV4y/iQok77HleDA4wsHORKiwxKBZ/D1qKqc+HziDJKkK01msh9CGe2rXRdL6LzYdTSi0NfkAppfJi6FvlaiBYTifmq7DE8O9BM7H2+dAZZJ6ViLjAqK81+O/dpAN3xNKHVOADqRTI6oGT3CMm1n8PRGRJshJCCNHtydB1IYQQ3Z4kKyGEEN2eJCshhBDdniQrIYQQ3Z4kKyGEEN2eJCshhBDdniQrIYQQ3Z4kKyGEEN2eJCshhBDdniQrISJMKZWtlCpRSq0Je57axWEJ0aNJshIi8vKAHOCZYHV6rbW9SyMSooeT2oBCdJJAaypda13a1bEI0dNJshKiEwS7/aRFJURkSDegEBEWXGQvmKjCFt0TQnSQLL4oRAQFlnDPBSqVUvn471/Z8a9vJYToIGlZCREhYV1/q/CvEnwYmCoLDgpx+eSelRBCiG5PWlZCCCG6PUlWQgghuj1JVkIIIbo9SVZCCCG6PUlWQgghuj1JVkIIIbo9SVZCCCG6PUlWQgghuj1JVkIIIbq9/w98TlGvVxfG1wAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig, axes = qp.plotting.plot_native(ens_n[15], xlim=(-5.,5.))\n",
     "qp.plotting.plot_native(ens_h[15], axes=axes)\n",
@@ -1632,7 +690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -1644,17 +702,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0 0.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cached_gridded = ens_n.gridded(grid)[1]\n",
     "check = gridded - cached_gridded\n",
@@ -1670,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1689,96 +739,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[-2.26209442e-06 -5.22381128e-06 -8.21403501e-06 -1.12278108e-05\n",
-      " -1.42602342e-05 -1.73064535e-05 -2.03616734e-05 -2.34211569e-05\n",
-      " -2.64802286e-05 -2.95342775e-05 -3.25787589e-05 -3.56091979e-05\n",
-      " -3.86211912e-05 -4.16104100e-05 -4.45726023e-05 -4.75035953e-05\n",
-      " -5.03992978e-05 -5.32557025e-05 -5.60688882e-05 -5.88350221e-05\n",
-      " -6.15503620e-05 -6.42112586e-05 -6.68141571e-05 -6.93556000e-05\n",
-      " -7.18322286e-05 -7.42407851e-05 -7.65781150e-05 -7.88411683e-05\n",
-      " -8.10270020e-05 -8.31327817e-05 -8.51557837e-05 -8.70933963e-05\n",
-      " -8.89431221e-05 -9.07025793e-05 -9.23695038e-05 -9.39417505e-05\n",
-      " -9.54172952e-05 -9.67942361e-05 -9.80707954e-05 -9.92453205e-05\n",
-      " -1.00316286e-04 -1.01282296e-04 -1.02142082e-04 -1.02894509e-04\n",
-      " -1.03538574e-04 -1.04073407e-04 -1.04498276e-04 -1.04812582e-04\n",
-      " -1.05015867e-04 -1.05107809e-04 -1.05088229e-04 -1.04957087e-04\n",
-      " -1.04714485e-04 -1.04360671e-04 -1.03896036e-04 -1.03321114e-04\n",
-      " -1.02636589e-04 -1.01843289e-04 -1.00942192e-04 -9.99344224e-05\n",
-      " -9.88212567e-05 -9.76041198e-05 -9.62845877e-05 -9.48643879e-05\n",
-      " -9.33453995e-05 -9.17296544e-05 -9.00193372e-05 -8.82167856e-05\n",
-      " -8.63244912e-05 -8.43450992e-05 -8.22814089e-05 -8.01363742e-05\n",
-      " -7.79131029e-05 -7.56148575e-05 -7.32450547e-05 -7.08072655e-05\n",
-      " -6.83052151e-05 -6.57427824e-05 -6.31239999e-05 -6.04530531e-05\n",
-      " -5.77342804e-05 -5.49721720e-05 -5.21713696e-05 -4.93366658e-05\n",
-      " -4.64730026e-05 -4.35854713e-05 -4.06793110e-05 -3.77599071e-05\n",
-      " -3.48327911e-05 -3.19036380e-05 -2.89782657e-05 -2.60626330e-05\n",
-      " -2.31628380e-05 -2.02851158e-05 -1.74358373e-05 -1.46215061e-05\n",
-      " -1.18487569e-05 -9.12435256e-06 -6.45518163e-06 -3.84825547e-06\n",
-      " -1.31052154e-06  1.15518502e-06  3.55015792e-06  5.87578596e-06\n",
-      "  8.13337174e-06  1.03241341e-05  1.24492106e-05  1.45096601e-05\n",
-      "  1.65064654e-05  1.84405359e-05  2.03127102e-05  2.21237593e-05\n",
-      "  2.38743891e-05  2.55652432e-05  2.71969063e-05  2.87699070e-05\n",
-      "  3.02847204e-05  3.17417718e-05  3.31414393e-05  3.44840571e-05\n",
-      "  3.57699188e-05  3.69992802e-05  3.81723626e-05  3.92893563e-05\n",
-      "  4.03504231e-05  4.13557004e-05  4.23053037e-05  4.31993301e-05\n",
-      "  4.40378616e-05  4.48209681e-05  4.55487107e-05  4.62211453e-05\n",
-      "  4.68383249e-05  4.74003038e-05  4.79071400e-05  4.83588989e-05\n",
-      "  4.87556561e-05  4.90975005e-05  4.93845378e-05  4.96168928e-05\n",
-      "  4.97947135e-05  4.99181729e-05  4.99874731e-05  5.00028473e-05\n",
-      "  4.99645632e-05  4.98729258e-05  4.97282800e-05  4.95310137e-05\n",
-      "  4.92815599e-05  4.89804001e-05  4.86280662e-05  4.82251436e-05\n",
-      "  4.77722733e-05  4.72701544e-05  4.67195466e-05  4.61212721e-05\n",
-      "  4.54762184e-05  4.47853399e-05  4.40496601e-05  4.32702738e-05\n",
-      "  4.24483487e-05  4.15851274e-05  4.06819290e-05  3.97401512e-05\n",
-      "  3.87612710e-05  3.77468469e-05  3.66985203e-05  3.56180161e-05\n",
-      "  3.45071446e-05  3.33678022e-05  3.22019728e-05  3.10117281e-05\n",
-      "  2.97992291e-05  2.85667260e-05  2.73165598e-05  2.60511620e-05\n",
-      "  2.47730553e-05  2.34848542e-05  2.21892647e-05  2.08890849e-05\n",
-      "  1.95872051e-05  1.82866073e-05  1.69903656e-05  1.57016459e-05\n",
-      "  1.44237056e-05  1.31598936e-05  1.19136496e-05  1.06885041e-05\n",
-      "  9.48807783e-06  8.31608155e-06  7.17631562e-06  6.07266971e-06\n",
-      "  5.00912249e-06  3.98974147e-06  3.01868288e-06  2.10019170e-06\n",
-      "  1.23860183e-06  4.38336438e-07 -2.96091428e-07 -9.60078005e-07]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# for a single pair of pdfs. (the 15th in each ensemble)\n",
-    "klds = ens_n.kld(ens_s, limits=all_lims[0])[15]\n",
+    "klds = qp.metrics.calculate_kld(ens_n, ens_s, limits=symm_lims)\n",
     "print(klds)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hist approximation: KLD over 1, 2, 3, sigma ranges = ['5.15e-05 +- 5.32e-04', '7.61e-05 +- 5.39e-04', '7.15e-05 +- 4.69e-04']\n",
-      "interp approximation: KLD over 1, 2, 3, sigma ranges = ['-1.41e-04 +- 1.79e-04', '-4.01e-05 +- 1.84e-04', '3.97e-06 +- 1.68e-04']\n",
-      "spline approximation: KLD over 1, 2, 3, sigma ranges = ['-1.27e-05 +- 4.25e-05', '-1.27e-06 +- 3.63e-05', '-1.10e-06 +- 3.05e-05']\n",
-      "quant approximation: KLD over 1, 2, 3, sigma ranges = ['-1.16e-04 +- 3.49e-04', '2.80e-05 +- 5.64e-04', '1.40e-04 +- 6.07e-04']\n",
-      "mixmod approximation: KLD over 1, 2, 3, sigma ranges = ['-4.07e-06 +- 2.45e-04', '3.21e-06 +- 2.12e-04', '1.23e-05 +- 1.80e-04']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Loop over all the other ensemble types\n",
     "ensembles = [ens_n, ens_h, ens_i, ens_s, ens_q, ens_m]\n",
     "for ensemble in ensembles[1:]:\n",
     "    D = []\n",
     "    for lims in all_lims:\n",
-    "        klds = ens_n.kld(ensemble, limits=lims)\n",
+    "        klds = qp.metrics.calculate_kld(ens_n, ensemble, limits=lims)\n",
     "        D.append(\"%.2e +- %.2e\" % (klds.mean(), klds.std()))\n",
     "    print(ensemble.gen_class.name + ' approximation: KLD over 1, 2, 3, sigma ranges = ' + str(D))"
    ]
@@ -1792,28 +773,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hist approximation: RMSE over 1, 2, 3, sigma ranges = ['2.86e-03 +- 2.10e-03', '2.04e-03 +- 1.49e-03', '1.34e-03 +- 1.19e-03']\n",
-      "interp approximation: RMSE over 1, 2, 3, sigma ranges = ['1.33e-03 +- 1.04e-03', '7.37e-04 +- 6.08e-04', '5.08e-04 +- 4.53e-04']\n",
-      "spline approximation: RMSE over 1, 2, 3, sigma ranges = ['2.44e-04 +- 1.99e-04', '1.33e-04 +- 1.24e-04', '8.43e-05 +- 9.18e-05']\n",
-      "quant approximation: RMSE over 1, 2, 3, sigma ranges = ['2.22e-03 +- 2.38e-03', '1.97e-03 +- 1.76e-03', '1.49e-03 +- 1.41e-03']\n",
-      "mixmod approximation: RMSE over 1, 2, 3, sigma ranges = ['1.41e-03 +- 1.02e-03', '8.22e-04 +- 6.72e-04', '5.21e-04 +- 5.16e-04']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for ensemble in ensembles[1:]:\n",
     "    D = []\n",
     "    for lims in all_lims:\n",
-    "        rmses = ens_n.rmse(ensemble, limits=lims)\n",
+    "        rmses = qp.metrics.calculate_rmse(ens_n, ensemble, limits=lims)\n",
     "        D.append(\"%.2e +- %.2e\" % (rmses.mean(), rmses.std()))\n",
     "    print(ensemble.gen_class.name + ' approximation: RMSE over 1, 2, 3, sigma ranges = ' + str(D))"
    ]
@@ -1838,57 +807,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "dict_keys(['meta', 'data'])\n",
-      "\n",
-      "Meta Data\n",
-      "pdf_name pdf_version\n",
-      "-------- -----------\n",
-      "    norm           0\n",
-      "\n",
-      "Object Data\n",
-      "       loc [1]            scale [1]     \n",
-      "--------------------- ------------------\n",
-      "  0.21890181476361925  1.056285515199821\n",
-      "  -0.9353465163053121  1.026997357837372\n",
-      "   0.0790311297883819 1.0650292686359373\n",
-      "   0.2817677311967628 1.0609266256396983\n",
-      " -0.24968255449689325  1.074816209393585\n",
-      " -0.26335093519888186 0.9037322517071256\n",
-      " -0.42948520774760524 0.9612918688186005\n",
-      "  -0.4387296971766421 0.9016267220210851\n",
-      "  -0.5721718878022877 0.9456574782851268\n",
-      "  -0.9245553404486575 0.9837884735516019\n",
-      "   0.3485864086454653 0.9315509277021065\n",
-      "  -0.9140685467095657 1.0122140028534963\n",
-      "  -0.9841498717108201 1.0480154702564222\n",
-      "   -0.860600381074875 1.0399719083435217\n",
-      "                  ...                ...\n",
-      "   0.7435764010663093 0.9720023232518367\n",
-      "  0.12353466858365003 1.0132577053993985\n",
-      "   -0.701840262821126 0.9285457000970706\n",
-      "  -0.5470405981046298 0.9817410948934674\n",
-      " -0.11981840164786872 1.0142932436528753\n",
-      "   -0.807956492346696 0.9467640761369589\n",
-      "  -0.8460750962310981 0.9940399193900734\n",
-      "   0.3498014730068775 1.0359665513079788\n",
-      "  0.08250538556297093 1.0266698031123653\n",
-      " -0.18080125328979002 0.9367304078396651\n",
-      "-0.024151853833798587 1.0119490615751972\n",
-      "   0.2985208224451117 0.9384862752521598\n",
-      "  0.16449944543187622 1.0453962103896604\n",
-      " -0.12600999108425714 1.0085541146917858\n",
-      "  -0.7155224408919922 0.9351607298580357\n",
-      "Length = 100 rows\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tabs = ens_n.build_tables()\n",
     "print(tabs.keys())\n",
@@ -1909,31 +830,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_n fits 0.0 0.0\n",
-      "_n hdf5 0.0 0.0\n",
-      "_h fits -1.1102230246251565e-16 5.551115123125783e-17\n",
-      "_h hdf5 -1.1102230246251565e-16 5.551115123125783e-17\n",
-      "_i fits -1.1102230246251565e-16 5.551115123125783e-17\n",
-      "_i hdf5 -1.1102230246251565e-16 5.551115123125783e-17\n",
-      "_s fits 0.0 0.0\n",
-      "_s hdf5 0.0 0.0\n",
-      "_q fits 0.0 0.0\n",
-      "_q hdf5 0.0 0.0\n",
-      "_m fits 0.0 0.0\n",
-      "_m hdf5 0.0 0.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "suffix_list = ['_n', '_h', '_i', '_s', '_q', '_m']\n",
-    "filetypes = ['fits', 'hdf5']\n",
+    "filetypes = ['fits', 'hf5']\n",
     "for ens, suffix in zip(ensembles, suffix_list):\n",
     "    for ft in filetypes:\n",
     "\n",
@@ -1964,23 +866,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "moments: range(0, 3)\n",
-      "norm: ['9.92e-01 +- 6.50e-03', '-1.02e-01 +- 5.32e-01', '1.23e+00 +- 2.43e-01']\n",
-      "hist: ['9.93e-01 +- 6.63e-03', '-1.03e-01 +- 5.31e-01', '1.39e+00 +- 2.36e-01']\n",
-      "interp: ['9.87e-01 +- 8.52e-03', '-9.91e-02 +- 5.18e-01', '1.34e+00 +- 2.16e-01']\n",
-      "spline: ['9.91e-01 +- 6.62e-03', '-1.02e-01 +- 5.33e-01', '1.23e+00 +- 2.48e-01']\n",
-      "quant: ['9.90e-01 +- 1.63e-02', '-9.93e-02 +- 5.20e-01', '1.44e+00 +- 1.94e-01']\n",
-      "mixmod: ['9.93e-01 +- 6.73e-03', '-1.05e-01 +- 5.37e-01', '1.26e+00 +- 2.52e-01']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "which_moments = range(3)\n",
     "all_moments = []\n",
@@ -1995,20 +883,6 @@
     "for ens, mom in zip(ensembles, all_moments):\n",
     "    print(ens.gen_class.name+': '+str(mom))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/nb/practical_example.ipynb
+++ b/nb/practical_example.ipynb
@@ -60,8 +60,8 @@
    "outputs": [],
    "source": [
     "base_url = 'https://slac.stanford.edu/~echarles/qp_example'\n",
-    "if not os.path.exists('qp_test_ensemble.hdf5'):\n",
-    "    os.system('curl -o %s -OL %s/%s' % ('qp_test_ensemble.hdf5', base_url, 'qp_test_ensemble.hdf5'))"
+    "if not os.path.exists('qp_test_ensemble.hf5'):\n",
+    "    os.system('curl -o %s -OL %s/%s' % ('qp_test_ensemble.hf5', base_url, 'qp_test_ensemble.hf5'))"
    ]
   },
   {
@@ -79,7 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens = qp.read('qp_test_ensemble.hdf5')"
+    "ens = qp.read('qp_test_ensemble.hf5')"
    ]
   },
   {
@@ -464,20 +464,6 @@
     "_ = ens_m5.plot(key, axes=axes_m1, label=\"m5\")\n",
     "leg_m1 = axes_m1.figure.legend()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/qp/ensemble.py
+++ b/qp/ensemble.py
@@ -598,8 +598,9 @@ class Ensemble:
         return self._gen_class.plot_native(self[key], **kwargs)
 
     def _get_allocation_kwds(self, npdf):
-        return self._gen_class.get_allocation_kwds(npdf, **self.metadata())
-
+        return self._gen_class.get_allocation_kwds(npdf,
+                                                   **{**self.metadata(),
+                                                      **self.objdata()})
 
     def initializeHdf5Write(self, filename, npdf):
         """set up the output write for an ensemble, but set size to npdf rather than

--- a/qp/metrics.py
+++ b/qp/metrics.py
@@ -105,9 +105,9 @@ def calculate_kld(p, q, limits, dx=0.01):
     # logq = safelog(qn)
     # Calculate the KLD from q to p
     Dpq = quick_kld(pn, qn, dx=dx)# np.dot(pn * logquotient, np.ones(len(grid)) * dx)
-    if Dpq < 0.: #pragma: no cover
+    if Dpq.any() < 0.: #pragma: no cover
         print('broken KLD: '+str((Dpq, pn, qn, dx)))
-        Dpq = epsilon
+        Dpq = epsilon*np.ones(Dpq.shape)
     return Dpq
 
 def quick_kld(p_eval, q_eval, dx=0.01):
@@ -136,7 +136,7 @@ def quick_kld(p_eval, q_eval, dx=0.01):
     # logp = safelog(pn)
     # logq = safelog(qn)
     # Calculate the KLD from q to p
-    Dpq = dx * np.sum(p_eval * logquotient)
+    Dpq = dx * np.sum(p_eval * logquotient, axis=-1)
     return Dpq
 
 def calculate_rmse(p, q, limits, dx=0.01):
@@ -195,5 +195,5 @@ def quick_rmse(p_eval, q_eval, N):
         the value of the RMS error between `q` and `p`
     """
     # Calculate the RMS between p and q
-    rms = np.sqrt(np.sum((p_eval - q_eval) ** 2) / N)
+    rms = np.sqrt(np.sum((p_eval - q_eval) ** 2, axis=-1) / N)
     return rms

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python",
         ],
     install_requires=["matplotlib",
+                      "astropy<5",
                       "numpy",
                       "scipy>=1.7.0",
                       "sklearn",


### PR DESCRIPTION
This one line PR fixes issue #69 and is a simple one line fix that adds the objdata dict in addition to the metadata dict in terms of what is passed to get_allocation_kwds in the Ensemble get_allocation_kwds.  This fixes a bug where a mixmod Ensemble could not be written out in iterative chunks, as it couldn't figure out the number of components it needed to write out to disk.