### PR TITLE
Add a new factory method read_metadata

### DIFF
--- a/src/qp/__init__.py
+++ b/src/qp/__init__.py
@@ -12,7 +12,7 @@ from .sparse_pdf import *
 from .scipy_pdfs import *
 from .packed_interp_pdf import *
 from .ensemble import Ensemble
-from .factory import instance, add_class, create, read, convert, concatenate, iterator, data_length, from_tables
+from .factory import instance, add_class, create, read, read_metadata, convert, concatenate, iterator, data_length, from_tables
 from .lazy_modules import *
 
 from . import utils

--- a/src/qp/factory.py
+++ b/src/qp/factory.py
@@ -150,6 +150,16 @@ class Factory(OrderedDict):
             data = reader_convert(data)
         return Ensemble(ctor_func, data=data, ancil=ancil_table)
 
+    def read_metadata(self, filename):
+        """Read an ensemble's metadata from a file, without loading the full data.
+
+        Parameters
+        ----------
+        filename : `str`
+        """
+        tables = io.read(filename, NUMPY_DICT, keys=['meta'])
+        return tables["meta"]
+
     def read(self, filename):
         """Read this ensemble from a file
 
@@ -159,8 +169,6 @@ class Factory(OrderedDict):
 
         Notes
         -----
-        This will actually read two files, one for the metadata and one for the object data
-
         This will use information in the meta data to figure out how to construct the data
         need to build the ensemble.
         """
@@ -331,6 +339,7 @@ stats = _FACTORY
 add_class = _FACTORY.add_class
 create = _FACTORY.create
 read = _FACTORY.read
+read_metadata = _FACTORY.read_metadata
 iterator = _FACTORY.iterator
 convert = _FACTORY.convert
 concatenate = _FACTORY.concatenate

--- a/src/qp/test_funcs.py
+++ b/src/qp/test_funcs.py
@@ -6,7 +6,7 @@ import numpy as np
 from qp.ensemble import Ensemble
 from qp.plotting import plot_native, plot, plot_pdf_samples_on_axes
 from qp.test_data import NPDF
-from qp.factory import read, convert
+from qp.factory import read, read_metadata, convert
 
 
 def assert_all_close(arr, arr2, **kwds):
@@ -143,7 +143,15 @@ def persist_func_test(ensemble, test_data):
         except FileNotFoundError:
             pass
         ensemble.write_to(filename)
+        meta = read_metadata(filename)
         ens_r = read(filename)
+        meta2 = ens_r.metadata()
+        # check that reading metadata and main file get same metadata items
+        for k, v in meta.items():
+            # we can't actually do a better check than this because the build_tables
+            # method in the ensemble class may add extra metadata items and change their type
+            assert k in meta2
+
         diff = ensemble.pdf(test_data['test_xvals']) - ens_r.pdf(test_data['test_xvals'])
         assert_all_small(diff, atol=1e-5, test_name="persist")
         if ensemble.ancil is not None:


### PR DESCRIPTION
This adds a function to read just the metadata portion of a qp file and not the whole data set.