### PR TITLE
Cleaning up docstrings

### DIFF
--- a/docs/qp.rst
+++ b/docs/qp.rst
@@ -117,7 +117,7 @@ Quantification Metrics
 Utility functions
 =================
 
-`qp.convertsion_funcs`
+`qp.conversion_funcs`
 ----------------------
        
 .. automodule:: qp.conversion_funcs

--- a/src/qp/conversion_funcs.py
+++ b/src/qp/conversion_funcs.py
@@ -3,12 +3,13 @@ These functions should then be registered with the `qp.ConversionDict` using `qp
 That will allow the automated conversion mechanisms to work.
 """
 import numpy as np
-
 from scipy import integrate as sciint
 from scipy import interpolate as sciinterp
 
-from .sparse_rep import indices2shapes, build_sparse_representation, decode_sparse_indices
 from .lazy_modules import mixture
+from .sparse_rep import (build_sparse_representation, decode_sparse_indices,
+                         indices2shapes)
+
 
 def extract_vals_at_x(in_dist, **kwargs):
     """Convert using a set of x and y values.
@@ -18,8 +19,8 @@ def extract_vals_at_x(in_dist, **kwargs):
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     xvals : `np.array`
         Locations at which the pdf is evaluated
 
@@ -43,8 +44,8 @@ def extract_xy_vals(in_dist, **kwargs):
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     xvals : `np.array`
         Locations at which the pdf is evaluated
 
@@ -69,8 +70,8 @@ def extract_samples(in_dist, **kwargs):
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     size : `int`
         Number of samples to generate
 
@@ -92,8 +93,8 @@ def extract_hist_values(in_dist, **kwargs):
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     bins : `np.array`
         Histogram bin edges
 
@@ -117,8 +118,8 @@ def extract_hist_samples(in_dist, **kwargs):
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     bins : `np.array`
         Histogram bin edges
     size : `int`
@@ -150,8 +151,8 @@ def extract_quantiles(in_dist, **kwargs):
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     quantiles : `np.array`
         Quantile values to use
 
@@ -175,8 +176,8 @@ def extract_fit(in_dist, **kwargs): # pragma: no cover
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     xvals : `np.array`
         Locations at which the pdf is evaluated
 
@@ -200,8 +201,8 @@ def extract_mixmod_fit_samples(in_dist, **kwargs):
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     ncomps : `int`
         Number of components in mixture model to use
     nsamples : `int`
@@ -313,8 +314,8 @@ def extract_sparse_from_xy(in_dist, **kwargs): #pragma: no cover
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     xvals : array-like
         Used to override the y-values
     xvals : array-like
@@ -359,8 +360,8 @@ def extract_xy_sparse(in_dist, **kwargs): #pragma: no cover
     in_dist : `qp.Ensemble`
         Input distributions
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     xvals : array-like
         Used to override the y-values
     xvals : array-like

--- a/src/qp/dict_utils.py
+++ b/src/qp/dict_utils.py
@@ -26,7 +26,7 @@ def get_val_or_default(in_dict, key):
         in_dict[key] : i.e., the requested item.
     If that fails it will try
         in_dict[None] : i.e., the default for that dictionary.
-    If that failes it will return
+    If that fails it will return
         None
     """
     if key in in_dict:
@@ -56,11 +56,11 @@ def set_val_or_default(in_dict, key, val):
     Notes
     -----
     This will first try to return:
-        in_dict[key] : i.e., the requested item.
+      in_dict[key] : i.e., the requested item.
     If that fails it will try
-        in_dict[None] : i.e., the default for that dictionary.
-    If that failes it will return
-        None
+      in_dict[None] : i.e., the default for that dictionary.
+    If that fails it will return
+      None
     """
     if key in in_dict:
         return in_dict[key]

--- a/src/qp/ensemble.py
+++ b/src/qp/ensemble.py
@@ -1,15 +1,19 @@
 """Implemenation of an ensemble of distributions"""
 
 import os
+
 import numpy as np
+from tables_io import io
+
+from qp.dict_utils import (check_array_shapes, compare_dicts,
+                           concatenate_dicts, slice_dict)
+from qp.metrics import quick_moment
+
 # import psutil
 #import timeit
 
-from tables_io import io
 
-from qp.dict_utils import slice_dict, check_array_shapes, compare_dicts, concatenate_dicts
 
-from qp.metrics import quick_moment
 
 
 class Ensemble:
@@ -125,12 +129,13 @@ class Ensemble:
         ----------
         to_class :  `class`
             Class to convert to
+        **kwargs : 
+            keyword arguments are passed to the output class constructor
 
-        Keywords
-        --------
+        Other Parameters
+        ----------------
         method : `str`
             Optional argument to specify a non-default conversion algorithm
-        kwargs : keyword arguments are passed to the output class constructor
 
         Returns
         -------
@@ -288,6 +293,7 @@ class Ensemble:
 
     def mode(self, grid):
         """return the mode of each ensemble PDF, evaluated on grid
+
         Parameters
         ----------
         new_grid: array-like
@@ -297,7 +303,10 @@ class Ensemble:
         -------
         mode: array-like
             The modes of the PDFs evaluated on new_grid
-        Note: adding expand_dims to return an (N, 1) array to be
+
+        Notes
+        -----
+        Adding expand_dims to return an (N, 1) array to be
         consistent with mean, median, and other point estimates
         """
         new_grid, griddata = self.gridded(grid)
@@ -630,11 +639,15 @@ class Ensemble:
     def initializeHdf5Write(self, filename, npdf, comm=None):
         """set up the output write for an ensemble, but set size to npdf rather than
         the size of the ensemble, as the "initial chunk" will not contain the full data
+
         Parameters
         ----------
-        filename : `str` Name of the file to create
-        npdf : `int` Total number of pdfs that will contain the file, usually larger then the size of the current ensemble
-        comm : `MPI communicator` Optional MPI communicator to allow parallel writing
+        filename : `str` 
+            Name of the file to create
+        npdf : `int` 
+            Total number of pdfs that will contain the file, usually larger then the size of the current ensemble
+        comm : `MPI communicator` 
+            Optional MPI communicator to allow parallel writing
         """
         kwds = self._get_allocation_kwds(npdf)
         group, fout = io.initializeHdf5Write(filename, comm=comm, **kwds)
@@ -642,11 +655,15 @@ class Ensemble:
 
     def writeHdf5Chunk(self, fname, start, end):
         """write ensemble data chunk to file
+
         Parameters
         ----------
-        fname : h5py `File object` file or group
-        start : `int` starting index of h5py file
-        end : `int` ending index in h5py file
+        fname : h5py `File object` 
+            file or group
+        start : `int` 
+            starting index of h5py file
+        end : `int` 
+            ending index in h5py file
         """
         odict = self.build_tables().copy()
         odict.pop('meta')
@@ -654,9 +671,11 @@ class Ensemble:
 
     def finalizeHdf5Write(self, filename):
         """write ensemble metadata to the output file
+
         Parameters
         ----------
-        filename : h5py `File object` file or group
+        filename : h5py `File object` 
+            file or group
         """
         mdata = self.metadata()
         io.finalizeHdf5Write(filename, 'meta', **mdata)

--- a/src/qp/interp_pdf.py
+++ b/src/qp/interp_pdf.py
@@ -2,17 +2,17 @@
 """
 
 import numpy as np
-
 from scipy.stats import rv_continuous
 
-from qp.pdf_gen import Pdf_rows_gen
-from qp.conversion_funcs import extract_vals_at_x, extract_xy_vals, extract_xy_sparse
-from qp.plotting import get_axes_and_xlims, plot_pdf_on_axes
-from qp.utils import normalize_interp1d, interpolate_multi_x_y,\
-    interpolate_multi_x_multi_y, interpolate_x_multi_y,\
-    reshape_to_pdf_size
-from qp.test_data import XBINS, XARRAY, YARRAY, TEST_XVALS
+from qp.conversion_funcs import (extract_vals_at_x, extract_xy_sparse,
+                                 extract_xy_vals)
 from qp.factory import add_class
+from qp.pdf_gen import Pdf_rows_gen
+from qp.plotting import get_axes_and_xlims, plot_pdf_on_axes
+from qp.test_data import TEST_XVALS, XARRAY, XBINS, YARRAY
+from qp.utils import (interpolate_multi_x_multi_y, interpolate_multi_x_y,
+                      interpolate_x_multi_y, normalize_interp1d,
+                      reshape_to_pdf_size)
 
 
 class interp_gen(Pdf_rows_gen):
@@ -151,14 +151,16 @@ class interp_gen(Pdf_rows_gen):
 
     @classmethod
     def get_allocation_kwds(cls, npdf, **kwargs):
-        """
-        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        """Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
         for iterative file writeout.  We only need to allocate the objdata columns, as
         the metadata can be written when we finalize the file.
+        
         Parameters
         ----------
-        npdf: (int) number of *total* PDFs that will be written out
-        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        npdf: int
+            number of *total* PDFs that will be written out
+        kwargs: dict
+            dictionary of kwargs needed to create the ensemble
         """
         if 'xvals' not in kwargs: #pragma: no cover
             raise ValueError("required argument xvals not included in kwargs")
@@ -307,14 +309,16 @@ class interp_irregular_gen(Pdf_rows_gen):
 
     @classmethod
     def get_allocation_kwds(cls, npdf, **kwargs):
-        """
-        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        """Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
         for iterative file writeout.  We only need to allocate the objdata columns, as
         the metadata can be written when we finalize the file.
+
         Parameters
         ----------
-        npdf: (int) number of *total* PDFs that will be written out
-        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        npdf: int
+            number of *total* PDFs that will be written out
+        kwargs: dict
+            dictionary of kwargs needed to create the ensemble
         """
         if 'xvals' not in kwargs: #pragma: no cover
             raise ValueError("required argument xvals not included in kwargs")

--- a/src/qp/metrics/metrics.py
+++ b/src/qp/metrics/metrics.py
@@ -2,13 +2,13 @@
 import logging
 from collections import namedtuple
 from functools import partial
-from deprecated import deprecated
 
 import numpy as np
+from deprecated import deprecated
 
 from qp.metrics import array_metrics
-from qp.metrics.goodness_of_fit import goodness_of_fit_metrics
 from qp.metrics.brier import Brier
+from qp.metrics.goodness_of_fit import goodness_of_fit_metrics
 from qp.utils import epsilon
 
 Grid = namedtuple('Grid', ['grid_values', 'cardinality', 'resolution', 'hist_bin_edges', 'limits'])
@@ -199,6 +199,7 @@ def calculate_rbpe(p, limits=(np.inf, np.inf)):
 
 def calculate_brier(p, truth, limits, dx=0.01):
     """This function will do the following:
+    
     1) Generate a Mx1 sized grid based on `limits` and `dx`.
     2) Produce an NxM array by evaluating the pdf for each of the N distribution objects in the Ensemble p on the grid. 
     3) Produce an NxM truth_array using the input truth and the generated grid. All values will be 0 or 1.

--- a/src/qp/metrics/pit.py
+++ b/src/qp/metrics/pit.py
@@ -1,9 +1,11 @@
 import logging
+
 import numpy as np
 from scipy import stats
+
 import qp
-from qp.metrics.metrics import calculate_outlier_rate
 from qp.metrics.array_metrics import quick_anderson_ksamp
+from qp.metrics.metrics import calculate_outlier_rate
 
 DEFAULT_QUANTS = np.linspace(0, 1, 100)
 
@@ -89,8 +91,8 @@ class PIT():
         return self._pit
 
     def calculate_pit_meta_metrics(self):
-        """Convenience method that will calculate all of the PIT meta metrics and return them 
-            as a dictionary.
+        """Convenience method that will calculate all of the PIT meta metrics and return 
+        them as a dictionary.
 
         Returns
         -------
@@ -124,9 +126,9 @@ class PIT():
 
         Returns
         -------
-        [Result objects]
+        array
             A array of objects with attributes `statistic`, `critical_values`, and `significance_level`.
-        For details see: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anderson_ksamp.html
+            For details see: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anderson_ksamp.html
         """
         # Removed the CDF values that are outside the min/max range
         trimmed_pit_values = self._trim_pit_values(pit_min, pit_max)
@@ -142,7 +144,7 @@ class PIT():
 
         Returns
         -------
-        [Result objects]
+        array
             A array of objects with attributes `statistic` and `pvalue`
             For details see: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.cramervonmises.html
         """
@@ -154,7 +156,7 @@ class PIT():
 
         Returns
         -------
-        [Return Object]
+        array
             A array of objects with attributes `statistic` and `pvalue`.
             For details see: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstest.html
         """
@@ -209,7 +211,7 @@ class PIT():
 
         Returns
         -------
-        [float]
+        clean: [float]
             The list of PIT values within the min/max range.
         """
         # Create truth mask for pit values between cdf_min and pit max

--- a/src/qp/mixmod_pdf.py
+++ b/src/qp/mixmod_pdf.py
@@ -2,16 +2,14 @@
 """
 
 import numpy as np
-
-from scipy.stats import rv_continuous
 from scipy import stats as sps
+from scipy.stats import rv_continuous
 
-
-from qp.pdf_gen import Pdf_rows_gen
 from qp.conversion_funcs import extract_mixmod_fit_samples
-from qp.test_data import WEIGHT_MIXMOD, MEAN_MIXMOD, STD_MIXMOD, TEST_XVALS
 from qp.factory import add_class
-from qp.utils import reshape_to_pdf_size, interpolate_multi_x_y, get_eval_case
+from qp.pdf_gen import Pdf_rows_gen
+from qp.test_data import MEAN_MIXMOD, STD_MIXMOD, TEST_XVALS, WEIGHT_MIXMOD
+from qp.utils import get_eval_case, interpolate_multi_x_y, reshape_to_pdf_size
 
 
 class mixmod_gen(Pdf_rows_gen):
@@ -65,7 +63,7 @@ class mixmod_gen(Pdf_rows_gen):
         self._addobjdata('means', self._means)
 
     def _scipy_version_warning(self):
-        import scipy #pylint: disable=import-outside-toplevel
+        import scipy  # pylint: disable=import-outside-toplevel
         scipy_version = scipy.__version__
         vtuple = scipy_version.split('.')
         if int(vtuple[0]) > 1 or int(vtuple[1]) > 7:
@@ -133,14 +131,16 @@ class mixmod_gen(Pdf_rows_gen):
 
     @classmethod
     def get_allocation_kwds(cls, npdf, **kwargs):
-        """
-        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        """Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
         for iterative file writeout.  We only need to allocate the objdata columns, as
         the metadata can be written when we finalize the file.
+        
         Parameters
         ----------
-        npdf: (int) number of *total* PDFs that will be written out
-        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        npdf: int
+            number of *total* PDFs that will be written out
+        kwargs: dict
+            dictionary of kwargs needed to create the ensemble
         """
         if 'means' not in kwargs: #pragma: no cover
             raise ValueError("required argument means not included in kwargs")

--- a/src/qp/packed_interp_pdf.py
+++ b/src/qp/packed_interp_pdf.py
@@ -2,17 +2,15 @@
 """
 
 import numpy as np
-
 from scipy.stats import rv_continuous
 
-from qp.pdf_gen import Pdf_rows_gen
-from qp.plotting import get_axes_and_xlims, plot_pdf_on_axes
-from qp.utils import interpolate_multi_x_y,\
-    interpolate_x_multi_y, reshape_to_pdf_size
-from qp.test_data import XBINS, YARRAY, TEST_XVALS
 from qp.factory import add_class
 from qp.packing_utils import PackingType, pack_array, unpack_array
-
+from qp.pdf_gen import Pdf_rows_gen
+from qp.plotting import get_axes_and_xlims, plot_pdf_on_axes
+from qp.test_data import TEST_XVALS, XBINS, YARRAY
+from qp.utils import (interpolate_multi_x_y, interpolate_x_multi_y,
+                      reshape_to_pdf_size)
 
 
 def extract_and_pack_vals_at_x(in_dist, **kwargs):
@@ -205,14 +203,16 @@ class packed_interp_gen(Pdf_rows_gen):
 
     @classmethod
     def get_allocation_kwds(cls, npdf, **kwargs):
-        """
-        Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
+        """Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
         for iterative file writeout.  We only need to allocate the objdata columns, as
         the metadata can be written when we finalize the file.
+
         Parameters
         ----------
-        npdf: (int) number of *total* PDFs that will be written out
-        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        npdf: int
+            number of *total* PDFs that will be written out
+        kwargs: dict
+            dictionary of kwargs needed to create the ensemble
         """
         if 'xvals' not in kwargs: #pragma: no cover
             raise ValueError("required argument xvals not included in kwargs")

--- a/src/qp/plotting.py
+++ b/src/qp/plotting.py
@@ -48,10 +48,8 @@ def make_figure_axes(xlim, **kwargs):
     ----------
     xlim : (float, float)
         The x-axis limits of the plot
-
-    Keywords
-    --------
-    **kwargs : passed directly to the `matplotlib` plot function
+    **kwargs
+        passed directly to the `matplotlib` plot function
 
     Return
     ------
@@ -100,10 +98,8 @@ def plot_pdf_on_axes(axes, pdf, xvals, **kwargs):
 
     xvals : `np.array`
         The locations we evaluate the PDF at for plotting
-
-    Keywods
-    -------
-    Keywords are passed to matplotlib
+    **kwargs
+        Keywords are passed to matplotlib
 
     Return
     ------
@@ -123,8 +119,8 @@ def plot_dist_pdf(pdf, **kwargs):
     pdf : `scipy.stats.rv_frozen`
         The distribution we want to plot
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     axes : `matplotlib.axes`
         The axes to plot on
 
@@ -134,7 +130,8 @@ def plot_dist_pdf(pdf, **kwargs):
     npts : int
         The number of x-axis points
 
-    remaining kwargs : passed directly to the `plot_pdf_on_axes` plot function
+    remaining kwargs : 
+        passed directly to the `plot_pdf_on_axes` plot function
 
     Return
     ------
@@ -151,7 +148,7 @@ def plot_pdf_quantiles_on_axes(axes, xvals, yvals, quantiles, **kwargs):
     """
     Plot a PDF on a set of axes, by evaluating at the quantiles provided
 
-`    Parameters
+    Parameters
     ----------
     axes : The axes we want to plot the data on
 
@@ -163,13 +160,13 @@ def plot_pdf_quantiles_on_axes(axes, xvals, yvals, quantiles, **kwargs):
 
     quantiles : (`np.array`, `np.array`)
        The quantiles that define the distribution pdf
+    **kwargs : 
+        passed directly to the `matplotlib` plot function
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     npoints : `int`
         Number of points to use in the plotting.  Evenly spaced along the axis provided.
-
-    **kwargs : passed directly to the `matplotlib` plot function
 
     Return
     ------
@@ -189,18 +186,20 @@ def plot_pdf_histogram_on_axes(axes, hist, **kwargs):
 
     Parameters
     ----------
-    axes : The axes we want to plot the data on
+    axes : 
+        The axes we want to plot the data on
+    **kwargs : 
+        passed directly to the `matplotlib` plot function
 
-    Keywords
-    --------
+    Other Parameters
+    ----------------
     npoints : `int`
         Number of points to use in the plotting.  Evenly spaced along the axis provided.
 
-    **kwargs : passed directly to the `matplotlib` plot function
-
     Return
     ------
-    axes : The axes the data are plotted on
+    axes : 
+        The axes the data are plotted on
     """
 
     kwargs.setdefault('color', COLORS['histogram'])
@@ -225,10 +224,8 @@ def plot_pdf_samples_on_axes(axes, pdf, samples, **kwargs):
 
     samples : `np.array`
         Points sampled from the PDF
-
-    Keywords
-    --------
-    **kwargs : passed directly to the `matplotlib` plot function
+    **kwargs : 
+        passed directly to the `matplotlib` plot function
 
     Return
     ------

--- a/src/qp/quant_pdf.py
+++ b/src/qp/quant_pdf.py
@@ -2,32 +2,28 @@
 """
 import logging
 import sys
-import numpy as np
 
+import numpy as np
 from scipy.stats import rv_continuous
 
-from qp.pdf_gen import Pdf_rows_gen
-
 from qp.conversion_funcs import extract_quantiles
-from qp.plotting import get_axes_and_xlims, plot_pdf_quantiles_on_axes
-from qp.utils import interpolate_multi_x_y, interpolate_x_multi_y, reshape_to_pdf_size
-from qp.test_data import QUANTS, QLOCS, TEST_XVALS
 from qp.factory import add_class
-
-from qp.quantile_pdf_constructors import \
-    AbstractQuantilePdfConstructor, \
-    CdfSplineDerivative, \
-    DualSplineAverage, \
-    PiecewiseConstant, \
-    PiecewiseLinear
-
+from qp.pdf_gen import Pdf_rows_gen
+from qp.plotting import get_axes_and_xlims, plot_pdf_quantiles_on_axes
+from qp.quantile_pdf_constructors import (AbstractQuantilePdfConstructor,
+                                          CdfSplineDerivative,
+                                          DualSplineAverage, PiecewiseConstant,
+                                          PiecewiseLinear)
+from qp.test_data import QLOCS, QUANTS, TEST_XVALS
+from qp.utils import (interpolate_multi_x_y, interpolate_x_multi_y,
+                      reshape_to_pdf_size)
 
 epsilon = sys.float_info.epsilon
 
 def pad_quantiles(quants, locs):
     """Pad the quantiles and locations used to build a quantile representation
 
-    Paramters
+    Parameters
     ---------
     quants : array_like
         The quantiles used to build the CDF

--- a/src/qp/spline_pdf.py
+++ b/src/qp/spline_pdf.py
@@ -2,18 +2,17 @@
 """
 
 import numpy as np
-
-from scipy.stats import rv_continuous
-from scipy.special import errstate
-from scipy.interpolate import splev, splrep, splint
 from scipy.integrate import quad
+from scipy.interpolate import splev, splint, splrep
+from scipy.special import errstate
+from scipy.stats import rv_continuous
 
-from qp.pdf_gen import Pdf_rows_gen
-from qp.conversion_funcs import extract_xy_vals, extract_samples
-from qp.plotting import get_axes_and_xlims, plot_pdf_on_axes
-from qp.utils import build_kdes, evaluate_kdes, reshape_to_pdf_size
-from qp.test_data import SAMPLES, XARRAY, YARRAY, TEST_XVALS
+from qp.conversion_funcs import extract_samples, extract_xy_vals
 from qp.factory import add_class
+from qp.pdf_gen import Pdf_rows_gen
+from qp.plotting import get_axes_and_xlims, plot_pdf_on_axes
+from qp.test_data import SAMPLES, TEST_XVALS, XARRAY, YARRAY
+from qp.utils import build_kdes, evaluate_kdes, reshape_to_pdf_size
 
 
 def normalize_spline(xvals, yvals, limits, **kwargs):
@@ -275,10 +274,13 @@ class spline_gen(Pdf_rows_gen):
         Return the keywords necessary to create an 'empty' hdf5 file with npdf entries
         for iterative file writeout.  We only need to allocate the objdata columns, as
         the metadata can be written when we finalize the file.
+        
         Parameters
         ----------
-        npdf: (int) number of *total* PDFs that will be written out
-        kwargs: (dict) dictionary of kwargs needed to create the ensemble
+        npdf: int
+            number of *total* PDFs that will be written out
+        kwargs: dict
+            dictionary of kwargs needed to create the ensemble
         """
         if 'splx' not in kwargs: #pragma: no cover
             raise ValueError("required argument splx not included in kwargs")

--- a/src/qp/utils.py
+++ b/src/qp/utils.py
@@ -1,8 +1,8 @@
 """Utility functions for the qp package"""
 
 import sys
-import numpy as np
 
+import numpy as np
 from scipy import stats as sps
 from scipy.interpolate import interp1d
 
@@ -787,7 +787,7 @@ def interpolate_multi_x_y(x, row, xvals, yvals, **kwargs):
 def profile(x_data, y_data, x_bins, std=True):
     """Make a 'profile' plot
 
-    Paramters
+    Parameters
     ---------
     x_data : array_like (n)
         The x-values
@@ -825,12 +825,14 @@ def profile(x_data, y_data, x_bins, std=True):
 
 def reshape_to_pdf_size(vals, split_dim):
     """Reshape an array to match the number of PDFs in a distribution
+
     Parameters
     ----------
     vals : array
         The input array
     split_dim : int
         The dimension at which to split between pdf indices and per_pdf indices
+    
     Returns
     -------
     out : array


### PR DESCRIPTION
This corrects some typos I happened to notice while scrolling through the RTD, as well as some formatting issues.

numpydoc doesn't have a "Keywords" section, so none of those named sections are rendering properly. "Other parameters" is supported, but still isn't quite right.

With these changes, there are no errors or warnings when I run `make html` locally, so this could potentially also fix the currently-broken RTD build.