### PR TITLE
Small link fix

### DIFF
--- a/nb/demo.ipynb
+++ b/nb/demo.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "### Requirements\n",
     "\n",
-    "To run `qp`, you will need to first install the module by following the instructions [here](https://github.com/LSSTDESC/qp/blob/u/eacharles/eac-dev-v2/docs/install.rst)."
+    "To run `qp`, you will need to first install the module by following the instructions [here](https://github.com/LSSTDESC/qp/blob/main/docs/install.rst)."
    ]
   },
   {


### PR DESCRIPTION
Was just looking to double check qp installation how-to, noticed this gave a 404. Suggesting a public version of the rst, though there's also the ReadTheDocs version if that would be preferred: https://qp.readthedocs.io/en/main/install.html 

Additionally, would a brief Installation section be beneficial in qp's README?