### PR TITLE
Issue/91/risk based point estimate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *,cover
 cover/
 .hypothesis/
+test_normancil.pq
 
 # Translations
 *.mo

--- a/qp/metrics.py
+++ b/qp/metrics.py
@@ -2,6 +2,9 @@
 
 import numpy as np
 
+from scipy.integrate import quad
+from scipy.optimize import minimize_scalar
+
 from qp.utils import safelog, epsilon
 
 def calculate_moment(p, N, limits, dx=0.01):
@@ -203,3 +206,64 @@ def quick_rmse(p_eval, q_eval, N):
     # Calculate the RMS between p and q
     rms = np.sqrt(np.sum((p_eval - q_eval) ** 2, axis=-1) / N)
     return rms
+
+def risk_based_point_estimate(p, limits=(np.inf, np.inf)):
+    """
+    Calculates the risk based point estimates of a qp.Ensemble object.
+    Algorithm as defined in 4.2 of 'Photometric redshifts for Hyper Suprime-Cam 
+    Subaru Strategic Program Data Release 1' (Tanaka et al. 2018).
+
+    Parameters
+    ----------
+    p: qp.Ensemble object
+        Ensemble of PDFs to be evalutated
+    limits, tuple of floats
+        The limits at which to evaluate possible z_best estimates.
+        If custom limits are not provided then all potential z value will be
+        considered using the scipy.optimize.minimize_scalar function.
+
+    Returns
+    -------
+    rbpes: array of floats
+        The risk based point estimates of the provided ensemble.
+    """
+    rbpes = []
+    for n in range(0, p.npdf):
+        rbpes.append(quick_rbpe(p[n], limits))
+
+    return rbpes
+
+def quick_rbpe(p_eval, limits=(np.inf, np.inf)):
+    """
+    Calculates the risk based point estimate of a qp.Ensemble object with npdf == 1.
+
+    Parameters
+    ----------
+    p_eval: qp.Ensemble object
+        Ensemble of a single PDF to be evaluated.
+    limits, tuple of floats
+        The limits at which to evaluate possible z_best estimates.
+        If custom limits are not provided then all potential z value will be
+        considered using the scipy.optimize.minimize_scalar function.
+
+    Returns
+    -------
+    rbpe: float
+        The risk based point estimate of the provided ensemble.
+    """
+    if p_eval.npdf != 1:
+        raise ValueError('quick_rbpe only handles Ensembles with a single PDF, for ensembles with more than one PDF, use the qp.metrics.risk_based_point_estimate function.')
+
+    loss = lambda x : 1. - (1. / (1. + (pow((x / .15), 2))))
+    pz = lambda z: p_eval.pdf(z)[0][0]
+    lower = p_eval.ppf(0.01)[0][0]
+    upper = p_eval.ppf(0.99)[0][0]
+
+    def find_z_risk(zp):
+                integrand = lambda z : pz(z) * loss((zp - z) / (1. + z))
+                return quad(integrand, lower, upper)[0]
+
+    if limits[0] == np.inf:
+        return minimize_scalar(find_z_risk).x
+    return minimize_scalar(find_z_risk, bounds=(limits[0], limits[1]), method='bounded').x
+

--- a/qp/metrics.py
+++ b/qp/metrics.py
@@ -231,7 +231,7 @@ def risk_based_point_estimate(p, limits=(np.inf, np.inf)):
     for n in range(0, p.npdf):
         rbpes.append(quick_rbpe(p[n], limits))
 
-    return rbpes
+    return np.array(rbpes)
 
 def quick_rbpe(p_eval, limits=(np.inf, np.inf)):
     """

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -125,6 +125,11 @@ class MetricTestCase(unittest.TestCase):
         assert np.all(rpbe >= 0.)
         assert np.all(rpbe <= 2.5)
 
+    def test_rpbe_no_limits(self):
+        """ Test the risk_based_point_estimate method when the user doesn't provide a set of limits """
+        rpbe = qp.metrics.risk_based_point_estimate(self.ens_n)
+        assert np.all(rpbe >= -2.)
+
     def test_rpbe_alternative_ensembles(self):
         """ Test the risk_based_point_estimate method against different types of ensembles """
         bins = np.linspace(-5, 5, 11)
@@ -162,6 +167,11 @@ class MetricTestCase(unittest.TestCase):
         rpbe = qp.metrics.quick_rbpe(self.ens_n[0], limits=(0.,2.5))
         assert np.all(rpbe >= 0.)
         assert np.all(rpbe <= 2.5)
+
+    def test_quick_rpbe_no_limits(self):
+        """ Test the quick_rpbe method """
+        rpbe = qp.metrics.quick_rbpe(self.ens_n[0])
+        assert np.all(rpbe >= -2.)
 
     def test_quick_rpbe_multiple_pdfs(self):
         """ Ensure that the quick_rpbe function fails when trying to evaluate an ensemble with more than one pdf. """

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -35,6 +35,35 @@ class MetricTestCase(unittest.TestCase):
         kld = qp.metrics.calculate_kld(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
         assert np.all(kld == 0.)
 
+    def test_kld_alternative_ensembles(self):
+        """ Test the calculate_kld method against different types of ensembles """
+        bins = np.linspace(-5, 5, 11)
+        quants = np.linspace(0.01, 0.99, 7)
+
+        ens_h = self.ens_n[0].convert_to(qp.hist_gen, bins=bins)
+        ens_h_shift = self.ens_n_shift[0].convert_to(qp.hist_gen, bins=bins)
+
+        ens_i = self.ens_n[0].convert_to(qp.interp_gen, xvals=bins)
+        ens_i_shift = self.ens_n_shift[0].convert_to(qp.interp_gen, xvals=bins)
+
+        ens_s = self.ens_n[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
+        ens_s_shift = self.ens_n_shift[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
+
+        ens_q = self.ens_n[0].convert_to(qp.quant_piecewise_gen, quants=quants)
+        ens_q_shift = self.ens_n_shift[0].convert_to(qp.quant_piecewise_gen, quants=quants)
+
+        kld_histogram = qp.metrics.calculate_kld(ens_h, ens_h_shift, limits=(0.,2.5))
+        assert np.all(kld_histogram == 0.)
+
+        kld_interp = qp.metrics.calculate_kld(ens_i, ens_i_shift, limits=(0.,2.5))
+        assert np.all(kld_interp == 0.)
+
+        kld_spline = qp.metrics.calculate_kld(ens_s, ens_s_shift, limits=(0.,2.5))
+        assert np.all(kld_spline == 0.)
+
+        kld_quants = qp.metrics.calculate_kld(ens_q, ens_q_shift, limits=(0.,2.5))
+        assert np.all(kld_quants == 0.)
+
     def test_kld_different_shapes(self):
         """ Ensure that the kld function fails when trying to compare ensembles of different sizes. """
         with self.assertRaises(ValueError) as context:
@@ -54,12 +83,93 @@ class MetricTestCase(unittest.TestCase):
         rmse = qp.metrics.calculate_rmse(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
         assert np.all(rmse == 0.)
 
+    def test_rmse_alternative_ensembles(self):
+        """ Test the calculate_rmse method against different types of ensembles """
+        bins = np.linspace(-5, 5, 11)
+        quants = np.linspace(0.01, 0.99, 7)
+
+        ens_h = self.ens_n[0].convert_to(qp.hist_gen, bins=bins)
+        ens_h_shift = self.ens_n_shift[0].convert_to(qp.hist_gen, bins=bins)
+
+        ens_i = self.ens_n[0].convert_to(qp.interp_gen, xvals=bins)
+        ens_i_shift = self.ens_n_shift[0].convert_to(qp.interp_gen, xvals=bins)
+
+        ens_s = self.ens_n[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
+        ens_s_shift = self.ens_n_shift[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
+
+        ens_q = self.ens_n[0].convert_to(qp.quant_piecewise_gen, quants=quants)
+        ens_q_shift = self.ens_n_shift[0].convert_to(qp.quant_piecewise_gen, quants=quants)
+
+        rmse_histogram = qp.metrics.calculate_rmse(ens_h, ens_h_shift, limits=(0.,2.5))
+        assert np.all(rmse_histogram == 0.)
+
+        rmse_interp = qp.metrics.calculate_rmse(ens_i, ens_i_shift, limits=(0.,2.5))
+        assert np.all(rmse_interp == 0.)
+
+        rmse_spline = qp.metrics.calculate_rmse(ens_s, ens_s_shift, limits=(0.,2.5))
+        assert np.all(rmse_spline == 0.)
+
+        rmse_quants = qp.metrics.calculate_rmse(ens_q, ens_q_shift, limits=(0.,2.5))
+        assert np.all(rmse_quants == 0.)
+
     def test_rmse_different_shapes(self):
         """ Ensure that the rmse function fails when trying to compare ensembles of different sizes. """
         with self.assertRaises(ValueError) as context:
             qp.metrics.calculate_rmse(self.ens_n, self.ens_n_plus_one, limits=(0.,2.5))
 
         self.assertTrue('Cannot calculate RMSE between two ensembles with different shapes' in str(context.exception))
+
+    def test_rpbe(self):
+        """ Test the risk_based_point_estimate method """
+        rpbe = qp.metrics.risk_based_point_estimate(self.ens_n, limits=(0.,2.5))
+        assert np.all(rpbe >= 0.)
+        assert np.all(rpbe <= 2.5)
+
+    def test_rpbe_alternative_ensembles(self):
+        """ Test the risk_based_point_estimate method against different types of ensembles """
+        bins = np.linspace(-5, 5, 11)
+        quants = np.linspace(0.01, 0.99, 7)
+
+        ens_h = self.ens_n[0].convert_to(qp.hist_gen, bins=bins)
+        ens_i = self.ens_n[0].convert_to(qp.interp_gen, xvals=bins)
+        ens_s = self.ens_n[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
+        ens_q = self.ens_n[0].convert_to(qp.quant_piecewise_gen, quants=quants)
+        ens_m = self.ens_n[0].convert_to(qp.mixmod_gen, samples=1000, ncomps=3)
+
+        rpbe_histogram = qp.metrics.risk_based_point_estimate(ens_h, limits=(0.,2.5))
+        assert np.all(rpbe_histogram >= 0.)
+        assert np.all(rpbe_histogram <= 2.5)
+
+        rpbe_interp = qp.metrics.risk_based_point_estimate(ens_i, limits=(0.,2.5))
+        assert np.all(rpbe_interp >= 0.)
+        assert np.all(rpbe_interp <= 2.5)
+
+        rpbe_spline = qp.metrics.risk_based_point_estimate(ens_s, limits=(0.,2.5))
+        assert np.all(rpbe_spline >= 0.)
+        assert np.all(rpbe_spline <= 2.5)
+
+        rpbe_quants = qp.metrics.risk_based_point_estimate(ens_q, limits=(0.,2.5))
+        assert np.all(rpbe_quants >= 0.)
+        assert np.all(rpbe_quants <= 2.5)
+
+        rpbe_mixmod = qp.metrics.risk_based_point_estimate(ens_m, limits=(0.,2.5))
+        assert np.all(rpbe_mixmod >= 0.)
+        assert np.all(rpbe_mixmod <= 2.5)
+        
+
+    def test_quick_rpbe(self):
+        """ Test the quick_rpbe method """
+        rpbe = qp.metrics.quick_rbpe(self.ens_n[0], limits=(0.,2.5))
+        assert np.all(rpbe >= 0.)
+        assert np.all(rpbe <= 2.5)
+
+    def test_quick_rpbe_multiple_pdfs(self):
+        """ Ensure that the quick_rpbe function fails when trying to evaluate an ensemble with more than one pdf. """
+        with self.assertRaises(ValueError) as context:
+            qp.metrics.quick_rbpe(self.ens_n, limits=(0.,2.5))
+
+        error_msg = 'quick_rbpe only handles Ensembles with a single PDF'
+        self.assertTrue(error_msg in str(context.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Created a new qp.metrics function 'risk_based_point_estimate' that gets a single point estimate for a pdf based on the algorithm described in Tanaka et al. 2018.
- https://academic.oup.com/pasj/article/70/SP1/S9/4494086?login=true#109747011
- expanded some of the qp.metrics unit test coverage (including all new tests for rbpe)
- also added a file that was being created by pytest (test_normancil.pq) to the gitignore