### PR TITLE
Adding metric wrapper classes

### DIFF
--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -75,9 +75,9 @@ class BaseMetric(ABC):
     metric_input_type = MetricInputType.unknown # The type of input data expected for this metric
     metric_output_type = MetricOuputType.unknown # The form of the output data from this metric
 
-    def __init__(self, limit:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
 
-        self._limit = limit
+        self._limits = limits
         self._dx = dx
 
     @classmethod
@@ -144,7 +144,24 @@ class PointToPointMetric(BaseMetric):
 
     metric_input_type = MetricInputType.point_to_point
 
+    def initialize(self):
+        raise NotImplementedError()
+
+    def evaluate(self, estimate, reference):
+        raise NotImplementedError()
+
+    def finalize(self):
+        raise NotImplementedError()
 
 class PointToDistMetric(BaseMetric):
 
     metric_input_type = MetricInputType.point_to_dist
+
+    def initialize(self):
+        raise NotImplementedError()
+
+    def evaluate(self, estimate, reference):
+        raise NotImplementedError()
+
+    def finalize(self):
+        raise NotImplementedError()

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -102,23 +102,41 @@ class SingleEnsembleMetric(BaseMetric):
     metric_input_type = MetricInputType.single_ensemble
     metric_output_type = MetricOuputType.one_value_per_distribution
 
+    def initialize(self):
+        raise NotImplementedError()
+
+    def evaluate(self, estimate):
+        raise NotImplementedError()
+
+    def finalize(self):
+        raise NotImplementedError()
+
 
 class DistToDistMetric(BaseMetric):
 
     metric_input_type = MetricInputType.dist_to_dist
+
+    def initialize(self):
+        raise NotImplementedError()
+
+    def evaluate(self, estimate, reference):
+        raise NotImplementedError()
+
+    def finalize(self):
+        raise NotImplementedError()
 
 
 class DistToPointMetric(BaseMetric):
 
     metric_input_type = MetricInputType.dist_to_point
 
-    def initialize(self, **kwargs):
+    def initialize(self):
         raise NotImplementedError()
 
-    def evaluate(self, estimate, reference, **kwargs):
+    def evaluate(self, estimate, reference):
         raise NotImplementedError()
 
-    def finalize(self, **kwargs):
+    def finalize(self):
         raise NotImplementedError()
 
 

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -44,7 +44,7 @@ class MetricInputType(enum.Enum):
     def uses_point_for_estimate(self) -> bool:
         return self in [
             MetricInputType.point_to_dist,
-            MetricInputType.point_to_dist,
+            MetricInputType.point_to_point,
         ]
 
     def uses_point_for_reference(self) -> bool:

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -2,9 +2,9 @@ import enum
 
 from abc import ABC
 
+
 class MetricInputType(enum.Enum):
-    """Defines the various combinations of input types that metric classes accept.
-    """
+    """Defines the various combinations of input types that metric classes accept."""
 
     unknown = -1
 
@@ -26,7 +26,6 @@ class MetricInputType(enum.Enum):
     # A single value, or collection of values for estimate(s) and a
     # distribution, or collection of distributions for reference(s).
     point_to_dist = 4
-
 
     def uses_distribution_for_estimate(self) -> bool:
         return self in [
@@ -55,8 +54,7 @@ class MetricInputType(enum.Enum):
 
 
 class MetricOuputType(enum.Enum):
-    """Defines the various output types that metric classes can return.
-    """
+    """Defines the various output types that metric classes can return."""
 
     unknown = -1
 
@@ -71,14 +69,27 @@ class MetricOuputType(enum.Enum):
 
 
 class BaseMetric(ABC):
-    metric_name = None # The name for this metric, overwritten in subclasses
-    metric_input_type = MetricInputType.unknown # The type of input data expected for this metric
-    metric_output_type = MetricOuputType.unknown # The form of the output data from this metric
+    """This is the base class for all of the qp metrics. It establishes the most
+    of the basic API for a consistent interaction with the metrics qp provides.
+    """
 
-    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+    metric_name = None  # The name for this metric, overwritten in subclasses
+    metric_input_type = (
+        MetricInputType.unknown
+    )  # The type of input data expected for this metric
+    metric_output_type = (
+        MetricOuputType.unknown
+    )  # The form of the output data from this metric
 
+    def __init__(self, limits: tuple = (0.0, 3.0), dx: float = 0.01) -> None:
         self._limits = limits
         self._dx = dx
+
+    def initialize(self):
+        pass
+
+    def finalize(self):
+        pass
 
     @classmethod
     def uses_distribution_for_estimate(cls) -> bool:
@@ -98,70 +109,54 @@ class BaseMetric(ABC):
 
 
 class SingleEnsembleMetric(BaseMetric):
+    """A base class for metrics that accept only a single ensemble as input."""
 
     metric_input_type = MetricInputType.single_ensemble
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def initialize(self):
-        raise NotImplementedError()
-
     def evaluate(self, estimate):
-        raise NotImplementedError()
-
-    def finalize(self):
         raise NotImplementedError()
 
 
 class DistToDistMetric(BaseMetric):
+    """A base class for metrics that requires distributions as input for both the
+    estimated and reference values.
+    """
 
     metric_input_type = MetricInputType.dist_to_dist
 
-    def initialize(self):
-        raise NotImplementedError()
-
     def evaluate(self, estimate, reference):
-        raise NotImplementedError()
-
-    def finalize(self):
         raise NotImplementedError()
 
 
 class DistToPointMetric(BaseMetric):
+    """A base class for metrics that require a distribution as the estimated
+    value and a point estimate as the reference value.
+    """
 
     metric_input_type = MetricInputType.dist_to_point
 
-    def initialize(self):
-        raise NotImplementedError()
-
     def evaluate(self, estimate, reference):
-        raise NotImplementedError()
-
-    def finalize(self):
         raise NotImplementedError()
 
 
 class PointToPointMetric(BaseMetric):
+    """A base class for metrics that require a point estimate as input for both
+    the estimated and reference values.
+    """
 
     metric_input_type = MetricInputType.point_to_point
 
-    def initialize(self):
-        raise NotImplementedError()
-
     def evaluate(self, estimate, reference):
         raise NotImplementedError()
 
-    def finalize(self):
-        raise NotImplementedError()
 
 class PointToDistMetric(BaseMetric):
+    """A base class for metrics that require a point estimate as the estimated
+    value and a distribution as the reference value.
+    """
 
     metric_input_type = MetricInputType.point_to_dist
 
-    def initialize(self):
-        raise NotImplementedError()
-
     def evaluate(self, estimate, reference):
-        raise NotImplementedError()
-
-    def finalize(self):
         raise NotImplementedError()

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -28,26 +28,26 @@ class MetricInputType(enum.Enum):
     point_to_dist = 4
 
 
-    def uses_distribution_for_estimate(self):
+    def uses_distribution_for_estimate(self) -> bool:
         return self in [
             MetricInputType.single_ensemble,
             MetricInputType.dist_to_point,
             MetricInputType.dist_to_dist,
         ]
 
-    def uses_distribution_for_reference(self):
+    def uses_distribution_for_reference(self) -> bool:
         return self in [
             MetricInputType.dist_to_dist,
             MetricInputType.point_to_dist,
         ]
 
-    def uses_point_for_estimate(self):
+    def uses_point_for_estimate(self) -> bool:
         return self in [
             MetricInputType.point_to_dist,
             MetricInputType.point_to_dist,
         ]
 
-    def uses_point_for_reference(self):
+    def uses_point_for_reference(self) -> bool:
         return self in [
             MetricInputType.dist_to_point,
             MetricInputType.point_to_point,
@@ -80,29 +80,20 @@ class BaseMetric(ABC):
         self._limit = limit
         self._dx = dx
 
-    def initialize(self) -> None:
-        pass
-
-    def evaluate(self) -> None:
-        pass
-
-    def finalize(self) -> None:
-        pass
-
     @classmethod
-    def uses_distribution_for_estimate(cls):
+    def uses_distribution_for_estimate(cls) -> bool:
         return cls.metric_input_type.uses_distribution_for_estimate()
 
     @classmethod
-    def uses_distribution_for_reference(cls):
+    def uses_distribution_for_reference(cls) -> bool:
         return cls.metric_input_type.uses_distribution_for_reference()
 
     @classmethod
-    def uses_point_for_estimate(cls):
+    def uses_point_for_estimate(cls) -> bool:
         return cls.metric_input_type.uses_point_for_estimate()
 
     @classmethod
-    def uses_point_for_reference(cls):
+    def uses_point_for_reference(cls) -> bool:
         return cls.metric_input_type.uses_point_for_reference()
 
 
@@ -120,6 +111,15 @@ class DistToDistMetric(BaseMetric):
 class DistToPointMetric(BaseMetric):
 
     metric_input_type = MetricInputType.dist_to_point
+
+    def initialize(self, **kwargs):
+        raise NotImplementedError()
+
+    def evaluate(self, estimate, reference, **kwargs):
+        raise NotImplementedError()
+
+    def finalize(self, **kwargs):
+        raise NotImplementedError()
 
 
 class PointToPointMetric(BaseMetric):

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -1,0 +1,132 @@
+import enum
+
+from abc import ABC
+
+class MetricInputType(enum.Enum):
+    """Defines the various combinations of input types that metric classes accept.
+    """
+
+    unknown = -1
+
+    # A single qp.Ensemble
+    single_ensemble = 0
+
+    # A distribution, or collection of distributions for estimate(s) and a
+    # single value, or collection of values for reference(s)
+    dist_to_point = 1
+
+    # A distribution, or collection of distributions for estimate(s) and a
+    # distribution, or collection of distributions for references(s)
+    dist_to_dist = 2
+
+    # A single value, or collection of values for estimate(s) and a
+    # single value, or collection of values for reference(s).
+    point_to_point = 3
+
+    # A single value, or collection of values for estimate(s) and a
+    # distribution, or collection of distributions for reference(s).
+    point_to_dist = 4
+
+
+    def uses_distribution_for_estimate(self):
+        return self in [
+            MetricInputType.single_ensemble,
+            MetricInputType.dist_to_point,
+            MetricInputType.dist_to_dist,
+        ]
+
+    def uses_distribution_for_reference(self):
+        return self in [
+            MetricInputType.dist_to_dist,
+            MetricInputType.point_to_dist,
+        ]
+
+    def uses_point_for_estimate(self):
+        return self in [
+            MetricInputType.point_to_dist,
+            MetricInputType.point_to_dist,
+        ]
+
+    def uses_point_for_reference(self):
+        return self in [
+            MetricInputType.dist_to_point,
+            MetricInputType.point_to_point,
+        ]
+
+
+class MetricOuputType(enum.Enum):
+    """Defines the various output types that metric classes can return.
+    """
+
+    unknown = -1
+
+    # The metric produces a single value for all input
+    single_value = 0
+
+    # The metric produces a single distribution for all input
+    single_distribution = 1
+
+    # The metric produces a value for each input distribution
+    one_value_per_distribution = 2
+
+
+class BaseMetric(ABC):
+    metric_name = None # The name for this metric, overwritten in subclasses
+    metric_input_type = MetricInputType.unknown # The type of input data expected for this metric
+    metric_output_type = MetricOuputType.unknown # The form of the output data from this metric
+
+    def __init__(self, limit:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+
+        self._limit = limit
+        self._dx = dx
+
+    def initialize(self) -> None:
+        pass
+
+    def evaluate(self) -> None:
+        pass
+
+    def finalize(self) -> None:
+        pass
+
+    @classmethod
+    def uses_distribution_for_estimate(cls):
+        return cls.metric_input_type.uses_distribution_for_estimate()
+
+    @classmethod
+    def uses_distribution_for_reference(cls):
+        return cls.metric_input_type.uses_distribution_for_reference()
+
+    @classmethod
+    def uses_point_for_estimate(cls):
+        return cls.metric_input_type.uses_point_for_estimate()
+
+    @classmethod
+    def uses_point_for_reference(cls):
+        return cls.metric_input_type.uses_point_for_reference()
+
+
+class SingleEnsembleMetric(BaseMetric):
+
+    metric_input_type = MetricInputType.single_ensemble
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+
+class DistToDistMetric(BaseMetric):
+
+    metric_input_type = MetricInputType.dist_to_dist
+
+
+class DistToPointMetric(BaseMetric):
+
+    metric_input_type = MetricInputType.dist_to_point
+
+
+class PointToPointMetric(BaseMetric):
+
+    metric_input_type = MetricInputType.point_to_point
+
+
+class PointToDistMetric(BaseMetric):
+
+    metric_input_type = MetricInputType.point_to_dist

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -154,11 +154,11 @@ class ADMetric(DistToDistMetric):
         self._random_state = None
 
     @property
-    def _random_state(self):
+    def random_state(self):
         return self._random_state
 
-    @_random_state.setter
-    def _random_state(self, random_state):
+    @random_state.setter
+    def random_state(self, random_state):
         self._random_state=random_state
 
     def initialize(self):
@@ -190,11 +190,11 @@ class CvMMetric(DistToDistMetric):
         self._random_state = None
 
     @property
-    def _random_state(self):
+    def random_state(self):
         return self._random_state
 
-    @_random_state.setter
-    def _random_state(self, random_state):
+    @random_state.setter
+    def random_state(self, random_state):
         self._random_state=random_state
 
     def initialize(self):
@@ -226,11 +226,11 @@ class KSMetric(DistToDistMetric):
         self._random_state = None
 
     @property
-    def _random_state(self):
+    def random_state(self):
         return self._random_state
 
-    @_random_state.setter
-    def _random_state(self, random_state):
+    @random_state.setter
+    def random_state(self, random_state):
         self._random_state=random_state
 
     def initialize(self):

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -1,3 +1,5 @@
+# pylint: disable=unused-argument
+
 import numpy as np
 
 from qp.ensemble import Ensemble
@@ -24,7 +26,7 @@ class MomentMetric(SingleEnsembleMetric):
 
     metric_name = "moment"
 
-    def __init__(self, moment_order:int=1, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+    def __init__(self, moment_order:int=1, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
         super().__init__(limits, dx)
         self._moment_order = moment_order
 
@@ -45,7 +47,7 @@ class KLDMetric(DistToDistMetric):
     metric_name = "kld"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
         super().__init__(limits, dx)
 
     def initialize(self) -> None:
@@ -65,7 +67,7 @@ class RMSEMetric(DistToDistMetric):
     metric_name = "rmse"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
         super().__init__(limits, dx)
 
     def initialize(self) -> None:
@@ -85,7 +87,7 @@ class RBPEMetric(SingleEnsembleMetric):
     metric_name = 'rbpe'
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(np.inf, np.inf)) -> None:
+    def __init__(self, limits:tuple=(np.inf, np.inf), **kwargs) -> None:
         super().__init__(limits)
 
     def initialize(self) -> None:
@@ -107,7 +109,7 @@ class BrierMetric(DistToPointMetric):
     metric_name = 'brier'
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
         super().__init__(limits, dx)
 
     def initialize(self) -> None:
@@ -127,7 +129,7 @@ class OutlierMetric(SingleEnsembleMetric):
     metric_name = 'outlier'
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, cdf_limits:tuple = (0.0001, 0.9999)) -> None:
+    def __init__(self, cdf_limits:tuple = (0.0001, 0.9999), **kwargs) -> None:
         super().__init__()
         self._cdf_limits=cdf_limits
 
@@ -148,10 +150,10 @@ class ADMetric(DistToDistMetric):
     metric_name = 'ad'
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, num_samples:int=100) -> None:
+    def __init__(self, num_samples:int=100, _random_state:float=None, **kwargs) -> None:
         super().__init__()
         self._num_samples = num_samples
-        self._random_state = None
+        self._random_state = _random_state
 
     @property
     def random_state(self):
@@ -184,10 +186,10 @@ class CvMMetric(DistToDistMetric):
     metric_name = 'cvm'
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, num_samples:int=100) -> None:
+    def __init__(self, num_samples:int=100, _random_state:float=None, **kwargs) -> None:
         super().__init__()
         self._num_samples = num_samples
-        self._random_state = None
+        self._random_state = _random_state
 
     @property
     def random_state(self):
@@ -220,10 +222,10 @@ class KSMetric(DistToDistMetric):
     metric_name = 'ks'
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, num_samples:int=100) -> None:
+    def __init__(self, num_samples:int=100, _random_state:float=None, **kwargs) -> None:
         super().__init__()
         self._num_samples = num_samples
-        self._random_state = None
+        self._random_state = _random_state
 
     @property
     def random_state(self):

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from qp.ensemble import Ensemble
 from qp.metrics.base_metric_classes import (
     MetricOuputType,
     DistToDistMetric,
@@ -15,6 +16,7 @@ from qp.metrics.metrics import (
     calculate_rmse,
     calculate_rbpe,
 )
+from qp.metrics.pit import PIT
 
 class MomentMetric(SingleEnsembleMetric):
     """Class wrapper around the `calculate_moment` function.
@@ -242,6 +244,30 @@ class KSMetric(DistToDistMetric):
             num_samples=self._num_samples,
             _random_state=self._random_state
         )
+
+    def finalize(self) -> None:
+        pass
+
+
+ #! Confirm metric output type - perhaps a new type is appropriate ???
+class PITMetric(DistToPointMetric):
+    """Class wrapper for the PIT Metric class.
+    """
+
+    metric_name = 'pit'
+    metric_output_type = MetricOuputType.single_distribution
+    default_eval_grid = np.linspace(0, 1, 100)
+
+    def __init__(self, eval_grid: list = default_eval_grid) -> None:
+        super().__init__()
+        self._eval_grid = eval_grid
+
+    def initialize(self):
+        pass
+
+    def evaluate(self, estimate, reference) -> Ensemble:
+        pit_object = PIT(estimate, reference, self._eval_grid)
+        return pit_object.pit
 
     def finalize(self) -> None:
         pass

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -1,5 +1,20 @@
-from qp.metrics.base_metric_classes import MetricOuputType, DistToDistMetric, SingleEnsembleMetric
-from qp.metrics.metrics import calculate_kld, calculate_moment
+import numpy as np
+
+from qp.metrics.base_metric_classes import (
+    MetricOuputType,
+    DistToDistMetric,
+    DistToPointMetric,
+    SingleEnsembleMetric,
+)
+from qp.metrics.metrics import (
+    calculate_brier,
+    calculate_goodness_of_fit,
+    calculate_kld,
+    calculate_moment,
+    calculate_outlier_rate,
+    calculate_rmse,
+    calculate_rbpe,
+)
 
 class MomentMetric(SingleEnsembleMetric):
     """Class wrapper around the `calculate_moment` function.
@@ -8,10 +23,8 @@ class MomentMetric(SingleEnsembleMetric):
     metric_name = "moment"
 
     def __init__(self, moment_order:int=1, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
-        super().__init__()
+        super().__init__(limits, dx)
         self._moment_order = moment_order
-        self._limits = limits
-        self._dx = dx
 
     def initialize(self) -> None:
         pass
@@ -31,15 +44,204 @@ class KLDMetric(DistToDistMetric):
     metric_output_type = MetricOuputType.one_value_per_distribution
 
     def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
-        super().__init__()
-        self._limits = limits
-        self._dx = dx
+        super().__init__(limits, dx)
 
     def initialize(self) -> None:
         pass
 
     def evaluate(self, estimate, reference) -> list:
         return calculate_kld(estimate, reference, self._limits, self._dx)
+
+    def finalize(self) -> None:
+        pass
+
+
+class RMSEMetric(DistToDistMetric):
+    """Class wrapper around the Root Mean Square Error metric
+    """
+
+    metric_name = "rmse"
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+        super().__init__(limits, dx)
+
+    def initialize(self) -> None:
+        pass
+
+    def evaluate(self, estimate, reference) -> list:
+        return calculate_rmse(estimate, reference, self._limits, self._dx)
+
+    def finalize(self) -> None:
+        pass
+
+
+class RBPEMetric(SingleEnsembleMetric):
+    """Class wrapper around the Risk Based Point Estimate metric.
+    """
+
+    metric_name = 'rbpe'
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, limits:tuple=(np.inf, np.inf)) -> None:
+        super().__init__(limits)
+
+    def initialize(self) -> None:
+        pass
+
+    def evaluate(self, estimate) -> list:
+        return calculate_rbpe(estimate, self._limits)
+
+    def finalize(self) -> None:
+        pass
+
+
+#! Should this be implemented as `DistToPointMetric` or `DistToDistMetric` ???
+class BrierMetric(DistToPointMetric):
+    """Class wrapper around the calculate_brier function. (Which itself is a
+    wrapper around the `Brier` metric evaluator class).
+    """
+
+    metric_name = 'brier'
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+        super().__init__(limits, dx)
+
+    def initialize(self) -> None:
+        pass
+
+    def evaluate(self, estimate, reference) -> list:
+        return calculate_brier(estimate, reference, self._limits, self._dx)
+
+    def finalize(self) -> None:
+        pass
+
+
+class OutlierMetric(SingleEnsembleMetric):
+    """Class wrapper around the outlier calculation metric.
+    """
+
+    metric_name = 'outlier'
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, cdf_limits:tuple = (0.0001, 0.9999)) -> None:
+        super().__init__()
+        self._cdf_limits=cdf_limits
+
+    def initialize(self) -> None:
+        pass
+
+    def evaluate(self, estimate) -> list:
+        return calculate_outlier_rate(estimate, self._cdf_limits[0], self._cdf_limits[1])
+
+    def finalize(self) -> None:
+        pass
+
+
+class ADMetric(DistToDistMetric):
+    """Class wrapper for Anderson Darling metric.
+    """
+
+    metric_name = 'ad'
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, num_samples:int=100) -> None:
+        super().__init__()
+        self._num_samples = num_samples
+        self._random_state = None
+
+    @property
+    def _random_state(self):
+        return self._random_state
+
+    @_random_state.setter
+    def _random_state(self, random_state):
+        self._random_state=random_state
+
+    def initialize(self):
+        pass
+
+    def evaluate(self, estimate, reference) -> list:
+        return calculate_goodness_of_fit(
+            estimate,
+            reference,
+            fit_metric=self.metric_name,
+            num_samples=self._num_samples,
+            _random_state=self._random_state
+        )
+
+    def finalize(self) -> None:
+        pass
+
+
+class CvMMetric(DistToDistMetric):
+    """Class wrapper for Cramer von Mises metric.
+    """
+
+    metric_name = 'cvm'
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, num_samples:int=100) -> None:
+        super().__init__()
+        self._num_samples = num_samples
+        self._random_state = None
+
+    @property
+    def _random_state(self):
+        return self._random_state
+
+    @_random_state.setter
+    def _random_state(self, random_state):
+        self._random_state=random_state
+
+    def initialize(self):
+        pass
+
+    def evaluate(self, estimate, reference) -> list:
+        return calculate_goodness_of_fit(
+            estimate,
+            reference,
+            fit_metric=self.metric_name,
+            num_samples=self._num_samples,
+            _random_state=self._random_state
+        )
+
+    def finalize(self) -> None:
+        pass
+
+
+class KSMetric(DistToDistMetric):
+    """Class wrapper for Kolmogorov Smirnov metric.
+    """
+
+    metric_name = 'ks'
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, num_samples:int=100) -> None:
+        super().__init__()
+        self._num_samples = num_samples
+        self._random_state = None
+
+    @property
+    def _random_state(self):
+        return self._random_state
+
+    @_random_state.setter
+    def _random_state(self, random_state):
+        self._random_state=random_state
+
+    def initialize(self):
+        pass
+
+    def evaluate(self, estimate, reference) -> list:
+        return calculate_goodness_of_fit(
+            estimate,
+            reference,
+            fit_metric=self.metric_name,
+            num_samples=self._num_samples,
+            _random_state=self._random_state
+        )
 
     def finalize(self) -> None:
         pass

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -1,0 +1,23 @@
+from qp.metrics.base_metric_classes import MetricOuputType, DistToDistMetric
+from qp.metrics.metrics import calculate_kld
+
+class KLDMetric(DistToDistMetric):
+    """Class wrapper around the KLD metric
+    """
+
+    metric_name = "kld"
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+        super().__init__()
+        self._limits = limits
+        self._dx = dx
+
+    def initialize(self) -> None:
+        pass
+
+    def evaluate(self, estimate, reference) -> None:
+        return calculate_kld(estimate, reference, self._limits, self._dx)
+
+    def finalize(self) -> None:
+        pass

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -1,5 +1,27 @@
-from qp.metrics.base_metric_classes import MetricOuputType, DistToDistMetric
-from qp.metrics.metrics import calculate_kld
+from qp.metrics.base_metric_classes import MetricOuputType, DistToDistMetric, SingleEnsembleMetric
+from qp.metrics.metrics import calculate_kld, calculate_moment
+
+class MomentMetric(SingleEnsembleMetric):
+    """Class wrapper around the `calculate_moment` function.
+    """
+
+    metric_name = "moment"
+
+    def __init__(self, moment_order:int=1, limits:tuple=(0.0, 3.0), dx:float=0.01) -> None:
+        super().__init__()
+        self._moment_order = moment_order
+        self._limits = limits
+        self._dx = dx
+
+    def initialize(self) -> None:
+        pass
+
+    def evalulate(self, estimate) -> list:
+        return calculate_moment(estimate, self._moment_order, self._limits, self._dx)
+
+    def finalize(self) -> None:
+        pass
+
 
 class KLDMetric(DistToDistMetric):
     """Class wrapper around the KLD metric
@@ -16,7 +38,7 @@ class KLDMetric(DistToDistMetric):
     def initialize(self) -> None:
         pass
 
-    def evaluate(self, estimate, reference) -> None:
+    def evaluate(self, estimate, reference) -> list:
         return calculate_kld(estimate, reference, self._limits, self._dx)
 
     def finalize(self) -> None:

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -33,7 +33,7 @@ class MomentMetric(SingleEnsembleMetric):
     def initialize(self) -> None:
         pass
 
-    def evalulate(self, estimate) -> list:
+    def evaluate(self, estimate) -> list:
         return calculate_moment(estimate, self._moment_order, self._limits, self._dx)
 
     def finalize(self) -> None:

--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -20,84 +20,63 @@ from qp.metrics.metrics import (
 )
 from qp.metrics.pit import PIT
 
+
 class MomentMetric(SingleEnsembleMetric):
-    """Class wrapper around the `calculate_moment` function.
-    """
+    """Class wrapper around the `calculate_moment` function."""
 
     metric_name = "moment"
 
-    def __init__(self, moment_order:int=1, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
+    def __init__(
+        self,
+        moment_order: int = 1,
+        limits: tuple = (0.0, 3.0),
+        dx: float = 0.01,
+        **kwargs,
+    ) -> None:
         super().__init__(limits, dx)
         self._moment_order = moment_order
-
-    def initialize(self) -> None:
-        pass
 
     def evaluate(self, estimate) -> list:
         return calculate_moment(estimate, self._moment_order, self._limits, self._dx)
 
-    def finalize(self) -> None:
-        pass
-
 
 class KLDMetric(DistToDistMetric):
-    """Class wrapper around the KLD metric
-    """
+    """Class wrapper around the KLD metric"""
 
     metric_name = "kld"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
+    def __init__(self, limits: tuple = (0.0, 3.0), dx: float = 0.01, **kwargs) -> None:
         super().__init__(limits, dx)
-
-    def initialize(self) -> None:
-        pass
 
     def evaluate(self, estimate, reference) -> list:
         return calculate_kld(estimate, reference, self._limits, self._dx)
 
-    def finalize(self) -> None:
-        pass
-
 
 class RMSEMetric(DistToDistMetric):
-    """Class wrapper around the Root Mean Square Error metric
-    """
+    """Class wrapper around the Root Mean Square Error metric"""
 
     metric_name = "rmse"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
+    def __init__(self, limits: tuple = (0.0, 3.0), dx: float = 0.01, **kwargs) -> None:
         super().__init__(limits, dx)
-
-    def initialize(self) -> None:
-        pass
 
     def evaluate(self, estimate, reference) -> list:
         return calculate_rmse(estimate, reference, self._limits, self._dx)
 
-    def finalize(self) -> None:
-        pass
-
 
 class RBPEMetric(SingleEnsembleMetric):
-    """Class wrapper around the Risk Based Point Estimate metric.
-    """
+    """Class wrapper around the Risk Based Point Estimate metric."""
 
-    metric_name = 'rbpe'
+    metric_name = "rbpe"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(np.inf, np.inf), **kwargs) -> None:
+    def __init__(self, limits: tuple = (np.inf, np.inf), **kwargs) -> None:
         super().__init__(limits)
-
-    def initialize(self) -> None:
-        pass
 
     def evaluate(self, estimate) -> list:
         return calculate_rbpe(estimate, self._limits)
-
-    def finalize(self) -> None:
-        pass
 
 
 #! Should this be implemented as `DistToPointMetric` or `DistToDistMetric` ???
@@ -106,51 +85,41 @@ class BrierMetric(DistToPointMetric):
     wrapper around the `Brier` metric evaluator class).
     """
 
-    metric_name = 'brier'
+    metric_name = "brier"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, limits:tuple=(0.0, 3.0), dx:float=0.01, **kwargs) -> None:
+    def __init__(self, limits: tuple = (0.0, 3.0), dx: float = 0.01, **kwargs) -> None:
         super().__init__(limits, dx)
-
-    def initialize(self) -> None:
-        pass
 
     def evaluate(self, estimate, reference) -> list:
         return calculate_brier(estimate, reference, self._limits, self._dx)
 
-    def finalize(self) -> None:
-        pass
-
 
 class OutlierMetric(SingleEnsembleMetric):
-    """Class wrapper around the outlier calculation metric.
-    """
+    """Class wrapper around the outlier calculation metric."""
 
-    metric_name = 'outlier'
+    metric_name = "outlier"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, cdf_limits:tuple = (0.0001, 0.9999), **kwargs) -> None:
+    def __init__(self, cdf_limits: tuple = (0.0001, 0.9999), **kwargs) -> None:
         super().__init__()
-        self._cdf_limits=cdf_limits
-
-    def initialize(self) -> None:
-        pass
+        self._cdf_limits = cdf_limits
 
     def evaluate(self, estimate) -> list:
-        return calculate_outlier_rate(estimate, self._cdf_limits[0], self._cdf_limits[1])
-
-    def finalize(self) -> None:
-        pass
+        return calculate_outlier_rate(
+            estimate, self._cdf_limits[0], self._cdf_limits[1]
+        )
 
 
 class ADMetric(DistToDistMetric):
-    """Class wrapper for Anderson Darling metric.
-    """
+    """Class wrapper for Anderson Darling metric."""
 
-    metric_name = 'ad'
+    metric_name = "ad"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, num_samples:int=100, _random_state:float=None, **kwargs) -> None:
+    def __init__(
+        self, num_samples: int = 100, _random_state: float = None, **kwargs
+    ) -> None:
         super().__init__()
         self._num_samples = num_samples
         self._random_state = _random_state
@@ -161,10 +130,7 @@ class ADMetric(DistToDistMetric):
 
     @random_state.setter
     def random_state(self, random_state):
-        self._random_state=random_state
-
-    def initialize(self):
-        pass
+        self._random_state = random_state
 
     def evaluate(self, estimate, reference) -> list:
         return calculate_goodness_of_fit(
@@ -172,21 +138,19 @@ class ADMetric(DistToDistMetric):
             reference,
             fit_metric=self.metric_name,
             num_samples=self._num_samples,
-            _random_state=self._random_state
+            _random_state=self._random_state,
         )
-
-    def finalize(self) -> None:
-        pass
 
 
 class CvMMetric(DistToDistMetric):
-    """Class wrapper for Cramer von Mises metric.
-    """
+    """Class wrapper for Cramer von Mises metric."""
 
-    metric_name = 'cvm'
+    metric_name = "cvm"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, num_samples:int=100, _random_state:float=None, **kwargs) -> None:
+    def __init__(
+        self, num_samples: int = 100, _random_state: float = None, **kwargs
+    ) -> None:
         super().__init__()
         self._num_samples = num_samples
         self._random_state = _random_state
@@ -197,10 +161,7 @@ class CvMMetric(DistToDistMetric):
 
     @random_state.setter
     def random_state(self, random_state):
-        self._random_state=random_state
-
-    def initialize(self):
-        pass
+        self._random_state = random_state
 
     def evaluate(self, estimate, reference) -> list:
         return calculate_goodness_of_fit(
@@ -208,21 +169,19 @@ class CvMMetric(DistToDistMetric):
             reference,
             fit_metric=self.metric_name,
             num_samples=self._num_samples,
-            _random_state=self._random_state
+            _random_state=self._random_state,
         )
-
-    def finalize(self) -> None:
-        pass
 
 
 class KSMetric(DistToDistMetric):
-    """Class wrapper for Kolmogorov Smirnov metric.
-    """
+    """Class wrapper for Kolmogorov Smirnov metric."""
 
-    metric_name = 'ks'
+    metric_name = "ks"
     metric_output_type = MetricOuputType.one_value_per_distribution
 
-    def __init__(self, num_samples:int=100, _random_state:float=None, **kwargs) -> None:
+    def __init__(
+        self, num_samples: int = 100, _random_state: float = None, **kwargs
+    ) -> None:
         super().__init__()
         self._num_samples = num_samples
         self._random_state = _random_state
@@ -233,10 +192,7 @@ class KSMetric(DistToDistMetric):
 
     @random_state.setter
     def random_state(self, random_state):
-        self._random_state=random_state
-
-    def initialize(self):
-        pass
+        self._random_state = random_state
 
     def evaluate(self, estimate, reference) -> list:
         return calculate_goodness_of_fit(
@@ -244,19 +200,15 @@ class KSMetric(DistToDistMetric):
             reference,
             fit_metric=self.metric_name,
             num_samples=self._num_samples,
-            _random_state=self._random_state
+            _random_state=self._random_state,
         )
 
-    def finalize(self) -> None:
-        pass
 
-
- #! Confirm metric output type - perhaps a new type is appropriate ???
+#! Confirm metric output type - perhaps a new type is appropriate ???
 class PITMetric(DistToPointMetric):
-    """Class wrapper for the PIT Metric class.
-    """
+    """Class wrapper for the PIT Metric class."""
 
-    metric_name = 'pit'
+    metric_name = "pit"
     metric_output_type = MetricOuputType.single_distribution
     default_eval_grid = np.linspace(0, 1, 100)
 
@@ -264,12 +216,6 @@ class PITMetric(DistToPointMetric):
         super().__init__()
         self._eval_grid = eval_grid
 
-    def initialize(self):
-        pass
-
     def evaluate(self, estimate, reference) -> Ensemble:
         pit_object = PIT(estimate, reference, self._eval_grid)
         return pit_object.pit
-
-    def finalize(self) -> None:
-        pass

--- a/tests/qp/test_base_metric_classes.py
+++ b/tests/qp/test_base_metric_classes.py
@@ -1,0 +1,147 @@
+# pylint: disable=protected-access
+
+import pytest
+from qp.metrics.base_metric_classes import (
+    SingleEnsembleMetric,
+    DistToDistMetric,
+    DistToPointMetric,
+    PointToPointMetric,
+    PointToDistMetric,
+)
+
+
+def test_single_ensemble_metrics():
+    """Test single ensemble basic properties"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    single_ens_metric = SingleEnsembleMetric(limits, dx)
+    assert single_ens_metric._limits == limits
+    assert single_ens_metric._dx == dx
+    assert SingleEnsembleMetric.uses_distribution_for_estimate() is True
+    assert SingleEnsembleMetric.uses_distribution_for_reference() is False
+    assert SingleEnsembleMetric.uses_point_for_estimate() is False
+    assert SingleEnsembleMetric.uses_point_for_reference() is False
+
+
+def test_single_ensemble_raises_unimplemented():
+    """Test single ensemble raises exceptions"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    single_ens_metric = SingleEnsembleMetric(limits, dx)
+
+    pytest.raises(NotImplementedError, single_ens_metric.initialize)
+    pytest.raises(NotImplementedError, single_ens_metric.evaluate, estimate=None)
+    pytest.raises(NotImplementedError, single_ens_metric.finalize)
+
+
+def test_dist_to_dist_metrics():
+    """Test dist to dist basic properties"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    dist_to_dist_metric = DistToDistMetric(limits, dx)
+    assert dist_to_dist_metric._limits == limits
+    assert dist_to_dist_metric._dx == dx
+    assert DistToDistMetric.uses_distribution_for_estimate() is True
+    assert DistToDistMetric.uses_distribution_for_reference() is True
+    assert DistToDistMetric.uses_point_for_estimate() is False
+    assert DistToDistMetric.uses_point_for_reference() is False
+
+
+def test_dist_to_dist_raises_unimplemented():
+    """Test dist to dist raises exceptions"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    dist_to_dist_metric = DistToDistMetric(limits, dx)
+
+    pytest.raises(NotImplementedError, dist_to_dist_metric.initialize)
+    pytest.raises(
+        NotImplementedError, dist_to_dist_metric.evaluate, estimate=None, reference=None
+    )
+    pytest.raises(NotImplementedError, dist_to_dist_metric.finalize)
+
+
+def test_dist_to_point_metrics():
+    """Test dist to point basic properties"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    dist_to_point_metric = DistToPointMetric(limits, dx)
+    assert dist_to_point_metric._limits == limits
+    assert dist_to_point_metric._dx == dx
+    assert DistToPointMetric.uses_distribution_for_estimate() is True
+    assert DistToPointMetric.uses_distribution_for_reference() is False
+    assert DistToPointMetric.uses_point_for_estimate() is False
+    assert DistToPointMetric.uses_point_for_reference() is True
+
+
+def test_dist_to_point_raises_unimplemented():
+    """Test dist to point raises exceptions"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    dist_to_point_metric = DistToPointMetric(limits, dx)
+
+    pytest.raises(NotImplementedError, dist_to_point_metric.initialize)
+    pytest.raises(
+        NotImplementedError,
+        dist_to_point_metric.evaluate,
+        estimate=None,
+        reference=None,
+    )
+    pytest.raises(NotImplementedError, dist_to_point_metric.finalize)
+
+
+def test_point_to_point_metrics():
+    """Test point to point basic properties"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    point_to_point_metric = PointToPointMetric(limits, dx)
+    assert point_to_point_metric._limits == limits
+    assert point_to_point_metric._dx == dx
+    assert PointToPointMetric.uses_distribution_for_estimate() is False
+    assert PointToPointMetric.uses_distribution_for_reference() is False
+    assert PointToPointMetric.uses_point_for_estimate() is True
+    assert PointToPointMetric.uses_point_for_reference() is True
+
+
+def test_point_to_point_raises_unimplemented():
+    """Test point to point raises exceptions"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    point_to_point_metric = PointToPointMetric(limits, dx)
+
+    pytest.raises(NotImplementedError, point_to_point_metric.initialize)
+    pytest.raises(
+        NotImplementedError,
+        point_to_point_metric.evaluate,
+        estimate=None,
+        reference=None,
+    )
+    pytest.raises(NotImplementedError, point_to_point_metric.finalize)
+
+
+def test_point_to_dist_metrics():
+    """Test point to dist basic properties"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    point_to_dist_metric = PointToDistMetric(limits, dx)
+    assert point_to_dist_metric._limits == limits
+    assert point_to_dist_metric._dx == dx
+    assert PointToDistMetric.uses_distribution_for_estimate() is False
+    assert PointToDistMetric.uses_distribution_for_reference() is True
+    assert PointToDistMetric.uses_point_for_estimate() is True
+    assert PointToDistMetric.uses_point_for_reference() is False
+
+
+def test_point_to_dist_raises_unimplemented():
+    """Test point to dist raises exceptions"""
+    limits = (0.01, 2.99)
+    dx = 0.001
+    point_to_dist_metric = PointToDistMetric(limits, dx)
+
+    pytest.raises(NotImplementedError, point_to_dist_metric.initialize)
+    pytest.raises(
+        NotImplementedError,
+        point_to_dist_metric.evaluate,
+        estimate=None,
+        reference=None,
+    )
+    pytest.raises(NotImplementedError, point_to_dist_metric.finalize)

--- a/tests/qp/test_base_metric_classes.py
+++ b/tests/qp/test_base_metric_classes.py
@@ -29,9 +29,7 @@ def test_single_ensemble_raises_unimplemented():
     dx = 0.001
     single_ens_metric = SingleEnsembleMetric(limits, dx)
 
-    pytest.raises(NotImplementedError, single_ens_metric.initialize)
     pytest.raises(NotImplementedError, single_ens_metric.evaluate, estimate=None)
-    pytest.raises(NotImplementedError, single_ens_metric.finalize)
 
 
 def test_dist_to_dist_metrics():
@@ -53,11 +51,9 @@ def test_dist_to_dist_raises_unimplemented():
     dx = 0.001
     dist_to_dist_metric = DistToDistMetric(limits, dx)
 
-    pytest.raises(NotImplementedError, dist_to_dist_metric.initialize)
     pytest.raises(
         NotImplementedError, dist_to_dist_metric.evaluate, estimate=None, reference=None
     )
-    pytest.raises(NotImplementedError, dist_to_dist_metric.finalize)
 
 
 def test_dist_to_point_metrics():
@@ -79,14 +75,12 @@ def test_dist_to_point_raises_unimplemented():
     dx = 0.001
     dist_to_point_metric = DistToPointMetric(limits, dx)
 
-    pytest.raises(NotImplementedError, dist_to_point_metric.initialize)
     pytest.raises(
         NotImplementedError,
         dist_to_point_metric.evaluate,
         estimate=None,
         reference=None,
     )
-    pytest.raises(NotImplementedError, dist_to_point_metric.finalize)
 
 
 def test_point_to_point_metrics():
@@ -108,14 +102,12 @@ def test_point_to_point_raises_unimplemented():
     dx = 0.001
     point_to_point_metric = PointToPointMetric(limits, dx)
 
-    pytest.raises(NotImplementedError, point_to_point_metric.initialize)
     pytest.raises(
         NotImplementedError,
         point_to_point_metric.evaluate,
         estimate=None,
         reference=None,
     )
-    pytest.raises(NotImplementedError, point_to_point_metric.finalize)
 
 
 def test_point_to_dist_metrics():
@@ -137,11 +129,9 @@ def test_point_to_dist_raises_unimplemented():
     dx = 0.001
     point_to_dist_metric = PointToDistMetric(limits, dx)
 
-    pytest.raises(NotImplementedError, point_to_dist_metric.initialize)
     pytest.raises(
         NotImplementedError,
         point_to_dist_metric.evaluate,
         estimate=None,
         reference=None,
     )
-    pytest.raises(NotImplementedError, point_to_dist_metric.finalize)

--- a/tests/qp/test_metrics.py
+++ b/tests/qp/test_metrics.py
@@ -8,7 +8,7 @@ import qp.metrics
 import numpy as np
 
 from qp import test_funcs
-from qp.metrics.metrics import * 
+from qp.metrics.metrics import *
 from qp.utils import epsilon
 from scipy import stats
 

--- a/tests/qp/test_metrics.py
+++ b/tests/qp/test_metrics.py
@@ -1,79 +1,120 @@
+# pylint: disable=no-member
+# pylint: disable=protected-access
+
 """
 Unit tests for PDF class
 """
-
 import unittest
+import numpy as np
 import qp
 import qp.metrics
-import numpy as np
 
 from qp import test_funcs
-from qp.metrics.metrics import *
+from qp.metrics.array_metrics import quick_rbpe
+from qp.metrics.metrics import (
+    _calculate_grid_parameters,
+    _check_ensemble_is_not_nested,
+    _check_ensembles_are_same_size,
+    _check_ensembles_contain_correct_number_of_distributions,
+    calculate_brier,
+    calculate_goodness_of_fit,
+    calculate_kld,
+    calculate_moment,
+    calculate_outlier_rate,
+    calculate_rbpe,
+    calculate_rmse,
+)
+from qp.metrics.concrete_metric_classes import (
+    BrierMetric,
+    KLDMetric,
+    MomentMetric,
+    OutlierMetric,
+    RBPEMetric,
+    RMSEMetric,
+)
 from qp.utils import epsilon
-from scipy import stats
+
 
 class MetricTestCase(unittest.TestCase):
-    """ Tests for the metrics """
+    """Tests for the metrics"""
 
     def setUp(self):
         """
         Make any objects that are used in multiple tests.
         """
-        self.ens_n = test_funcs.build_ensemble(qp.stats.norm_gen.test_data['norm'])  #pylint: disable=no-member
-        self.ens_n_shift = test_funcs.build_ensemble(qp.stats.norm_gen.test_data['norm_shifted'])  #pylint: disable=no-member
-        self.ens_n_multi = test_funcs.build_ensemble(qp.stats.norm_gen.test_data['norm_multi_d'])  #pylint: disable=no-member
+        self.ens_n = test_funcs.build_ensemble(qp.stats.norm_gen.test_data["norm"])
+        self.ens_n_shift = test_funcs.build_ensemble(
+            qp.stats.norm_gen.test_data["norm_shifted"]
+        )
+        self.ens_n_multi = test_funcs.build_ensemble(
+            qp.stats.norm_gen.test_data["norm_multi_d"]
+        )
 
-        locs = 2* (np.random.uniform(size=(10,1))-0.5)
-        scales = 1 + 0.2*(np.random.uniform(size=(10,1))-0.5)
-        self.ens_n_plus_one = qp.Ensemble(qp.stats.norm, data=dict(loc=locs, scale=scales))  #pylint: disable=no-member
+        locs = 2 * (np.random.uniform(size=(10, 1)) - 0.5)
+        scales = 1 + 0.2 * (np.random.uniform(size=(10, 1)) - 0.5)
+        self.ens_n_plus_one = qp.Ensemble(
+            qp.stats.norm, data=dict(loc=locs, scale=scales)
+        )
 
         bins = np.linspace(-5, 5, 11)
         self.ens_s = self.ens_n.convert_to(qp.spline_gen, xvals=bins, method="xy")
 
-    def tearDown(self):
-        """ Clean up any mock data files created by the tests. """
-
     def test_calculate_grid_parameters(self):
-        """ Given a small, simple input, ensure that the grid parameters are correct. """
-        limits = (0,1)
-        dx = 1./11
-        grid_params = qp.metrics._calculate_grid_parameters(limits, dx)  #pylint: disable=W0212
+        """Given a small, simple input, ensure that the grid parameters are correct."""
+        limits = (0, 1)
+        dx = 1.0 / 11
+        grid_params = _calculate_grid_parameters(limits, dx)
         assert grid_params.cardinality == 11
         assert grid_params.resolution == 0.1
         assert grid_params.grid_values[0] == limits[0]
         assert grid_params.grid_values[-1] == limits[-1]
         assert grid_params.grid_values.size == grid_params.cardinality
-        assert grid_params.hist_bin_edges[0] == limits[0] - grid_params.resolution/2
-        assert grid_params.hist_bin_edges[-1] == limits[-1] + grid_params.resolution/2
+        assert grid_params.hist_bin_edges[0] == limits[0] - grid_params.resolution / 2
+        assert grid_params.hist_bin_edges[-1] == limits[-1] + grid_params.resolution / 2
         assert grid_params.hist_bin_edges.size == grid_params.cardinality + 1
 
     def test_calculate_grid_parameters_larger_range(self):
-        """ Test that a large range in limits and small delta returns expected results """
-        limits = (-75,112)
+        """Test that a large range in limits and small delta returns expected results"""
+        limits = (-75, 112)
         dx = 0.042
-        grid_params = qp.metrics._calculate_grid_parameters(limits, dx)  #pylint: disable=W0212
+        grid_params = _calculate_grid_parameters(limits, dx)
         assert grid_params.grid_values[0] == limits[0]
         assert grid_params.grid_values[-1] == limits[-1]
         assert grid_params.grid_values.size == grid_params.cardinality
-        assert grid_params.hist_bin_edges[0] == limits[0] - grid_params.resolution/2
-        assert grid_params.hist_bin_edges[-1] == limits[-1] + grid_params.resolution/2
+        assert grid_params.hist_bin_edges[0] == limits[0] - grid_params.resolution / 2
+        assert grid_params.hist_bin_edges[-1] == limits[-1] + grid_params.resolution / 2
         assert grid_params.hist_bin_edges.size == grid_params.cardinality + 1
 
     def test_kld(self):
-        """ Test the calculate_kld method """
-        kld = qp.metrics.calculate_kld(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
-        assert np.all(kld == 0.)
+        """Test the calculate_kld method. Ensure that the class wrapped version
+        returns the same results."""
+        limits = (0.0, 2.5)
+        kld = calculate_kld(self.ens_n, self.ens_n_shift, limits=limits)
+        assert np.all(kld == 0.0)
+
+        kld_class = KLDMetric(limits=limits)
+        kld_class.initialize()
+        result = kld_class.evaluate(self.ens_n, self.ens_n_shift)
+        kld_class.finalize()
+        assert np.all(kld == result)
 
     def test_calculate_moment(self):
-        """ Base case test """
+        """Base case test. Ensure that the class wrapped
+        version returns the same results."""
         moment = 1
-        limits = (-2., 2.)
+        limits = (-2.0, 2.0)
         result = calculate_moment(self.ens_n, moment, limits)
 
         self.assertTrue(result is not None)
-    
+
+        moment_class = MomentMetric(moment_order=moment, limits=limits)
+        moment_class.initialize()
+        class_result = moment_class.evaluate(self.ens_n)
+        moment_class.finalize()
+        assert np.all(result == class_result)
+
     def test_kld_alternative_ensembles(self):
-        """ Test the calculate_kld method against different types of ensembles """
+        """Test the calculate_kld method against different types of ensembles"""
         bins = np.linspace(-5, 5, 11)
         quants = np.linspace(0.01, 0.99, 7)
 
@@ -84,44 +125,56 @@ class MetricTestCase(unittest.TestCase):
         ens_i_shift = self.ens_n_shift[0].convert_to(qp.interp_gen, xvals=bins)
 
         ens_s = self.ens_n[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
-        ens_s_shift = self.ens_n_shift[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
+        ens_s_shift = self.ens_n_shift[0].convert_to(
+            qp.spline_gen, xvals=bins, method="xy"
+        )
 
         ens_q = self.ens_n[0].convert_to(qp.quant_gen, quants=quants)
         ens_q_shift = self.ens_n_shift[0].convert_to(qp.quant_gen, quants=quants)
 
-        kld_histogram = qp.metrics.calculate_kld(ens_h, ens_h_shift, limits=(0.,2.5))
-        assert np.all(kld_histogram == 0.)
+        kld_histogram = calculate_kld(ens_h, ens_h_shift, limits=(0.0, 2.5))
+        assert np.all(kld_histogram == 0.0)
 
-        kld_interp = qp.metrics.calculate_kld(ens_i, ens_i_shift, limits=(0.,2.5))
-        assert np.all(kld_interp == 0.)
+        kld_interp = calculate_kld(ens_i, ens_i_shift, limits=(0.0, 2.5))
+        assert np.all(kld_interp == 0.0)
 
-        kld_spline = qp.metrics.calculate_kld(ens_s, ens_s_shift, limits=(0.,2.5))
-        assert np.all(kld_spline == 0.)
+        kld_spline = calculate_kld(ens_s, ens_s_shift, limits=(0.0, 2.5))
+        assert np.all(kld_spline == 0.0)
 
-        kld_quants = qp.metrics.calculate_kld(ens_q, ens_q_shift, limits=(0.,2.5))
-        assert np.all(kld_quants == 0.)
+        kld_quants = calculate_kld(ens_q, ens_q_shift, limits=(0.0, 2.5))
+        assert np.all(kld_quants == 0.0)
 
     def test_kld_different_shapes(self):
-        """ Ensure that the kld function fails when trying to compare ensembles of different sizes. """
+        """Ensure that the kld function fails when trying to compare ensembles of different sizes."""
         with self.assertRaises(ValueError) as context:
-            qp.metrics.calculate_kld(self.ens_n, self.ens_n_plus_one, limits=(0.,2.5))
+            calculate_kld(self.ens_n, self.ens_n_plus_one, limits=(0.0, 2.5))
 
-        self.assertTrue('Cannot calculate KLD between two ensembles with different shapes' in str(context.exception))
+        self.assertTrue(
+            "Cannot calculate KLD between two ensembles with different shapes"
+            in str(context.exception)
+        )
 
     def test_broken_kld(self):
-        """ Test to see if the calculate_kld function responds appropriately to negative results """
-        kld = qp.metrics.calculate_kld(self.ens_n, self.ens_s, limits=(0.,2.5))
+        """Test to see if the calculate_kld function responds appropriately to negative results"""
+        kld = calculate_kld(self.ens_n, self.ens_s, limits=(0.0, 2.5))
 
         assert np.all(kld == epsilon)
-        
 
     def test_rmse(self):
-        """ Test the calculate_rmse method """
-        rmse = qp.metrics.calculate_rmse(self.ens_n, self.ens_n_shift, limits=(0.,2.5))
-        assert np.all(rmse == 0.)
+        """Test the calculate_rmse method. Ensure that the class wrapped version
+        returns the same results."""
+        limits = (0.0, 2.5)
+        rmse = calculate_rmse(self.ens_n, self.ens_n_shift, limits=limits)
+        assert np.all(rmse == 0.0)
+
+        rmse_class = RMSEMetric(limits=limits)
+        rmse_class.initialize()
+        result = rmse_class.evaluate(self.ens_n, self.ens_n_shift)
+        rmse_class.finalize()
+        assert np.all(rmse == result)
 
     def test_rmse_alternative_ensembles(self):
-        """ Test the calculate_rmse method against different types of ensembles """
+        """Test the calculate_rmse method against different types of ensembles"""
         bins = np.linspace(-5, 5, 11)
         quants = np.linspace(0.01, 0.99, 7)
 
@@ -132,43 +185,56 @@ class MetricTestCase(unittest.TestCase):
         ens_i_shift = self.ens_n_shift[0].convert_to(qp.interp_gen, xvals=bins)
 
         ens_s = self.ens_n[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
-        ens_s_shift = self.ens_n_shift[0].convert_to(qp.spline_gen, xvals=bins, method="xy")
+        ens_s_shift = self.ens_n_shift[0].convert_to(
+            qp.spline_gen, xvals=bins, method="xy"
+        )
 
         ens_q = self.ens_n[0].convert_to(qp.quant_gen, quants=quants)
         ens_q_shift = self.ens_n_shift[0].convert_to(qp.quant_gen, quants=quants)
 
-        rmse_histogram = qp.metrics.calculate_rmse(ens_h, ens_h_shift, limits=(0.,2.5))
-        assert np.all(rmse_histogram == 0.)
+        rmse_histogram = calculate_rmse(ens_h, ens_h_shift, limits=(0.0, 2.5))
+        assert np.all(rmse_histogram == 0.0)
 
-        rmse_interp = qp.metrics.calculate_rmse(ens_i, ens_i_shift, limits=(0.,2.5))
-        assert np.all(rmse_interp == 0.)
+        rmse_interp = calculate_rmse(ens_i, ens_i_shift, limits=(0.0, 2.5))
+        assert np.all(rmse_interp == 0.0)
 
-        rmse_spline = qp.metrics.calculate_rmse(ens_s, ens_s_shift, limits=(0.,2.5))
-        assert np.all(rmse_spline == 0.)
+        rmse_spline = calculate_rmse(ens_s, ens_s_shift, limits=(0.0, 2.5))
+        assert np.all(rmse_spline == 0.0)
 
-        rmse_quants = qp.metrics.calculate_rmse(ens_q, ens_q_shift, limits=(0.,2.5))
-        assert np.all(rmse_quants == 0.)
+        rmse_quants = calculate_rmse(ens_q, ens_q_shift, limits=(0.0, 2.5))
+        assert np.all(rmse_quants == 0.0)
 
     def test_rmse_different_shapes(self):
-        """ Ensure that the rmse function fails when trying to compare ensembles of different sizes. """
+        """Ensure that the rmse function fails when trying to compare ensembles of different sizes."""
         with self.assertRaises(ValueError) as context:
-            qp.metrics.calculate_rmse(self.ens_n, self.ens_n_plus_one, limits=(0.,2.5))
+            calculate_rmse(self.ens_n, self.ens_n_plus_one, limits=(0.0, 2.5))
 
-        self.assertTrue('Cannot calculate RMSE between two ensembles with different shapes' in str(context.exception))
+        self.assertTrue(
+            "Cannot calculate RMSE between two ensembles with different shapes"
+            in str(context.exception)
+        )
 
     def test_rbpe(self):
-        """ Test the risk_based_point_estimate method """
-        rbpe = qp.metrics.calculate_rbpe(self.ens_n, limits=(0.,2.5))
-        assert np.all(rbpe >= 0.)
+        """Test the risk_based_point_estimate method. Ensure that the class wrapped
+        version returns the same results."""
+        limits = (0.0, 2.5)
+        rbpe = calculate_rbpe(self.ens_n, limits=limits)
+        assert np.all(rbpe >= 0.0)
         assert np.all(rbpe <= 2.5)
 
+        rbpe_class = RBPEMetric(limits=limits)
+        rbpe_class.initialize()
+        result = rbpe_class.evaluate(self.ens_n)
+        rbpe_class.finalize()
+        assert np.all(rbpe == result)
+
     def test_rbpe_no_limits(self):
-        """ Test the risk_based_point_estimate method when the user doesn't provide a set of limits """
-        rbpe = qp.metrics.calculate_rbpe(self.ens_n)
-        assert np.all(rbpe >= -2.)
+        """Test the risk_based_point_estimate method when the user doesn't provide a set of limits"""
+        rbpe = calculate_rbpe(self.ens_n)
+        assert np.all(rbpe >= -2.0)
 
     def test_rbpe_alternative_ensembles(self):
-        """ Test the risk_based_point_estimate method against different types of ensembles """
+        """Test the risk_based_point_estimate method against different types of ensembles"""
         bins = np.linspace(-5, 5, 11)
         quants = np.linspace(0.01, 0.99, 7)
 
@@ -178,63 +244,79 @@ class MetricTestCase(unittest.TestCase):
         ens_q = self.ens_n[0].convert_to(qp.quant_gen, quants=quants)
         ens_m = self.ens_n[0].convert_to(qp.mixmod_gen, samples=1000, ncomps=3)
 
-        rbpe_histogram = qp.metrics.calculate_rbpe(ens_h, limits=(0.,2.5))
-        assert np.all(rbpe_histogram >= 0.)
+        rbpe_histogram = calculate_rbpe(ens_h, limits=(0.0, 2.5))
+        assert np.all(rbpe_histogram >= 0.0)
         assert np.all(rbpe_histogram <= 2.5)
 
-        rbpe_interp = qp.metrics.calculate_rbpe(ens_i, limits=(0.,2.5))
-        assert np.all(rbpe_interp >= 0.)
+        rbpe_interp = calculate_rbpe(ens_i, limits=(0.0, 2.5))
+        assert np.all(rbpe_interp >= 0.0)
         assert np.all(rbpe_interp <= 2.5)
 
-        rbpe_spline = qp.metrics.calculate_rbpe(ens_s, limits=(0.,2.5))
-        assert np.all(rbpe_spline >= 0.)
+        rbpe_spline = calculate_rbpe(ens_s, limits=(0.0, 2.5))
+        assert np.all(rbpe_spline >= 0.0)
         assert np.all(rbpe_spline <= 2.5)
 
-        rbpe_quants = qp.metrics.calculate_rbpe(ens_q, limits=(0.,2.5))
-        assert np.all(rbpe_quants >= 0.)
+        rbpe_quants = calculate_rbpe(ens_q, limits=(0.0, 2.5))
+        assert np.all(rbpe_quants >= 0.0)
         assert np.all(rbpe_quants <= 2.5)
 
-        rbpe_mixmod = qp.metrics.calculate_rbpe(ens_m, limits=(0.,2.5))
-        assert np.all(rbpe_mixmod >= 0.)
+        rbpe_mixmod = calculate_rbpe(ens_m, limits=(0.0, 2.5))
+        assert np.all(rbpe_mixmod >= 0.0)
         assert np.all(rbpe_mixmod <= 2.5)
-        
 
     def test_quick_rbpe(self):
-        """ Test the quick_rbpe method """
+        """Test the quick_rbpe method"""
+
         def eval_pdf_at_z(z):
             return self.ens_n[0].pdf(z)[0][0]
-        integration_bounds = (self.ens_n[0].ppf(0.01)[0][0], self.ens_n[0].ppf(0.99)[0][0])
-        rbpe = qp.metrics.quick_rbpe(eval_pdf_at_z, integration_bounds, limits=(0.,2.5))
-        assert np.all(rbpe >= 0.)
+
+        integration_bounds = (
+            self.ens_n[0].ppf(0.01)[0][0],
+            self.ens_n[0].ppf(0.99)[0][0],
+        )
+        rbpe = quick_rbpe(eval_pdf_at_z, integration_bounds, limits=(0.0, 2.5))
+        assert np.all(rbpe >= 0.0)
         assert np.all(rbpe <= 2.5)
 
     def test_quick_rbpe_no_limits(self):
-        """ Test the quick_rbpe method """
+        """Test the quick_rbpe method"""
+
         def eval_pdf_at_z(z):
             return self.ens_n[0].pdf(z)[0][0]
-        integration_bounds = (self.ens_n[0].ppf(0.01)[0][0], self.ens_n[0].ppf(0.99)[0][0])
-        rbpe = qp.metrics.quick_rbpe(eval_pdf_at_z, integration_bounds)
-        assert np.all(rbpe >= -2.)
+
+        integration_bounds = (
+            self.ens_n[0].ppf(0.01)[0][0],
+            self.ens_n[0].ppf(0.99)[0][0],
+        )
+        rbpe = quick_rbpe(eval_pdf_at_z, integration_bounds)
+        assert np.all(rbpe >= -2.0)
 
     def test_rbpe_multiple_pdfs(self):
-        """ Ensure that calculate_rbpe function fails when working with multi-dimensional Ensembles. """
+        """Ensure that calculate_rbpe function fails when working with multi-dimensional Ensembles."""
         with self.assertRaises(ValueError) as context:
-            _ = qp.metrics.calculate_rbpe(self.ens_n_multi, limits=(0.,2.5))
+            _ = calculate_rbpe(self.ens_n_multi, limits=(0.0, 2.5))
 
-        error_msg = 'quick_rbpe only handles Ensembles with a single PDF'
+        error_msg = "quick_rbpe only handles Ensembles with a single PDF"
         self.assertTrue(error_msg in str(context.exception))
 
     def test_calculate_brier(self):
-        """ Base test case of Ensemble-based brier metric """
-        truth = 2* (np.random.uniform(size=(11,1))-0.5)
-        limits = [-2., 2]
+        """Base test case of Ensemble-based brier metric. Ensure that the class wrapped
+        version returns the same results."""
+        truth = 2 * (np.random.uniform(size=(11, 1)) - 0.5)
+        limits = [-2.0, 2]
         result = calculate_brier(self.ens_n, truth, limits)
         self.assertTrue(result is not None)
 
+        brier_class = BrierMetric(limits=limits)
+        brier_class.initialize()
+        class_result = brier_class.evaluate(self.ens_n, truth)
+        brier_class.finalize()
+        assert np.all(result == class_result)
+
     def test_calculate_brier_mismatched_number_of_truths(self):
-        """ Expect an exception when number of truth values doesn't match number of distributions """
-        truth = 2* (np.random.uniform(size=(10,1))-0.5)
-        limits = [-2., 2]
+        """Expect an exception when number of truth values doesn't match number of distributions"""
+        truth = 2 * (np.random.uniform(size=(10, 1)) - 0.5)
+        limits = [-2.0, 2]
         with self.assertRaises(ValueError) as context:
             _ = calculate_brier(self.ens_n, truth, limits)
 
@@ -242,10 +324,10 @@ class MetricTestCase(unittest.TestCase):
         self.assertTrue(error_msg in str(context.exception))
 
     def test_calculate_brier_truth_outside_of_limits(self):
-        """ Expect an exception when truth is outside of the limits """
-        truth = 2* (np.random.uniform(size=(10,1))-0.5)
+        """Expect an exception when truth is outside of the limits"""
+        truth = 2 * (np.random.uniform(size=(10, 1)) - 0.5)
         truth = np.append(truth, 100)
-        limits = [-2., 2]
+        limits = [-2.0, 2]
         with self.assertRaises(ValueError) as context:
             _ = calculate_brier(self.ens_n, truth, limits)
 
@@ -253,33 +335,40 @@ class MetricTestCase(unittest.TestCase):
         self.assertTrue(error_msg in str(context.exception))
 
     def test_calculate_outlier_rate(self):
-        """Base case test"""
-        output = qp.metrics.calculate_outlier_rate(self.ens_n[0])
+        """Base case test. Ensure that the class wrapped
+        version returns the same results."""
+        output = calculate_outlier_rate(self.ens_n[0])
         self.assertTrue(len(output) == 1)
         self.assertTrue(np.isclose(output[0], 0.012436869911068668))
 
+        outlier_class = OutlierMetric()
+        outlier_class.initialize()
+        class_results = outlier_class.evaluate(self.ens_n[0])
+        outlier_class.finalize()
+        assert np.all(output == class_results)
+
     def test_calculate_outlier_rate_with_bounds(self):
         """Include min/max bounds for outlier rate"""
-        output = qp.metrics.calculate_outlier_rate(self.ens_n[0], -10, 10)
+        output = calculate_outlier_rate(self.ens_n[0], -10, 10)
         self.assertTrue(len(output) == 1)
         self.assertTrue(np.isclose(output[0], 0))
 
     def test_calculate_outlier_rate_many_distributions(self):
         """Check that the outlier rate is correctly calculated for an Ensemble with many distributions"""
-        output = qp.metrics.calculate_outlier_rate(self.ens_n)
+        output = calculate_outlier_rate(self.ens_n)
         self.assertTrue(len(output) == 11)
 
     def test_check_ensembles_are_same_size(self):
         """Test that no Value Error is raised when the ensembles are the same size"""
         try:
-            qp.metrics._check_ensembles_are_same_size(self.ens_n, self.ens_n_shift)  #pylint: disable=W0212
+            _check_ensembles_are_same_size(self.ens_n, self.ens_n_shift)
         except ValueError:
             self.fail("Unexpectedly raised ValueError")
 
     def test_check_ensembles_are_same_size_asserts(self):
         """Test that a Value Error is raised when the ensembles are not the same size"""
         with self.assertRaises(ValueError) as context:
-            qp.metrics._check_ensembles_are_same_size(self.ens_n, self.ens_n_plus_one)  #pylint: disable=W0212
+            _check_ensembles_are_same_size(self.ens_n, self.ens_n_plus_one)
 
         error_msg = "Input ensembles should have the same number of distributions"
         self.assertTrue(error_msg in str(context.exception))
@@ -287,43 +376,57 @@ class MetricTestCase(unittest.TestCase):
     def test_check_ensemble_is_not_nested_with_flat_ensemble(self):
         """Test that no ValueError is raised when a flat Ensemble is passed in"""
         try:
-            qp.metrics._check_ensemble_is_not_nested(self.ens_n)  #pylint: disable=W0212
+            _check_ensemble_is_not_nested(self.ens_n)
         except ValueError:
             self.fail("Unexpectedly raised ValueError")
 
     def test_check_ensemble_is_not_nested_with_nested_ensemble(self):
         """Test that a ValueError is raised when a nested Ensemble is passed in"""
         with self.assertRaises(ValueError) as context:
-            qp.metrics._check_ensemble_is_not_nested(self.ens_n_multi)  #pylint: disable=W0212
+            _check_ensemble_is_not_nested(self.ens_n_multi)
 
-        error_msg = "Each element in the input Ensemble should be a single distribution."
+        error_msg = (
+            "Each element in the input Ensemble should be a single distribution."
+        )
         self.assertTrue(error_msg in str(context.exception))
 
     def test_check_ensembles_contain_correct_number_of_distributions_base(self):
         """Test base case of two ensembles the same size"""
         try:
-            qp.metrics._check_ensembles_contain_correct_number_of_distributions(estimate=self.ens_n, reference=self.ens_n)
+            _check_ensembles_contain_correct_number_of_distributions(
+                estimate=self.ens_n, reference=self.ens_n
+            )
         except ValueError:
             self.fail("Unexpectedly raised ValueError")
 
     def test_check_ensembles_contain_correct_number_of_distributions_both_size_1(self):
         """Test base case of two ensembles with 1 distribution each"""
         try:
-            qp.metrics._check_ensembles_contain_correct_number_of_distributions(estimate=self.ens_n[0], reference=self.ens_n[1])
+            _check_ensembles_contain_correct_number_of_distributions(
+                estimate=self.ens_n[0], reference=self.ens_n[1]
+            )
         except ValueError:
             self.fail("Unexpected raised ValueError")
 
-    def test_check_ensembles_contain_correct_number_of_distributions_reference_has_1(self):
+    def test_check_ensembles_contain_correct_number_of_distributions_reference_has_1(
+        self,
+    ):
         """Test case of reference ensemble has 1 distribution, estimate has N"""
         try:
-            qp.metrics._check_ensembles_contain_correct_number_of_distributions(estimate=self.ens_n, reference=self.ens_n[1])
+            _check_ensembles_contain_correct_number_of_distributions(
+                estimate=self.ens_n, reference=self.ens_n[1]
+            )
         except ValueError:
             self.fail("Unexpected raised ValueError")
 
-    def test_check_ensembles_contain_correct_number_of_distributions_with_different_sizes(self):
+    def test_check_ensembles_contain_correct_number_of_distributions_with_different_sizes(
+        self,
+    ):
         """Test the case of reference with M distributions, and estimate with N distributions"""
         with self.assertRaises(ValueError) as context:
-            qp.metrics._check_ensembles_contain_correct_number_of_distributions(estimate=self.ens_n, reference=self.ens_n_plus_one)
+            _check_ensembles_contain_correct_number_of_distributions(
+                estimate=self.ens_n, reference=self.ens_n_plus_one
+            )
 
         error_msg = "`reference` should contain either"
         self.assertTrue(error_msg in str(context.exception))
@@ -331,10 +434,11 @@ class MetricTestCase(unittest.TestCase):
     def test_calculate_goodness_of_fit_with_unsupported_fit_metric(self):
         """Test that a KeyError is raised if an unsupported fit_metric is requested"""
         with self.assertRaises(KeyError) as context:
-            qp.metrics.calculate_goodness_of_fit(self.ens_n, self.ens_n, 'xx')
+            calculate_goodness_of_fit(self.ens_n, self.ens_n, "xx")
 
         error_msg = "`fit_metric` should be one of"
         self.assertTrue(error_msg in str(context.exception))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/qp/test_scipy_vectorization.py
+++ b/tests/qp/test_scipy_vectorization.py
@@ -1,18 +1,23 @@
+# pylint: disable=no-member
 """
 Unit tests for PDF class
 """
-
+import time
 import unittest
+import numpy as np
 import qp
 import qp.metrics
-import numpy as np
 
 from qp import test_funcs
+from qp.metrics.concrete_metric_classes import (
+    ADMetric,
+    CvMMetric,
+    KSMetric,
+)
 
-import time
 
 class ScipyVectorizationTests(unittest.TestCase):
-    """ Tests for the metrics """
+    """Tests for the metrics"""
 
     @classmethod
     def setUpClass(cls):
@@ -22,21 +27,35 @@ class ScipyVectorizationTests(unittest.TestCase):
         cls.random_state = 9999
         cls.rvs_size = 100
         t1 = time.perf_counter()
-        # ! Consider changing this to the gamma distribution - norm is symmetric. trunc_norm is a good option too.
-        cls.ens_n = test_funcs.build_ensemble(qp.stats.norm_gen.test_data['norm'])  #pylint: disable=no-member
+        # ! Consider changing this to the gamma distribution - norm is symmetric.
+        # ! trunc_norm is a good option too.
+        cls.ens_n = test_funcs.build_ensemble(qp.stats.norm_gen.test_data["norm"])
         t2 = time.perf_counter()
-        print(f'Setup time is {t2-t1}')
-        print(f'Ensemble contains {cls.ens_n.npdf} distributions.')
-        print(f'For each statistic {cls.rvs_size} random variables will be generated.')
+        print(f"Setup time is {t2-t1}")
+        print(f"Ensemble contains {cls.ens_n.npdf} distributions.")
+        print(f"For each statistic {cls.rvs_size} random variables will be generated.")
 
     @classmethod
     def tearDownClass(cls):
-        """ Clean up any mock data files created by the tests. """
+        """Clean up any mock data files created by the tests."""
 
     def test_ad_results(self):
-        """This test compares the results of the Anderson-Darling evaluation against a known output"""
-        expected_output = [1.41296516, 2.18126088, 0.59390624, 0.43942853, 0.67658563, 0.38376997,
-        0.66460796, 2.72899571, 1.4542696, 1.34378282, 1.19221443]
+        """This test compares the results of the Anderson-Darling evaluation
+        against a known output. Ensure that the class wrapped version returns
+        the same results."""
+        expected_output = [
+            1.41296516,
+            2.18126088,
+            0.59390624,
+            0.43942853,
+            0.67658563,
+            0.38376997,
+            0.66460796,
+            2.72899571,
+            1.4542696,
+            1.34378282,
+            1.19221443,
+        ]
 
         # Specify these here, so that changes in setupClass don't affect the results
         rvs_size = 100
@@ -45,19 +64,37 @@ class ScipyVectorizationTests(unittest.TestCase):
         test_output = qp.metrics.calculate_goodness_of_fit(
             self.ens_n,
             self.ens_n,
-            fit_metric='ad',
+            fit_metric="ad",
             num_samples=rvs_size,
-            _random_state=random_state
+            _random_state=random_state,
         )
 
         for test, expected in zip(test_output, expected_output):
             assert np.isclose(test, expected)
 
+        ad_class = ADMetric(num_samples=rvs_size)
+        ad_class.random_state = random_state
+        ad_class.initialize()
+        class_results = ad_class.evaluate(self.ens_n, self.ens_n)
+        ad_class.finalize()
+        assert np.all(test_output == class_results)
+        assert ad_class.random_state == random_state
+
     def test_call_copied_method_ad_versus_single_distribution_ensemble(self):
         """For Anderson-Darling stat stat for ensemble vs. ensemble-with-1-distribution"""
-        expected_output = [1.41296516e+00, 5.94997248e+01, 1.76866646e+02, 3.76671747e+02,
-        6.17435009e+02, 9.61477755e+02, 1.24161826e+03, 2.33034254e+03, 1.87698332e+03,
-        2.44635392e+03, 4.10601407e+03]
+        expected_output = [
+            1.41296516e00,
+            5.94997248e01,
+            1.76866646e02,
+            3.76671747e02,
+            6.17435009e02,
+            9.61477755e02,
+            1.24161826e03,
+            2.33034254e03,
+            1.87698332e03,
+            2.44635392e03,
+            4.10601407e03,
+        ]
 
         # Specify these here, so that changes in setupClass don't affect the results
         rvs_size = 100
@@ -66,18 +103,31 @@ class ScipyVectorizationTests(unittest.TestCase):
         test_output = qp.metrics.calculate_goodness_of_fit(
             self.ens_n,
             self.ens_n[0],
-            fit_metric='ad',
+            fit_metric="ad",
             num_samples=rvs_size,
-            _random_state=random_state
+            _random_state=random_state,
         )
 
         for test, expected in zip(test_output, expected_output):
             assert np.isclose(test, expected)
 
     def test_cvm_results(self):
-        """This test compares the results of the Cramer-von Mises evaluation against a known output"""
-        expected_output = [0.22630139, 0.27090351, 0.09884569, 0.04506071, 0.10731862, 0.05631584,
-            0.07646541, 0.52543176, 0.23656815, 0.21094075, 0.22384716]
+        """This test compares the results of the Cramer-von Mises evaluation
+        against a known output. Ensure that the class wrapped version returns
+        the same results."""
+        expected_output = [
+            0.22630139,
+            0.27090351,
+            0.09884569,
+            0.04506071,
+            0.10731862,
+            0.05631584,
+            0.07646541,
+            0.52543176,
+            0.23656815,
+            0.21094075,
+            0.22384716,
+        ]
 
         # Specify these here, so that changes in setupClass don't affect the results
         rvs_size = 100
@@ -86,18 +136,37 @@ class ScipyVectorizationTests(unittest.TestCase):
         test_output = qp.metrics.calculate_goodness_of_fit(
             self.ens_n,
             self.ens_n,
-            fit_metric='cvm',
+            fit_metric="cvm",
             num_samples=rvs_size,
-            _random_state=random_state
+            _random_state=random_state,
         )
 
         for test, expected in zip(test_output, expected_output):
             assert np.isclose(test, expected)
 
+        cvm_class = CvMMetric(num_samples=rvs_size)
+        cvm_class.random_state = random_state
+        cvm_class.initialize()
+        class_results = cvm_class.evaluate(self.ens_n, self.ens_n)
+        cvm_class.finalize()
+        assert np.all(test_output == class_results)
+        assert cvm_class.random_state == random_state
+
     def test_call_copied_method_cvm_versus_single_distribution_ensemble(self):
         """For Cramer von Mises stat stat for ensemble vs. ensemble-with-1-distribution"""
-        expected_output = [0.22630139, 4.90875135, 12.18815523, 17.88155095, 21.76168586, 24.17512056,
-        22.69008766, 28.436041, 23.2801267, 23.87779491, 28.99530345]
+        expected_output = [
+            0.22630139,
+            4.90875135,
+            12.18815523,
+            17.88155095,
+            21.76168586,
+            24.17512056,
+            22.69008766,
+            28.436041,
+            23.2801267,
+            23.87779491,
+            28.99530345,
+        ]
 
         # Specify these here, so that changes in setupClass don't affect the results
         rvs_size = 100
@@ -106,18 +175,31 @@ class ScipyVectorizationTests(unittest.TestCase):
         test_output = qp.metrics.calculate_goodness_of_fit(
             self.ens_n,
             self.ens_n[0],
-            fit_metric='cvm',
+            fit_metric="cvm",
             num_samples=rvs_size,
-            _random_state=random_state
+            _random_state=random_state,
         )
 
         for test, expected in zip(test_output, expected_output):
             assert np.isclose(test, expected)
 
     def test_ks_results(self):
-        """This test compares the results of the Kolmogorov-Smirnov evaluation against a known output"""
-        expected_output = [0.11739344, 0.10533858, 0.07950318, 0.06216017, 0.08471774, 0.05786293,
-        0.08342168, 0.14441362, 0.09896913, 0.11243258, 0.09189444]
+        """This test compares the results of the Kolmogorov-Smirnov evaluation
+        against a known output. Ensure that the class wrapped version returns
+        the same results."""
+        expected_output = [
+            0.11739344,
+            0.10533858,
+            0.07950318,
+            0.06216017,
+            0.08471774,
+            0.05786293,
+            0.08342168,
+            0.14441362,
+            0.09896913,
+            0.11243258,
+            0.09189444,
+        ]
 
         # Specify these here, so that changes in setupClass don't affect the results
         rvs_size = 100
@@ -126,18 +208,37 @@ class ScipyVectorizationTests(unittest.TestCase):
         test_output = qp.metrics.calculate_goodness_of_fit(
             self.ens_n,
             self.ens_n,
-            fit_metric='ks',
+            fit_metric="ks",
             num_samples=rvs_size,
-            _random_state=random_state
+            _random_state=random_state,
         )
 
         for test, expected in zip(test_output, expected_output):
             assert np.isclose(test, expected)
 
+        ks_class = KSMetric(num_samples=rvs_size)
+        ks_class.random_state = random_state
+        ks_class.initialize()
+        class_results = ks_class.evaluate(self.ens_n, self.ens_n)
+        ks_class.finalize()
+        assert np.all(test_output == class_results)
+        assert ks_class.random_state == random_state
+
     def test_call_copied_method_ks_versus_single_distribution_ensemble(self):
         """Test Kolmogorov-Smirnov stat for ensemble vs. ensemble-with-1-distribution"""
-        expected_output = [0.11739344, 0.38809819, 0.51939786, 0.70188153, 0.76502763, 0.80196938,
-        0.79053856, 0.8996195, 0.80379571, 0.82881527, 0.9095734]
+        expected_output = [
+            0.11739344,
+            0.38809819,
+            0.51939786,
+            0.70188153,
+            0.76502763,
+            0.80196938,
+            0.79053856,
+            0.8996195,
+            0.80379571,
+            0.82881527,
+            0.9095734,
+        ]
 
         # Specify these here, so that changes in setupClass don't affect the results
         rvs_size = 100
@@ -146,9 +247,9 @@ class ScipyVectorizationTests(unittest.TestCase):
         test_output = qp.metrics.calculate_goodness_of_fit(
             self.ens_n,
             self.ens_n[0],
-            fit_metric='ks',
+            fit_metric="ks",
             num_samples=rvs_size,
-            _random_state=random_state
+            _random_state=random_state,
         )
 
         for test, expected in zip(test_output, expected_output):


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
The variety of different metric APIs that are present in qp currently make it challenging to write consistent evaluator stages in RAIL. By introducing wrapper classes we can abstract and unify the API (as much as possible) while making it easier to interface with RAIL evaluator stages.

## TODO
Need to add simple unit test coverage for the classes
Include PIT Metric wrapper class.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
