### PR TITLE
Build fails due to missing dependency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt install -y libopenmpi-dev libhdf5-mpi-dev
         python -m pip install --upgrade pip
         pip install .


### PR DESCRIPTION
Added apt-get update, as suggested by the error message to see if this addresses the problem.