### PR TITLE
Move quant_pdf tests into their own test module

### DIFF
--- a/tests/qp/quant_pdf/test_quant_pdf.py
+++ b/tests/qp/quant_pdf/test_quant_pdf.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for quant_pdf class
+"""
+import logging
+import numpy as np
+import unittest
+import qp
+
+from qp.quantile_pdf_constructors import AbstractQuantilePdfConstructor
+
+
+class QuantPdfTestCase(unittest.TestCase):
+    """ Class to test quant_pdf qp.Ensemble functionality """
+
+    def test_quant_get_default_pdf_constructor_name(self):
+        """Test that the getter for pdf constructor name works"""
+        quantiles = np.linspace(0.001, 0.999, 16)
+        locations = np.linspace(0, 5, 16)
+        quant_dist = qp.quant(quants=quantiles, locs=locations)
+        self.assertEqual(quant_dist.dist.pdf_constructor_name, 'piecewise_linear')
+
+    def test_quant_get_default_pdf_constructor(self):
+        """Test that the getter for pdf constructor returns an AbstractQuantilePdfConstructor"""
+        quantiles = np.linspace(0.001, 0.999, 16)
+        locations = np.linspace(0, 5, 16)
+        quant_dist = qp.quant(quants=quantiles, locs=locations)
+        assert isinstance(quant_dist.dist.pdf_constructor, AbstractQuantilePdfConstructor)
+
+    def test_quant_change_pdf_constructor(self):
+        """Test that changing the pdf constructor works as expected"""
+        quantiles = np.linspace(0.001, 0.999, 16)
+        locations = np.linspace(0, 5, 16)
+        quant_dist = qp.quant(quants=quantiles, locs=locations)
+        quant_dist.dist.pdf_constructor_name = 'piecewise_constant'
+        self.assertEqual(quant_dist.dist.pdf_constructor_name, 'piecewise_constant')
+
+    def test_quant_change_pdf_constructor_raises(self):
+        """Verify that attempting to change the pdf constructor to one that
+        isn't in the dictionary, will raise an error."""
+        quantiles = np.linspace(0.001, 0.999, 16)
+        locations = np.linspace(0, 5, 16)
+        quant_dist = qp.quant(quants=quantiles, locs=locations)
+        with self.assertRaises(ValueError):
+            quant_dist.dist.pdf_constructor_name = 'drewtonian'
+
+    def test_quant_change_pdf_constructor_warns(self):
+        """Verify that attempting to change the pdf constructor to the one
+        currently being used will log a warning."""
+        quantiles = np.linspace(0.001, 0.999, 16)
+        locations = np.linspace(0, 5, 16)
+        quant_dist = qp.quant(quants=quantiles, locs=locations)
+        with self.assertLogs(level=logging.WARNING) as log:
+            quant_dist.dist.pdf_constructor_name = 'piecewise_linear'
+            self.assertIn('Already using', log.output[0])

--- a/tests/qp/test_ensemble.py
+++ b/tests/qp/test_ensemble.py
@@ -213,46 +213,5 @@ class EnsembleTestCase(unittest.TestCase):
             test_vals = ens_i.pdf(test_grid)
             assert np.allclose(check_vals, test_vals)
 
-    def test_quant_get_default_pdf_constructor_name(self):
-        """Test that the getter for pdf constructor name works"""
-        quantiles = np.linspace(0.001, 0.999, 16)
-        locations = np.linspace(0, 5, 16)
-        quant_dist = qp.quant(quants=quantiles, locs=locations)
-        self.assertEqual(quant_dist.dist.pdf_constructor_name, 'piecewise_linear')
-
-    def test_quant_get_default_pdf_constructor(self):
-        """Test that the getter for pdf constructor returns an AbstractQuantilePdfConstructor"""
-        quantiles = np.linspace(0.001, 0.999, 16)
-        locations = np.linspace(0, 5, 16)
-        quant_dist = qp.quant(quants=quantiles, locs=locations)
-        assert isinstance(quant_dist.dist.pdf_constructor, AbstractQuantilePdfConstructor)
-
-    def test_quant_change_pdf_constructor(self):
-        """Test that changing the pdf constructor works as expected"""
-        quantiles = np.linspace(0.001, 0.999, 16)
-        locations = np.linspace(0, 5, 16)
-        quant_dist = qp.quant(quants=quantiles, locs=locations)
-        quant_dist.dist.pdf_constructor_name = 'piecewise_constant'
-        self.assertEqual(quant_dist.dist.pdf_constructor_name, 'piecewise_constant')
-
-    def test_quant_change_pdf_constructor_raises(self):
-        """Verify that attempting to change the pdf constructor to one that
-        isn't in the dictionary, will raise an error."""
-        quantiles = np.linspace(0.001, 0.999, 16)
-        locations = np.linspace(0, 5, 16)
-        quant_dist = qp.quant(quants=quantiles, locs=locations)
-        with self.assertRaises(ValueError):
-            quant_dist.dist.pdf_constructor_name = 'drewtonian'
-
-    def test_quant_change_pdf_constructor_warns(self):
-        """Verify that attempting to change the pdf constructor to the one
-        currently being used will log a warning."""
-        quantiles = np.linspace(0.001, 0.999, 16)
-        locations = np.linspace(0, 5, 16)
-        quant_dist = qp.quant(quants=quantiles, locs=locations)
-        with self.assertLogs(level=logging.WARNING) as log:
-            quant_dist.dist.pdf_constructor_name = 'piecewise_linear'
-            self.assertIn('Already using', log.output[0])
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The unit tests that were protecting the machinery in the `quant_pdf` module were mixed in with the unit tests associated with the mathematical functionality of various ensembles. 

It could be fine to have these together, but since the the machinery logic for quant_pdf is currently unique to that class, I felt like it would be ok to separate it from the other ensemble unit tests. 