### PR TITLE
Fixed pyproject.toml to include required dependencies in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,14 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
+dependencies = [
+    "matplotlib",
+    "numpy",
+    "scipy >= 1.9.0",
+    "scikit-learn",
+    "tables_io >= 0.7.7",
+]
+
 
 [metadata]
 author = "Alex Malz, Phil Marshall, Eric Charles"
@@ -34,15 +42,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/qp/_version.py"
-
-[options]
-install_requires = [
-    "matplotlib",
-    "numpy",
-    "scipy >= 1.9.0",
-    "scikit-learn",
-    "tables_io >= 0.7.7",
-]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Moved required dependencies to the [project] tag, renamed from install_requires to dependencies.