### PR TITLE
Incorporated vectorized versions of PIT goodness of fit metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "scipy >= 1.9.0",
     "scikit-learn",
     "tables_io >= 0.7.7",
+    "deprecated",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy
 scipy>=1.9.0
 scikit-learn
 setuptools_scm
-tables_io>=0.7.7,
+tables_io>=0.7.7
 deprecated

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy
 scipy>=1.9.0
 scikit-learn
 setuptools_scm
-tables_io >=0.7.7,
+tables_io>=0.7.7,
 deprecated

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 matplotlib
 numpy
-scipy>=1.7.0
+scipy>=1.9.0
 scikit-learn
 setuptools_scm
-tables_io
+tables_io >=0.7.7,
+deprecated

--- a/src/qp/ensemble.py
+++ b/src/qp/ensemble.py
@@ -428,6 +428,21 @@ class Ensemble:
         """
         return self._frozen.sf(q)
 
+    def logsf(self, q):
+        """Evaluates the log of the survival function of the distribution
+
+        Parameters
+        ----------
+        q: float or ndarray, float
+            location(s) at which to evaluate the pdfs
+
+        Returns
+        -------
+        float or ndarray
+            Log of the survival function
+        """
+        return self._frozen.logsf(q)
+
     def isf(self, q):
         """
         Evaluates the inverse of the survival fraction of the distribution

--- a/src/qp/metrics/__init__.py
+++ b/src/qp/metrics/__init__.py
@@ -1,5 +1,7 @@
 from .array_metrics import *
 from .metrics import *
+from .goodness_of_fit import *
 
 # added for testing purposes
 from .metrics import _calculate_grid_parameters, _check_ensemble_is_not_nested, _check_ensembles_are_same_size
+from .metrics import _check_ensembles_contain_correct_number_of_distributions

--- a/src/qp/metrics/goodness_of_fit.py
+++ b/src/qp/metrics/goodness_of_fit.py
@@ -1,0 +1,50 @@
+"""This module contains functions copied from the 1.10.0dev branch of Scipy.
+The original code can be found here: https://github.com/scipy/scipy/blob/maintenance/1.10.x/scipy/stats/_fit.py#L722
+The original Scipy 1.10.0dev code is wrapped with a function that prevents passing more than 1 distribution at a time.
+So, temporarily, we'll make use of the underlying, vectorized functions.
+Fortunately, the vectorized Scipy code works without modification. 
+Once Scipy 1.10 is made available, we can swap out the copied functions for those in Scipy 1.10.
+"""
+
+import numpy as np
+
+def _anderson_darling(dist, data):
+    x = np.sort(data, axis=-1)
+    n = data.shape[-1]
+    i = np.arange(1, n+1)
+    Si = (2*i - 1)/n * (dist.logcdf(x) + dist.logsf(x[..., ::-1]))
+    S = np.sum(Si, axis=-1)
+    return -n - S
+
+def _kolmogorov_smirnov(dist, data):
+    x = np.sort(data, axis=-1)
+    cdfvals = dist.cdf(x)
+    Dplus = _compute_dplus(cdfvals)  # always works along last axis
+    Dminus = _compute_dminus(cdfvals)
+    return np.maximum(Dplus, Dminus)
+
+def _compute_dplus(cdfvals):  # adapted from _stats_py before gh-17062
+    n = cdfvals.shape[-1]
+    return (np.arange(1.0, n + 1) / n - cdfvals).max(axis=-1)
+
+def _compute_dminus(cdfvals, axis=-1):
+    n = cdfvals.shape[-1]
+    return (cdfvals - np.arange(0.0, n)/n).max(axis=-1)
+
+def _cramer_von_mises(dist, data):
+    x = np.sort(data, axis=-1)
+    n = data.shape[-1]
+    cdfvals = dist.cdf(x)
+    u = (2*np.arange(1, n+1) - 1)/(2*n)
+    w = 1 / (12*n) + np.sum((u - cdfvals)**2, axis=-1)
+    return w
+
+# The following methods can be replaced by:
+# scipy.stats._fit._anderson_darling,
+# scipy.stats._fit._cramer_von_mises, and
+# scipy.stats._fit._kolmogorov_smirnov when Scipy 1.10 is available.
+goodness_of_fit_metrics = {
+    'ad': _anderson_darling,
+    'cvm': _cramer_von_mises,
+    'ks': _kolmogorov_smirnov
+}

--- a/src/qp/metrics/pit.py
+++ b/src/qp/metrics/pit.py
@@ -163,7 +163,7 @@ class PIT():
         float
             The percentage of outliers in this distribution given the min and max bounds.
         """
-        return calculate_outlier_rate(self._pit, pit_min, pit_max)
+        return calculate_outlier_rate(self._pit, pit_min, pit_max)[0]
 
     def _trim_pit_values(self, cdf_min, cdf_max):
         """Remove and report any cdf(x) that are outside the min/max range.

--- a/tests/qp/test_scipy_vectorization.py
+++ b/tests/qp/test_scipy_vectorization.py
@@ -1,0 +1,256 @@
+"""
+Unit tests for PDF class
+"""
+
+import unittest
+import qp
+import qp.metrics
+import numpy as np
+
+from qp import test_funcs
+
+import time
+
+class ScipyVectorizationTests(unittest.TestCase):
+    """ Tests for the metrics """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Make any objects that are used in multiple tests.
+        """
+        cls.random_state = 9999
+        cls.rvs_size = 100
+        t1 = time.perf_counter()
+        # ! Consider changing this to the gamma distribution - norm is symmetric. trunc_norm is a good option too.
+        cls.ens_n = test_funcs.build_ensemble(qp.stats.norm_gen.test_data['norm'])  #pylint: disable=no-member
+        t2 = time.perf_counter()
+        print(f'Setup time is {t2-t1}')
+        print(f'Ensemble contains {cls.ens_n.npdf} distributions.')
+        print(f'For each statistic {cls.rvs_size} random variables will be generated.')
+
+    @classmethod
+    def tearDownClass(cls):
+        """ Clean up any mock data files created by the tests. """
+
+    @unittest.skip("The two implementations of Anderson-Darling will converge for very large values of self.rvs_size. See docstring for more info.")
+    def test_copied_ad(self):
+        """For Anderson Darling stat, test the parity between Scipy 1.9 code and
+        Scipy 1.10.0dev code that was copied over into qp. Note that due to slightly different
+        implementations there will not be exact agreement of results for a finite number
+        of random variates.
+        However, as self.rvs_size is increased, the results begin to converge.
+        Because there isn't parity for a finite number of random variates, this test is
+        disabled for automation."""
+        print('Anderson Darling comparison')
+        t1 = time.perf_counter()
+
+        data = np.squeeze(self.ens_n.rvs(size=self.rvs_size, random_state=self.random_state))
+        fdist = self.ens_n
+        gof_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n,
+            fit_metric='ad',
+            num_samples=self.rvs_size,
+            _random_state=self.random_state
+        )
+
+        t2 = time.perf_counter()
+        gof2_run_time = t2 - t1
+        print(f"GOF 2 run time: {gof2_run_time}")
+        print(gof_output)
+
+        t1 = time.perf_counter()
+
+        adr_output = qp.metrics.calculate_anderson_darling(self.ens_n, 'norm', _random_state=self.random_state)
+        t2 = time.perf_counter()
+
+        ad_run_time = t2 - t1
+        print(f"Scipy 1.9 AD run time: {ad_run_time}")
+        print([a.statistic for a in adr_output])
+
+        print(f"Speed increase: {ad_run_time/gof2_run_time} x")
+
+        for gof, adr in zip(gof_output, adr_output):
+            self.assertEqual(gof, adr.statistic)
+
+    def test_ad_results(self):
+        """This test compares the results of the Anderson-Darling evaluation against a known output"""
+        expected_output = [1.41296516, 2.18126088, 0.59390624, 0.43942853, 0.67658563, 0.38376997,
+        0.66460796, 2.72899571, 1.4542696, 1.34378282, 1.19221443]
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        test_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n,
+            fit_metric='ad',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+
+        for test, expected in zip(test_output, expected_output):
+            assert np.isclose(test, expected)
+
+    def test_call_copied_method_ad_versus_single_distribution_ensemble(self):
+        """For Anderson-Darling stat stat for ensemble vs. ensemble-with-1-distribution"""
+        expected_output = [1.41296516e+00, 5.94997248e+01, 1.76866646e+02, 3.76671747e+02,
+        6.17435009e+02, 9.61477755e+02, 1.24161826e+03, 2.33034254e+03, 1.87698332e+03,
+        2.44635392e+03, 4.10601407e+03]
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        test_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n[0],
+            fit_metric='ad',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+
+        for test, expected in zip(test_output, expected_output):
+            assert np.isclose(test, expected)
+
+    def test_copied_cvm(self):
+        """For Cramer von Mises stat, test the parity between Scipy 1.9 code and
+        Scipy 1.10.0dev code that was copied over into qp"""
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        t1 = time.perf_counter()
+        gof_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n,
+            fit_metric='cvm',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+        t2 = time.perf_counter()
+        gof_run_time = t2 - t1
+        print(f"GOF run time: {gof_run_time}")
+
+        t1 = time.perf_counter()
+        cvm_output = qp.metrics.calculate_cramer_von_mises(self.ens_n, self.ens_n, num_samples=rvs_size, _random_state=random_state)
+        t2 = time.perf_counter()
+        cvm_run_time = t2 - t1
+        print(f"Scipy 1.9 AD run time: {cvm_run_time}")
+        print(f"Speed increase: {cvm_run_time/gof_run_time} x")
+
+        for gof, cvm in zip(gof_output, cvm_output):
+            self.assertEqual(gof, cvm.statistic)
+
+    def test_cvm_results(self):
+        """This test compares the results of the Cramer-von Mises evaluation against a known output"""
+        expected_output = [0.22630139, 0.27090351, 0.09884569, 0.04506071, 0.10731862, 0.05631584,
+            0.07646541, 0.52543176, 0.23656815, 0.21094075, 0.22384716]
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        test_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n,
+            fit_metric='cvm',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+
+        for test, expected in zip(test_output, expected_output):
+            assert np.isclose(test, expected)
+
+    def test_call_copied_method_cvm_versus_single_distribution_ensemble(self):
+        """For Cramer von Mises stat stat for ensemble vs. ensemble-with-1-distribution"""
+        expected_output = [0.22630139, 4.90875135, 12.18815523, 17.88155095, 21.76168586, 24.17512056,
+        22.69008766, 28.436041, 23.2801267, 23.87779491, 28.99530345]
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        test_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n[0],
+            fit_metric='cvm',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+
+        for test, expected in zip(test_output, expected_output):
+            assert np.isclose(test, expected)
+
+    def test_copied_ks(self):
+        """For Kolmogorov-Smirnov stat, test the parity between Scipy 1.9 code and
+        Scipy 1.10.0dev code that was copied over into qp"""
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        t1 = time.perf_counter()
+        gof_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n,
+            fit_metric='ks',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+        t2 = time.perf_counter()
+        gof_run_time = t2 - t1
+        print(f"GOF run time: {gof_run_time}")
+
+        t1 = time.perf_counter()
+        cvm_output = qp.metrics.calculate_kolmogorov_smirnov(self.ens_n, self.ens_n, num_samples=rvs_size, _random_state=random_state)
+        t2 = time.perf_counter()
+        ks_run_time = t2 - t1
+        print(f"Scipy 1.9 AD run time: {ks_run_time}")
+        print(f"Speed increase: {ks_run_time/gof_run_time} x")
+
+        for gof, cvm in zip(gof_output, cvm_output):
+            self.assertEqual(gof, cvm.statistic)
+
+    def test_ks_results(self):
+        """This test compares the results of the Kolmogorov-Smirnov evaluation against a known output"""
+        expected_output = [0.11739344, 0.10533858, 0.07950318, 0.06216017, 0.08471774, 0.05786293,
+        0.08342168, 0.14441362, 0.09896913, 0.11243258, 0.09189444]
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        test_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n,
+            fit_metric='ks',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+
+        for test, expected in zip(test_output, expected_output):
+            assert np.isclose(test, expected)
+
+    def test_call_copied_method_ks_versus_single_distribution_ensemble(self):
+        """Test Kolmogorov-Smirnov stat for ensemble vs. ensemble-with-1-distribution"""
+        expected_output = [0.11739344, 0.38809819, 0.51939786, 0.70188153, 0.76502763, 0.80196938,
+        0.79053856, 0.8996195, 0.80379571, 0.82881527, 0.9095734]
+
+        # Specify these here, so that changes in setupClass don't affect the results
+        rvs_size = 100
+        random_state = 9999
+
+        test_output = qp.metrics.calculate_goodness_of_fit(
+            self.ens_n,
+            self.ens_n[0],
+            fit_metric='ks',
+            num_samples=rvs_size,
+            _random_state=random_state
+        )
+
+        for test, expected in zip(test_output, expected_output):
+            assert np.isclose(test, expected)


### PR DESCRIPTION
Pulled in vectorized goodness of fit metrics from Scipy 1.10.0dev. 
Added a thin qp wrapper and test coverage.
Marked the prior implementations of Anderson-Darling, Cramer-von Mises, and Kolmogorov-Smirnov as deprecated. 
Made some slight performance adjustments to the prior implementations of the metrics, because they can be used as reference values in tests for the new implementations.
Added a `logsf` method in the Ensemble class to support the use of the vectorized statistic metrics.
