### PR TITLE
Moving metrics from `rail_base` to qp

### DIFF
--- a/src/qp/metrics/point_estimate_metric_classes.py
+++ b/src/qp/metrics/point_estimate_metric_classes.py
@@ -1,0 +1,172 @@
+import numpy as np
+from qp.metrics.base_metric_classes import (
+    MetricOuputType,
+    PointToPointMetric,
+)
+
+
+class PointStatsEz(PointToPointMetric):
+    """Copied from PZDC1paper repo. Adapted to remove the cut based on
+    magnitude."""
+
+    metric_name = "point_stats_ez"
+
+    #! This doesn't seem quiet correct, perhaps we need a `single_value_per_input_element` ???
+    metric_output_type = MetricOuputType.one_value_per_distribution
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def evaluate(self, estimate, reference):
+        """A calculation that takes in vectors of the estimated point values
+        the known true values.
+
+        Parameters
+        ----------
+        estimate : Numpy 1d array
+            Point estimate values
+        reference : Numpy 1d array
+            True values
+
+        Returns
+        -------
+        Numpy 1d array
+            The result of calculating (estimate-reference)/(1+reference)
+        """
+
+        return (estimate - reference) / (1.0 + reference)
+
+
+class PointSigmaIQR(PointToPointMetric):
+    """Calculate sigmaIQR"""
+
+    metric_name = "point_stats_iqr"
+    metric_output_type = MetricOuputType.single_value
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def evaluate(self, estimate, reference):
+        """Calculate the width of the e_z distribution
+        using the Interquartile range
+
+        Parameters
+        ----------
+        estimate : Numpy 1d array
+            Point estimate values
+        reference : Numpy 1d array
+            True values
+
+        Returns
+        -------
+        float
+            The interquartile range.
+        """
+        ez = (estimate - reference) / (1.0 + reference)
+        x75, x25 = np.percentile(ez, [75.0, 25.0])
+        iqr = x75 - x25
+        sigma_iqr = iqr / 1.349
+        return sigma_iqr
+
+
+class PointBias(PointToPointMetric):
+    """calculates the bias of the point stats ez samples.
+    In keeping with the Science Book, this is just the median of the ez values.
+    """
+
+    metric_name = "point_bias"
+    metric_output_type = MetricOuputType.single_value
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def evaluate(self, estimate, reference):
+        """The point bias, or median of the point stats ez samples.
+
+        Parameters
+        ----------
+        estimate : Numpy 1d array
+            Point estimate values
+        reference : Numpy 1d array
+            True values
+
+        Returns
+        -------
+        float
+            Median of the ez values
+        """
+        return np.median((estimate - reference) / (1.0 + reference))
+
+
+class PointOutlierRate(PointToPointMetric):
+    """Calculates the catastrophic outlier rate, defined in the
+    Science Book as the number of galaxies with ez larger than
+    max(0.06,3sigma).  This keeps the fraction reasonable when
+    sigma is very small.
+    """
+
+    metric_name = "point_outlier_rate"
+    metric_output_type = MetricOuputType.single_value
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def evaluate(self, estimate, reference):
+        """Calculates the catastrophic outlier rate
+
+        Parameters
+        ----------
+        estimate : Numpy 1d array
+            Point estimate values
+        reference : Numpy 1d array
+            True values
+
+        Returns
+        -------
+        float
+            Fraction of catastrophic outliers for full sample
+        """
+
+        ez = (estimate - reference) / (1.0 + reference)
+        num = len(ez)
+        sig_iqr = PointSigmaIQR().evaluate(estimate, reference)
+        three_sig = 3.0 * sig_iqr
+        cut_criterion = np.maximum(0.06, three_sig)
+        mask = np.fabs(ez) > cut_criterion
+        outlier = np.sum(mask)
+        return float(outlier) / float(num)
+
+
+class PointSigmaMAD(PointToPointMetric):
+    """Function to calculate median absolute deviation and sigma
+    based on MAD (just scaled up by 1.4826) for the full and
+    magnitude trimmed samples of ez values
+    """
+
+    metric_name = "point_stats_sigma_mad"
+    metric_output_type = MetricOuputType.single_value
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def evaluate(self, estimate, reference):
+        """Function to calculate SigmaMAD (the median absolute deviation scaled
+        up by constant factor, ``SCALE_FACTOR``.
+
+        Parameters
+        ----------
+        estimate : Numpy 1d array
+            Point estimate values
+        reference : Numpy 1d array
+            True values
+
+        Returns
+        -------
+        float
+            sigma_MAD for full sample
+        """
+
+        SCALE_FACTOR = 1.4826
+        ez = (estimate - reference) / (1.0 + reference)
+        mad = np.median(np.fabs(ez - np.median(ez)))
+        return mad * SCALE_FACTOR

--- a/tests/qp/test_point_metrics.py
+++ b/tests/qp/test_point_metrics.py
@@ -1,0 +1,55 @@
+import numpy as np
+import qp
+
+from qp.metrics.point_estimate_metric_classes import (
+    PointStatsEz,
+    PointBias,
+    PointOutlierRate,
+    PointSigmaIQR,
+    PointSigmaMAD,
+)
+
+# values for metrics
+OUTRATE = 0.0
+# CDEVAL = -4.31200
+SIGIQR = 0.0045947
+BIAS = -0.00001576
+OUTRATE = 0.0
+SIGMAD = 0.0046489
+
+
+def construct_test_ensemble():
+    np.random.seed(87)
+    nmax = 2.5
+    NPDF = 399
+    true_zs = np.random.uniform(high=nmax, size=NPDF)
+    locs = np.expand_dims(true_zs + np.random.normal(0.0, 0.01, NPDF), -1)
+    true_ez = (locs.flatten() - true_zs) / (1.0 + true_zs)
+    scales = np.ones((NPDF, 1)) * 0.1 + np.random.uniform(size=(NPDF, 1)) * 0.05
+
+    #pylint: disable=no-member
+    n_ens = qp.Ensemble(qp.stats.norm, data=dict(loc=locs, scale=scales))
+    zgrid = np.linspace(0, nmax, 301)
+    grid_ens = n_ens.convert_to(qp.interp_gen, xvals=zgrid)
+    return zgrid, true_zs, grid_ens, true_ez
+
+
+def test_point_metrics():
+    zgrid, zspec, pdf_ens, true_ez = construct_test_ensemble()
+    zb = pdf_ens.mode(grid=zgrid).flatten()
+
+    ez = PointStatsEz().evaluate(zb, zspec)
+    assert np.allclose(ez, true_ez, atol=1.0e-2)
+    # grid limits ez vals to ~10^-2 tol
+
+    sig_iqr = PointSigmaIQR().evaluate(zb, zspec)
+    assert np.isclose(sig_iqr, SIGIQR)
+
+    bias = PointBias().evaluate(zb, zspec)
+    assert np.isclose(bias, BIAS)
+
+    out_rate = PointOutlierRate().evaluate(zb, zspec)
+    assert np.isclose(out_rate, OUTRATE)
+
+    sig_mad = PointSigmaMAD().evaluate(zb, zspec)
+    assert np.isclose(sig_mad, SIGMAD)

--- a/tests/qp/test_point_metrics.py
+++ b/tests/qp/test_point_metrics.py
@@ -9,9 +9,11 @@ from qp.metrics.point_estimate_metric_classes import (
     PointSigmaMAD,
 )
 
+from qp.metrics.concrete_metric_classes import CDELossMetric
+
 # values for metrics
 OUTRATE = 0.0
-# CDEVAL = -4.31200
+CDEVAL = -4.31200
 SIGIQR = 0.0045947
 BIAS = -0.00001576
 OUTRATE = 0.0
@@ -27,7 +29,7 @@ def construct_test_ensemble():
     true_ez = (locs.flatten() - true_zs) / (1.0 + true_zs)
     scales = np.ones((NPDF, 1)) * 0.1 + np.random.uniform(size=(NPDF, 1)) * 0.05
 
-    #pylint: disable=no-member
+    # pylint: disable=no-member
     n_ens = qp.Ensemble(qp.stats.norm, data=dict(loc=locs, scale=scales))
     zgrid = np.linspace(0, nmax, 301)
     grid_ens = n_ens.convert_to(qp.interp_gen, xvals=zgrid)
@@ -35,6 +37,8 @@ def construct_test_ensemble():
 
 
 def test_point_metrics():
+    """Basic tests for the various point estimate metrics
+    """
     zgrid, zspec, pdf_ens, true_ez = construct_test_ensemble()
     zb = pdf_ens.mode(grid=zgrid).flatten()
 
@@ -53,3 +57,12 @@ def test_point_metrics():
 
     sig_mad = PointSigmaMAD().evaluate(zb, zspec)
     assert np.isclose(sig_mad, SIGMAD)
+
+
+def test_cde_loss_metric():
+    """Basic test to ensure that the CDE Loss metric class is working.
+    """
+    zgrid, zspec, pdf_ens, _ = construct_test_ensemble()
+    cde_loss_class = CDELossMetric(zgrid)
+    result = cde_loss_class.evaluate(pdf_ens, zspec)
+    assert np.isclose(result, CDEVAL)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
There are a handful of metrics that are not rail-specific still buried in `rail_base`. It makes sense to move those here to qp so that they can share the same consistent API as the rest of the metrics. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
