### PR TITLE
Issue/211/two metric fixes

### DIFF
--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -225,7 +225,7 @@ class CDELossMetric(DistToPointMetric):
     """Conditional density loss"""
 
     metric_name = "cdeloss"
-    metric_output_type = MetricOutputType.one_value_per_distribution
+    metric_output_type = MetricOutputType.single_value
     default_eval_grid = np.linspace(0, 2.5, 301)
 
     def __init__(self, eval_grid: list = default_eval_grid, **kwargs) -> None:

--- a/src/qp/metrics/metrics.py
+++ b/src/qp/metrics/metrics.py
@@ -322,7 +322,7 @@ def calculate_outlier_rate(p, lower_limit=0.0001, upper_limit=0.9999):
     except ValueError:  #pragma: no cover - unittest coverage for _check_ensemble_is_not_nested is complete
         logging.warning("Each element in the ensemble `p` must be a single distribution.")
 
-    outlier_rates = [(dist.cdf(lower_limit) + (1. - dist.cdf(upper_limit)))[0][0] for dist in p]
+    outlier_rates = np.array([(dist.cdf(lower_limit) + (1. - dist.cdf(upper_limit)))[0][0] for dist in p])
     return outlier_rates
 
 def calculate_goodness_of_fit(estimate, reference, fit_metric='ks', num_samples=100, _random_state=None):


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

#211 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
