### PR TITLE
Issue/109/calculate kld

### DIFF
--- a/qp/metrics.py
+++ b/qp/metrics.py
@@ -85,8 +85,8 @@ def calculate_kld(p, q, limits, dx=0.01):
     TO DO: change this to calculate_kld
     TO DO: have this take number of points not dx!
     """
-    if p.npdf != q.npdf:
-        raise ValueError('Cannot calculate KLD between two ensembles with different number of PDFs')
+    if p.shape != q.shape:
+        raise ValueError('Cannot calculate KLD between two ensembles with different shapes')
     
     # Make a grid from the limits and resolution
     N = int((limits[-1] - limits[0]) / dx)
@@ -166,8 +166,8 @@ def calculate_rmse(p, q, limits, dx=0.01):
     -----
     TO DO: change dx to N
     """
-    if p.npdf != q.npdf:
-        raise ValueError('Cannot calculate RMSE between two ensembles with different number of PDFs')
+    if p.shape != q.shape:
+        raise ValueError('Cannot calculate RMSE between two ensembles with different shapes')
     
     # Make a grid from the limits and resolution
     N = int((limits[-1] - limits[0]) / dx)

--- a/qp/metrics.py
+++ b/qp/metrics.py
@@ -85,6 +85,9 @@ def calculate_kld(p, q, limits, dx=0.01):
     TO DO: change this to calculate_kld
     TO DO: have this take number of points not dx!
     """
+    if p.npdf != q.npdf:
+        raise ValueError('Cannot calculate KLD between two ensembles with different number of PDFs')
+    
     # Make a grid from the limits and resolution
     N = int((limits[-1] - limits[0]) / dx)
     grid = np.linspace(limits[0], limits[1], N)
@@ -105,7 +108,7 @@ def calculate_kld(p, q, limits, dx=0.01):
     # logq = safelog(qn)
     # Calculate the KLD from q to p
     Dpq = quick_kld(pn, qn, dx=dx)# np.dot(pn * logquotient, np.ones(len(grid)) * dx)
-    if Dpq.any() < 0.: #pragma: no cover
+    if np.any(Dpq < 0.): #pragma: no cover
         print('broken KLD: '+str((Dpq, pn, qn, dx)))
         Dpq = epsilon*np.ones(Dpq.shape)
     return Dpq
@@ -163,6 +166,9 @@ def calculate_rmse(p, q, limits, dx=0.01):
     -----
     TO DO: change dx to N
     """
+    if p.npdf != q.npdf:
+        raise ValueError('Cannot calculate RMSE between two ensembles with different number of PDFs')
+    
     # Make a grid from the limits and resolution
     N = int((limits[-1] - limits[0]) / dx)
     grid = np.linspace(limits[0], limits[1], N)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -35,12 +35,12 @@ class MetricTestCase(unittest.TestCase):
         kld = qp.metrics.calculate_kld(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
         assert np.all(kld == 0.)
 
-    def test_kld_different_npdf(self):
+    def test_kld_different_shapes(self):
         """ Ensure that the kld function fails when trying to compare ensembles of different sizes. """
         with self.assertRaises(ValueError) as context:
             qp.metrics.calculate_kld(self.ens_n, self.ens_n_plus_one, limits=(0.,2.5))
 
-        self.assertTrue('Cannot calculate KLD between two ensembles with different number of PDFs' in str(context.exception))
+        self.assertTrue('Cannot calculate KLD between two ensembles with different shapes' in str(context.exception))
 
     def test_broken_kld(self):
         """ Test to see if the calculate_kld function responds appropriately to negative results """
@@ -54,12 +54,12 @@ class MetricTestCase(unittest.TestCase):
         rmse = qp.metrics.calculate_rmse(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
         assert np.all(rmse == 0.)
 
-    def test_rmse_different_npdf(self):
+    def test_rmse_different_shapes(self):
         """ Ensure that the rmse function fails when trying to compare ensembles of different sizes. """
         with self.assertRaises(ValueError) as context:
             qp.metrics.calculate_rmse(self.ens_n, self.ens_n_plus_one, limits=(0.,2.5))
 
-        self.assertTrue('Cannot calculate RMSE between two ensembles with different number of PDFs' in str(context.exception))
+        self.assertTrue('Cannot calculate RMSE between two ensembles with different shapes' in str(context.exception))
 
 
 if __name__ == '__main__':

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,8 +4,10 @@ Unit tests for PDF class
 
 import unittest
 import qp
+import numpy as np
 
 from qp import test_funcs
+from qp.utils import epsilon
 
 
 class MetricTestCase(unittest.TestCase):
@@ -18,16 +20,46 @@ class MetricTestCase(unittest.TestCase):
         self.ens_n = test_funcs.build_ensemble(qp.stats.norm_gen.test_data['norm'])  #pylint: disable=no-member
         self.ens_n_shift = test_funcs.build_ensemble(qp.stats.norm_gen.test_data['norm_shifted'])  #pylint: disable=no-member
 
+        locs = 2* (np.random.uniform(size=(10,1))-0.5)
+        scales = 1 + 0.2*(np.random.uniform(size=(10,1))-0.5)
+        self.ens_n_plus_one = qp.Ensemble(qp.stats.norm, data=dict(loc=locs, scale=scales)) #pylint: disable=no-member
+
+        bins = np.linspace(-5, 5, 11)
+        self.ens_s = self.ens_n.convert_to(qp.spline_gen, xvals=bins, method="xy")
+
     def tearDown(self):
         """ Clean up any mock data files created by the tests. """
 
     def test_kld(self):
         """ Test the calculate_kld method """
-        _ = qp.metrics.calculate_kld(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
+        kld = qp.metrics.calculate_kld(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
+        assert np.all(kld == 0.)
+
+    def test_kld_different_npdf(self):
+        """ Ensure that the kld function fails when trying to compare ensembles of different sizes. """
+        with self.assertRaises(ValueError) as context:
+            qp.metrics.calculate_kld(self.ens_n, self.ens_n_plus_one, limits=(0.,2.5))
+
+        self.assertTrue('Cannot calculate KLD between two ensembles with different number of PDFs' in str(context.exception))
+
+    def test_broken_kld(self):
+        """ Test to see if the calculate_kld function responds appropriately to negative results """
+        kld = qp.metrics.calculate_kld(self.ens_n, self.ens_s, limits=(0.,2.5))
+
+        assert np.all(kld == epsilon)
+        
 
     def test_rmse(self):
         """ Test the calculate_rmse method """
-        _ = qp.metrics.calculate_rmse(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
+        rmse = qp.metrics.calculate_rmse(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
+        assert np.all(rmse == 0.)
+
+    def test_rmse_different_npdf(self):
+        """ Ensure that the rmse function fails when trying to compare ensembles of different sizes. """
+        with self.assertRaises(ValueError) as context:
+            qp.metrics.calculate_rmse(self.ens_n, self.ens_n_plus_one, limits=(0.,2.5))
+
+        self.assertTrue('Cannot calculate RMSE between two ensembles with different number of PDFs' in str(context.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- the .any function wasn't being used correctly and letting broken KLD's to be returned.
- also made the KLD and RMSE functions return more explicit error messages when trying to compare ensembles of different shapes (before it was returning a similar error but from a scipy method instead)
- also added tests for the above issues