### PR TITLE
Use t-digest to parallelize point to point metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pylint",
     "mpi4py",
     "coverage",
+    "ipyparallel",
 ]
 full = [
     "tables-io[full]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "scipy",
     "tables-io",
     "deprecated",
+    "pytdigest",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -151,6 +151,21 @@ class PointToPointMetric(BaseMetric):
     def evaluate(self, estimate, reference):
         raise NotImplementedError()
 
+    def eval_from_iterator(self, estimate, reference):
+        self.initialize()
+        for estimate, reference in zip(estimate, reference):
+            self.accumulate(estimate, reference)
+        return self.finalize()
+
+    def initialize(self):
+        pass
+
+    def accumulate(self, estimate, reference):
+        raise NotImplementedError()
+
+    def finalize(self):
+        raise NotImplementedError()
+
 
 class PointToDistMetric(BaseMetric):
     """A base class for metrics that require a point estimate as the estimated

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -147,7 +147,22 @@ class PointToPointMetric(BaseMetric):
 
     metric_input_type = MetricInputType.point_to_point
 
+    def eval_from_iterator(self, estimate, reference):
+        self.initialize()
+        for estimate, reference in zip(estimate, reference):
+            centroids = self.accumulate(estimate, reference)
+        return self.finalize([centroids])
+
     def evaluate(self, estimate, reference):
+        raise NotImplementedError()
+
+    def initialize(self):  #pragma: no cover
+        pass
+
+    def accumulate(self, estimate, reference):  #pragma: no cover
+        raise NotImplementedError()
+
+    def finalize(self):  #pragma: no cover
         raise NotImplementedError()
 
 
@@ -159,19 +174,4 @@ class PointToDistMetric(BaseMetric):
     metric_input_type = MetricInputType.point_to_dist
 
     def evaluate(self, estimate, reference):
-        raise NotImplementedError()
-
-    def eval_from_iterator(self, estimate, reference):
-        self.initialize()
-        for estimate, reference in zip(estimate, reference):
-            self.accumulate(estimate, reference)
-        return self.finalize()
-
-    def initialize(self):
-        pass
-
-    def accumulate(self, estimate, reference):
-        raise NotImplementedError()
-
-    def finalize(self):
         raise NotImplementedError()

--- a/src/qp/metrics/base_metric_classes.py
+++ b/src/qp/metrics/base_metric_classes.py
@@ -2,6 +2,7 @@ import enum
 
 from abc import ABC
 
+from pytdigest import TDigest
 
 class MetricInputType(enum.Enum):
     """Defines the various combinations of input types that metric classes accept."""
@@ -160,3 +161,44 @@ class PointToDistMetric(BaseMetric):
 
     def evaluate(self, estimate, reference):
         raise NotImplementedError()
+
+    def eval_from_iterator(self, estimate, reference):
+        self.initialize()
+        for estimate, reference in zip(estimate, reference):
+            self.accumulate(estimate, reference)
+        return self.finalize()
+
+    def initialize(self):
+        pass
+
+    def accumulate(self, estimate, reference):
+        raise NotImplementedError()
+
+    def finalize(self):
+        raise NotImplementedError()
+
+
+class PointToPointMetricDigester(PointToPointMetric):
+
+    def accumulate(self, estimate, reference):
+        # centroids = estimate.ancil['z_mode'] - reference
+        # digest = TDigest.make_centroied(centroids)  # Or something like this
+        digest = TDigest.compute(estimate, compression=100)
+        centroids = digest.get_centroids()
+        return centroids
+
+    def finalize(self):
+        # ents = comm.gather()
+        # meta_digest = TDigest.from_centroid(cents)  # Or something like this
+        # return self.compute_from_digest(meta_digest)
+        centroids = comm.gather(centroids, root=0) # ???
+
+        #? Does this need to be the more complex version from the example? i.e.
+        # digests = (
+        #     TDigest.of_centroids(centroid, compression=COMPRESSION)
+        #     for centroid in chain.from_iterable(centroids)
+        # )
+        # digest = reduce(add, digests)
+        digest = TDigest.of_centroids(centroids, compression=100)
+
+        return self.compute_from_digest(digest)

--- a/src/qp/metrics/parallel_metrics.ipynb
+++ b/src/qp/metrics/parallel_metrics.ipynb
@@ -2,39 +2,56 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qp.metrics.point_estimate_metric_classes import PointSigmaIQR\n"
+    "from qp.metrics.point_estimate_metric_classes import PointSigmaIQR"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Generate the random numbers \n",
     "SEED = 1002330\n",
     "rng = np.random.default_rng(SEED)\n",
     "\n",
-    "estimate = rng.lognormal(mean=1.0, sigma=2, size=1000)\n",
-    "reference = rng.lognormal(mean=1.3, sigma=1.9, size=1000)"
+    "chunk_size = 10_000\n",
+    "n_chunk = 10\n",
+    "total_size = n_chunk*chunk_size\n",
+    "\n",
+    "estimate = rng.lognormal(mean=1.0, sigma=2, size=total_size)\n",
+    "reference = rng.lognormal(mean=1.3, sigma=1.9, size=total_size)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.844492171486455"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "# Do the explicit full calculation\n",
     "PointSigmaIQR().evaluate(estimate, reference)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,25 +59,99 @@
     "def chunker(seq, size):\n",
     "    return (seq[pos:pos + size] for pos in range(0, len(seq), size))\n",
     "\n",
-    "# create an iterator that yields chunks of 100 elements\n",
-    "estimate_chunks = chunker(estimate, 100)\n",
-    "reference_chunks = chunker(reference, 100)"
+    "# create an iterator that yields chunks of chunk_size elements\n",
+    "estimate_chunks = chunker(estimate, chunk_size)\n",
+    "reference_chunks = chunker(reference, chunk_size)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "PointSigmaIQR().eval_from_iterator(estimate_chunks, reference_chunks)\n",
-    "# fails as expected when we get to the `comm` and `centroid` bits in `finalize`."
+    "# A function to pass to MPI\n",
+    "def mpi_example(chunk):\n",
+    "    centroids = chunk[0].accumulate(chunk[1], chunk[2])\n",
+    "    return centroids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the data for ipyparallel\n",
+    "estimator = PointSigmaIQR()\n",
+    "estimator_list = [estimator]*n_chunk\n",
+    "data_chunks = [chunk for chunk in zip(estimator_list, estimate_chunks, reference_chunks)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# request an MPI cluster with 5 engines\n",
+    "import ipyparallel as ipp\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
+      "100%|██████████| 4/4 [00:05<00:00,  1.48s/engine]\n",
+      "mpi_example: 100%|██████████| 10/10 [00:00<00:00, 13.42tasks/s]\n",
+      "0 : (53, 2)\n",
+      "1 : (53, 2)\n",
+      "2 : (54, 2)\n",
+      "3 : (53, 2)\n",
+      "4 : (55, 2)\n",
+      "5 : (53, 2)\n",
+      "6 : (52, 2)\n",
+      "7 : (55, 2)\n",
+      "8 : (51, 2)\n",
+      "9 : (54, 2)\n",
+      "1.98106779379963\n",
+      "Stopping engine(s): 1707869025\n",
+      "engine set stopped 1707869025: {'exit_code': 0, 'pid': 27802, 'identifier': 'ipengine-1707869024-vf70-1707869025-27783'}\n",
+      "Stopping controller\n",
+      "Controller stopped: {'exit_code': 0, 'pid': 27789, 'identifier': 'ipcontroller-1707869024-vf70-27783'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "with ipp.Cluster(controller_ip=\"*\", engines=\"mpi\", n=4) as rc:\n",
+    "    # get a broadcast_view on the cluster which is best\n",
+    "    # suited for MPI style computation\n",
+    "    view = rc.load_balanced_view()\n",
+    "    # run the mpi_example function on all engines in parallel\n",
+    "    asyncresult = view.map_async(mpi_example, data_chunks)\n",
+    "    # Retrieve and print the result from the engines\n",
+    "    asyncresult.wait_interactive()\n",
+    "    # retrieve actual results\n",
+    "    result = asyncresult.get()\n",
+    "    # get and print the results\n",
+    "    for i, res in enumerate(result):\n",
+    "        np.array(res)\n",
+    "        print(f\"{i} : {res.shape}\")\n",
+    "    final = estimator.finalize(centroids=result)\n",
+    "    print(final)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "qp",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -74,9 +165,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/src/qp/metrics/parallel_metrics.ipynb
+++ b/src/qp/metrics/parallel_metrics.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from qp.metrics.point_estimate_metric_classes import PointSigmaIQR\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SEED = 1002330\n",
+    "rng = np.random.default_rng(SEED)\n",
+    "\n",
+    "estimate = rng.lognormal(mean=1.0, sigma=2, size=1000)\n",
+    "reference = rng.lognormal(mean=1.3, sigma=1.9, size=1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PointSigmaIQR().evaluate(estimate, reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#generator that yields chunks from estimate and reference\n",
+    "def chunker(seq, size):\n",
+    "    return (seq[pos:pos + size] for pos in range(0, len(seq), size))\n",
+    "\n",
+    "# create an iterator that yields chunks of 100 elements\n",
+    "estimate_chunks = chunker(estimate, 100)\n",
+    "reference_chunks = chunker(reference, 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PointSigmaIQR().eval_from_iterator(estimate_chunks, reference_chunks)\n",
+    "# fails as expected when we get to the `comm` and `centroid` bits in `finalize`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qp",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/qp/metrics/parallel_metrics.ipynb
+++ b/src/qp/metrics/parallel_metrics.ipynb
@@ -62,29 +62,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set up the data for ipyparallel\n",
-    "\n",
-    "# An example with PointSigmaIQR\n",
-    "sigma_iqr_estimator = PointSigmaIQR()\n",
-    "sigma_iqr_estimator_list = [sigma_iqr_estimator]*n_chunk\n",
-    "iqr_data_chunks = [chunk for chunk in zip(sigma_iqr_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]\n",
-    "\n",
-    "# An example with PointBias\n",
-    "point_bias_estimator = PointBias()\n",
-    "point_bias_estimator_list = [point_bias_estimator]*n_chunk\n",
-    "point_bias_data_chunks = [chunk for chunk in zip(point_bias_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we have a functional version of the cell above, but with the ability to run any metric/data_chunk"
+    "Here is a function that will configure a local cluster of 4 nodes using MPI as the engine.\n",
+    "\n",
+    "A metric estimator class is passed in as well as list of 3-tuple \"data chunks\".\n",
+    "\n",
+    "The 3-tuple is (metric class, chunk_of_estimated_values, chunk_of_reference_values)"
    ]
   },
   {
@@ -93,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_parallel_metric(estimator, data_chunks):\n",
+    "def run_parallel_metric(data_chunks):\n",
     "    with ipp.Cluster(controller_ip=\"*\", engines=\"mpi\", n=4) as rc:\n",
     "        # get a broadcast_view on the cluster which is best\n",
     "        # suited for MPI style computation\n",
@@ -108,7 +93,8 @@
     "        for i, res in enumerate(result):\n",
     "            np.array(res)\n",
     "            print(f\"{i} : {res.shape}\")\n",
-    "        final = estimator.finalize(centroids=result)\n",
+    "        metric_estimator = data_chunks[0][0]\n",
+    "        final = metric_estimator.finalize(centroids=result)\n",
     "        print(final)"
    ]
   },
@@ -116,9 +102,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Repeating the results of the non-functional parallel PointSigmaIQR run.\n",
+    "### An example running the PointSigmaIQR metric directly and in parallel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for ipyparallel\n",
+    "config = {'tdigest_compression': 1000}\n",
     "\n",
-    "Plus a comparison against the direct implementation of PointSigmaIQR"
+    "sigma_iqr_estimator = PointSigmaIQR(**config)\n",
+    "sigma_iqr_estimator_list = [sigma_iqr_estimator]*n_chunk\n",
+    "iqr_data_chunks = [chunk for chunk in zip(sigma_iqr_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]\n"
    ]
   },
   {
@@ -136,14 +134,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_parallel_metric(PointSigmaIQR(), iqr_data_chunks)"
+    "run_parallel_metric(iqr_data_chunks)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### An example running the PointBias metric in directly and in parallel"
+    "### An example running the PointBias metric directly and in parallel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up for ipyparallel\n",
+    "config = {'tdigest_compression': 1000}\n",
+    "\n",
+    "point_bias_estimator = PointBias(**config)\n",
+    "point_bias_estimator_list = [point_bias_estimator]*n_chunk\n",
+    "point_bias_data_chunks = [chunk for chunk in zip(point_bias_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]"
    ]
   },
   {
@@ -161,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_parallel_metric(PointBias(), point_bias_data_chunks)"
+    "run_parallel_metric(point_bias_data_chunks)"
    ]
   },
   {
@@ -178,7 +190,8 @@
    "outputs": [],
    "source": [
     "# An example with PointSigmaMAD\n",
-    "point_sigma_mad_estimator = PointSigmaMAD()\n",
+    "config = {'num_bins': 1_000_000, 'tdigest_compression': 1000}\n",
+    "point_sigma_mad_estimator = PointSigmaMAD(**config)\n",
     "point_sigma_mad_estimator_list = [point_sigma_mad_estimator]*n_chunk\n",
     "point_sigma_mad_data_chunks = [chunk for chunk in zip(point_sigma_mad_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]"
    ]
@@ -207,11 +220,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psmad = PointSigmaMAD()\n",
+    "config = {'num_bins': 1_000_000, 'tdigest_compression': 1000}\n",
+    "psmad = PointSigmaMAD(**config)\n",
     "centroids = psmad.accumulate(estimate, reference)\n",
     "\n",
     "#default value for `num_bins` is 1_000_000\n",
-    "psmad.finalize(centroids=[centroids], num_bins=1_000_000)"
+    "psmad.finalize(centroids=[centroids])"
    ]
   },
   {
@@ -220,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_parallel_metric(PointSigmaMAD(), point_sigma_mad_data_chunks)"
+    "run_parallel_metric(point_sigma_mad_data_chunks)"
    ]
   },
   {
@@ -237,7 +251,8 @@
    "outputs": [],
    "source": [
     "# An example with PointOutlierRate\n",
-    "point_outlier_estimator = PointOutlierRate()\n",
+    "config = {'tdigest_compression': 1000}\n",
+    "point_outlier_estimator = PointOutlierRate(**config)\n",
     "point_outlier_estimator_list = [point_outlier_estimator]*n_chunk\n",
     "point_outlier_data_chunks = [chunk for chunk in zip(point_outlier_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]"
    ]
@@ -252,35 +267,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parallel estimation of the metric trends closer to the analytic as the value of `compression` is increased.\n",
+    "\n",
+    "The default value for compression is 1000. If set to 10_000, the estimate becomes 0.13663.\n",
+    "\n",
+    "Note that, of course, setting compression = 10_000 increases memory usage with minimal affect on runtime."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "por = PointOutlierRate()\n",
+    "config = {'tdigest_compression': 1000}\n",
+    "por = PointOutlierRate(**config)\n",
     "centroids = por.accumulate(estimate, reference)\n",
     "\n",
     "por.finalize(centroids=[centroids])"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The estimation of the metric trends closer to the analytic if the value of `compression` is increased.\n",
-    "\n",
-    "The default value for compression is 1000. If set to 10_000, the estimate becomes 0.13645.\n",
-    "\n",
-    "Note that, of course, setting compression = 10_000 increases runtime and memory usage."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_parallel_metric(PointOutlierRate(), point_outlier_data_chunks)"
+    "run_parallel_metric(point_outlier_data_chunks)"
    ]
   }
  ],

--- a/src/qp/metrics/parallel_metrics.ipynb
+++ b/src/qp/metrics/parallel_metrics.ipynb
@@ -2,17 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qp.metrics.point_estimate_metric_classes import PointSigmaIQR"
+    "import ipyparallel as ipp\n",
+    "from qp.metrics.point_estimate_metric_classes import (\n",
+    "    PointSigmaIQR,\n",
+    "    PointBias,\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,28 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.844492171486455"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Do the explicit full calculation\n",
-    "PointSigmaIQR().evaluate(estimate, reference)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,64 +61,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Set up the data for ipyparallel\n",
-    "estimator = PointSigmaIQR()\n",
-    "estimator_list = [estimator]*n_chunk\n",
-    "data_chunks = [chunk for chunk in zip(estimator_list, estimate_chunks, reference_chunks)]"
+    "\n",
+    "# An example with PointSigmaIQR\n",
+    "sigma_iqr_estimator = PointSigmaIQR()\n",
+    "sigma_iqr_estimator_list = [sigma_iqr_estimator]*n_chunk\n",
+    "iqr_data_chunks = [chunk for chunk in zip(sigma_iqr_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]\n",
+    "\n",
+    "# An example with PointBias\n",
+    "point_bias_estimator = PointBias()\n",
+    "point_bias_estimator_list = [point_bias_estimator]*n_chunk\n",
+    "point_bias_data_chunks = [chunk for chunk in zip(point_bias_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following is a hardcoded version of the ipyparallel driver to run PointSigmaIQR in parallel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# request an MPI cluster with 5 engines\n",
-    "import ipyparallel as ipp\n",
-    "import time"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
-      "100%|██████████| 4/4 [00:05<00:00,  1.48s/engine]\n",
-      "mpi_example: 100%|██████████| 10/10 [00:00<00:00, 13.42tasks/s]\n",
-      "0 : (53, 2)\n",
-      "1 : (53, 2)\n",
-      "2 : (54, 2)\n",
-      "3 : (53, 2)\n",
-      "4 : (55, 2)\n",
-      "5 : (53, 2)\n",
-      "6 : (52, 2)\n",
-      "7 : (55, 2)\n",
-      "8 : (51, 2)\n",
-      "9 : (54, 2)\n",
-      "1.98106779379963\n",
-      "Stopping engine(s): 1707869025\n",
-      "engine set stopped 1707869025: {'exit_code': 0, 'pid': 27802, 'identifier': 'ipengine-1707869024-vf70-1707869025-27783'}\n",
-      "Stopping controller\n",
-      "Controller stopped: {'exit_code': 0, 'pid': 27789, 'identifier': 'ipcontroller-1707869024-vf70-27783'}\n"
-     ]
-    }
-   ],
    "source": [
     "with ipp.Cluster(controller_ip=\"*\", engines=\"mpi\", n=4) as rc:\n",
     "    # get a broadcast_view on the cluster which is best\n",
     "    # suited for MPI style computation\n",
     "    view = rc.load_balanced_view()\n",
     "    # run the mpi_example function on all engines in parallel\n",
-    "    asyncresult = view.map_async(mpi_example, data_chunks)\n",
+    "    asyncresult = view.map_async(mpi_example, iqr_data_chunks)\n",
     "    # Retrieve and print the result from the engines\n",
     "    asyncresult.wait_interactive()\n",
     "    # retrieve actual results\n",
@@ -144,8 +105,92 @@
     "    for i, res in enumerate(result):\n",
     "        np.array(res)\n",
     "        print(f\"{i} : {res.shape}\")\n",
-    "    final = estimator.finalize(centroids=result)\n",
+    "    final = sigma_iqr_estimator.finalize(centroids=result)\n",
     "    print(final)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we have a functional version of the cell above, but with the ability to run any metric/data_chunk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_parallel_metric(estimator, data_chunks):\n",
+    "    with ipp.Cluster(controller_ip=\"*\", engines=\"mpi\", n=4) as rc:\n",
+    "        # get a broadcast_view on the cluster which is best\n",
+    "        # suited for MPI style computation\n",
+    "        view = rc.load_balanced_view()\n",
+    "        # run the mpi_example function on all engines in parallel\n",
+    "        asyncresult = view.map_async(mpi_example, data_chunks)\n",
+    "        # Retrieve and print the result from the engines\n",
+    "        asyncresult.wait_interactive()\n",
+    "        # retrieve actual results\n",
+    "        result = asyncresult.get()\n",
+    "        # get and print the results\n",
+    "        for i, res in enumerate(result):\n",
+    "            np.array(res)\n",
+    "            print(f\"{i} : {res.shape}\")\n",
+    "        final = estimator.finalize(centroids=result)\n",
+    "        print(final)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Repeating the results of the non-functional parallel PointSigmaIQR run.\n",
+    "\n",
+    "Plus a comparison against the direct implementation of PointSigmaIQR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PointSigmaIQR().evaluate(estimate, reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_parallel_metric(PointSigmaIQR(), iqr_data_chunks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An example running the PointBias metric in directly and in parallel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PointBias().evaluate(estimate, reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_parallel_metric(PointBias(), point_bias_data_chunks)"
    ]
   }
  ],
@@ -165,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/src/qp/metrics/parallel_metrics.ipynb
+++ b/src/qp/metrics/parallel_metrics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,54 +122,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.844492171486455"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "PointSigmaIQR().evaluate(estimate, reference)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
-      "100%|██████████| 4/4 [00:05<00:00,  1.48s/engine]\n",
-      "mpi_example: 100%|██████████| 10/10 [00:00<00:00, 12.39tasks/s]\n",
-      "0 : (296, 2)\n",
-      "1 : (295, 2)\n",
-      "2 : (298, 2)\n",
-      "3 : (299, 2)\n",
-      "4 : (296, 2)\n",
-      "5 : (297, 2)\n",
-      "6 : (295, 2)\n",
-      "7 : (295, 2)\n",
-      "8 : (294, 2)\n",
-      "9 : (297, 2)\n",
-      "1.8458703638788456\n",
-      "Stopping engine(s): 1708026063\n",
-      "engine set stopped 1708026063: {'exit_code': 0, 'pid': 40773, 'identifier': 'ipengine-1708026062-ui56-1708026063-40755'}\n",
-      "Stopping controller\n",
-      "Controller stopped: {'exit_code': 0, 'pid': 40761, 'identifier': 'ipcontroller-1708026062-ui56-40755'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "run_parallel_metric(PointSigmaIQR(), iqr_data_chunks)"
    ]
@@ -183,54 +147,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-0.15921544705180912"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "PointBias().evaluate(estimate, reference)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
-      "100%|██████████| 4/4 [00:05<00:00,  1.49s/engine]\n",
-      "mpi_example: 100%|██████████| 10/10 [00:00<00:00, 12.51tasks/s]\n",
-      "0 : (296, 2)\n",
-      "1 : (295, 2)\n",
-      "2 : (298, 2)\n",
-      "3 : (299, 2)\n",
-      "4 : (296, 2)\n",
-      "5 : (297, 2)\n",
-      "6 : (295, 2)\n",
-      "7 : (295, 2)\n",
-      "8 : (294, 2)\n",
-      "9 : (297, 2)\n",
-      "-0.15852842748117044\n",
-      "Stopping engine(s): 1708026071\n",
-      "engine set stopped 1708026071: {'exit_code': 0, 'pid': 40822, 'identifier': 'ipengine-1708026070-ddho-1708026071-40755'}\n",
-      "Stopping controller\n",
-      "Controller stopped: {'exit_code': 0, 'pid': 40810, 'identifier': 'ipcontroller-1708026070-ddho-40755'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "run_parallel_metric(PointBias(), point_bias_data_chunks)"
    ]
@@ -244,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,45 +184,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.0738614584809976"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "PointSigmaMAD().evaluate(estimate, reference)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 9,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.101290495249205"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "psmad = PointSigmaMAD()\n",
-    "centroid_1 = psmad.accumulate(estimate[0:5000], reference[0:5000])\n",
-    "centroid_2 = psmad.accumulate(estimate[5000:], reference[5000:])\n",
-    "psmad.finalize(centroids=[centroid_1, centroid_2])\n"
+    "This cell allows for adjustment of the `num_bins` parameter.\n",
+    "\n",
+    "Larger values trend closer to the analytic result from the cell above."
    ]
   },
   {
@@ -302,7 +205,22 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "psmad = PointSigmaMAD()\n",
+    "centroids = psmad.accumulate(estimate, reference)\n",
+    "\n",
+    "#default value for `num_bins` is 1_000_000\n",
+    "psmad.finalize(centroids=[centroids], num_bins=1_000_000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_parallel_metric(PointSigmaMAD(), point_sigma_mad_data_chunks)"
+   ]
   }
  ],
  "metadata": {

--- a/src/qp/metrics/parallel_metrics.ipynb
+++ b/src/qp/metrics/parallel_metrics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,12 +11,13 @@
     "from qp.metrics.point_estimate_metric_classes import (\n",
     "    PointSigmaIQR,\n",
     "    PointBias,\n",
+    "    PointSigmaMAD,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,43 +83,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following is a hardcoded version of the ipyparallel driver to run PointSigmaIQR in parallel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "with ipp.Cluster(controller_ip=\"*\", engines=\"mpi\", n=4) as rc:\n",
-    "    # get a broadcast_view on the cluster which is best\n",
-    "    # suited for MPI style computation\n",
-    "    view = rc.load_balanced_view()\n",
-    "    # run the mpi_example function on all engines in parallel\n",
-    "    asyncresult = view.map_async(mpi_example, iqr_data_chunks)\n",
-    "    # Retrieve and print the result from the engines\n",
-    "    asyncresult.wait_interactive()\n",
-    "    # retrieve actual results\n",
-    "    result = asyncresult.get()\n",
-    "    # get and print the results\n",
-    "    for i, res in enumerate(result):\n",
-    "        np.array(res)\n",
-    "        print(f\"{i} : {res.shape}\")\n",
-    "    final = sigma_iqr_estimator.finalize(centroids=result)\n",
-    "    print(final)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Here we have a functional version of the cell above, but with the ability to run any metric/data_chunk"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,18 +122,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.844492171486455"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "PointSigmaIQR().evaluate(estimate, reference)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
+      "100%|██████████| 4/4 [00:05<00:00,  1.48s/engine]\n",
+      "mpi_example: 100%|██████████| 10/10 [00:00<00:00, 12.39tasks/s]\n",
+      "0 : (296, 2)\n",
+      "1 : (295, 2)\n",
+      "2 : (298, 2)\n",
+      "3 : (299, 2)\n",
+      "4 : (296, 2)\n",
+      "5 : (297, 2)\n",
+      "6 : (295, 2)\n",
+      "7 : (295, 2)\n",
+      "8 : (294, 2)\n",
+      "9 : (297, 2)\n",
+      "1.8458703638788456\n",
+      "Stopping engine(s): 1708026063\n",
+      "engine set stopped 1708026063: {'exit_code': 0, 'pid': 40773, 'identifier': 'ipengine-1708026062-ui56-1708026063-40755'}\n",
+      "Stopping controller\n",
+      "Controller stopped: {'exit_code': 0, 'pid': 40761, 'identifier': 'ipcontroller-1708026062-ui56-40755'}\n"
+     ]
+    }
+   ],
    "source": [
     "run_parallel_metric(PointSigmaIQR(), iqr_data_chunks)"
    ]
@@ -177,11 +183,118 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-0.15921544705180912"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PointBias().evaluate(estimate, reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
+      "100%|██████████| 4/4 [00:05<00:00,  1.49s/engine]\n",
+      "mpi_example: 100%|██████████| 10/10 [00:00<00:00, 12.51tasks/s]\n",
+      "0 : (296, 2)\n",
+      "1 : (295, 2)\n",
+      "2 : (298, 2)\n",
+      "3 : (299, 2)\n",
+      "4 : (296, 2)\n",
+      "5 : (297, 2)\n",
+      "6 : (295, 2)\n",
+      "7 : (295, 2)\n",
+      "8 : (294, 2)\n",
+      "9 : (297, 2)\n",
+      "-0.15852842748117044\n",
+      "Stopping engine(s): 1708026071\n",
+      "engine set stopped 1708026071: {'exit_code': 0, 'pid': 40822, 'identifier': 'ipengine-1708026070-ddho-1708026071-40755'}\n",
+      "Stopping controller\n",
+      "Controller stopped: {'exit_code': 0, 'pid': 40810, 'identifier': 'ipcontroller-1708026070-ddho-40755'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_parallel_metric(PointBias(), point_bias_data_chunks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An example running PointSigmaMAD directly and in parallel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "PointBias().evaluate(estimate, reference)"
+    "# An example with PointSigmaMAD\n",
+    "point_sigma_mad_estimator = PointSigmaMAD()\n",
+    "point_sigma_mad_estimator_list = [point_sigma_mad_estimator]*n_chunk\n",
+    "point_sigma_mad_data_chunks = [chunk for chunk in zip(point_sigma_mad_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.0738614584809976"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PointSigmaMAD().evaluate(estimate, reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.101290495249205"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "psmad = PointSigmaMAD()\n",
+    "centroid_1 = psmad.accumulate(estimate[0:5000], reference[0:5000])\n",
+    "centroid_2 = psmad.accumulate(estimate[5000:], reference[5000:])\n",
+    "psmad.finalize(centroids=[centroid_1, centroid_2])\n"
    ]
   },
   {
@@ -189,9 +302,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "run_parallel_metric(PointBias(), point_bias_data_chunks)"
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -210,7 +321,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/src/qp/metrics/parallel_metrics.ipynb
+++ b/src/qp/metrics/parallel_metrics.ipynb
@@ -12,6 +12,7 @@
     "    PointSigmaIQR,\n",
     "    PointBias,\n",
     "    PointSigmaMAD,\n",
+    "    PointOutlierRate,\n",
     ")"
    ]
   },
@@ -142,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An example running the PointBias metric in directly and in parallel"
+    "### An example running the PointBias metric in directly and in parallel"
    ]
   },
   {
@@ -167,7 +168,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An example running PointSigmaMAD directly and in parallel"
+    "### An example running PointSigmaMAD directly and in parallel"
    ]
   },
   {
@@ -220,6 +221,66 @@
    "outputs": [],
    "source": [
     "run_parallel_metric(PointSigmaMAD(), point_sigma_mad_data_chunks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example running PointOutlierRate metric directly and in parallel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# An example with PointOutlierRate\n",
+    "point_outlier_estimator = PointOutlierRate()\n",
+    "point_outlier_estimator_list = [point_outlier_estimator]*n_chunk\n",
+    "point_outlier_data_chunks = [chunk for chunk in zip(point_outlier_estimator_list, chunker(estimate, chunk_size), chunker(reference, chunk_size))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PointOutlierRate().evaluate(estimate, reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "por = PointOutlierRate()\n",
+    "centroids = por.accumulate(estimate, reference)\n",
+    "\n",
+    "por.finalize(centroids=[centroids])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The estimation of the metric trends closer to the analytic if the value of `compression` is increased.\n",
+    "\n",
+    "The default value for compression is 1000. If set to 10_000, the estimate becomes 0.13645.\n",
+    "\n",
+    "Note that, of course, setting compression = 10_000 increases runtime and memory usage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_parallel_metric(PointOutlierRate(), point_outlier_data_chunks)"
    ]
   }
  ],

--- a/src/qp/metrics/pit.py
+++ b/src/qp/metrics/pit.py
@@ -57,7 +57,7 @@ class PIT:
         # efficiently on line 61 with `data_quants = np.nanquantile(...)`.`
         samp_mask = np.isfinite(self._pit_samps)
         self._pit_samps[~samp_mask] = 0
-        if not np.all(samp_mask):
+        if not np.all(samp_mask):  #pragma: no cover
             logging.warning(
                 "Some PIT samples were `NaN`. They have been replacd with 0."
             )

--- a/src/qp/metrics/point_estimate_metric_classes.py
+++ b/src/qp/metrics/point_estimate_metric_classes.py
@@ -14,13 +14,6 @@ class PointToPointMetricDigester(PointToPointMetric):
         super().__init__()
         self._tdigest_compression = tdigest_compression
 
-    # ! Not entirely sure this function will be used, will keep it here for now.
-    def eval_from_iterator(self, estimate, reference):
-        self.initialize()
-        for estimate, reference in zip(estimate, reference):
-            self.accumulate(estimate, reference)
-        return self.finalize()
-
     def initialize(self):
         pass
 
@@ -70,7 +63,7 @@ class PointToPointMetricDigester(PointToPointMetric):
 
         return self.compute_from_digest(digest)
 
-    def compute_from_digest(self, digest):
+    def compute_from_digest(self, digest):  #pragma: no cover
         raise NotImplementedError
 
 

--- a/src/qp/metrics/point_estimate_metric_classes.py
+++ b/src/qp/metrics/point_estimate_metric_classes.py
@@ -282,9 +282,9 @@ class PointSigmaMAD(PointToPointMetricDigester):
         this_pdf = digest.cdf(bins[1:]) - digest.cdf(bins[0:-1]) # len(this_pdf) = lots_of_bins - 1
         bin_dist = np.fabs(bins - this_median) # get the distance to the center for each bin in the hist
 
-        sorted_bins_dist_idx = np.argsort(bin_dist) # sort the bins by dist to median
+        sorted_bins_dist_idx = np.argsort(bin_dist[0:-1]) # sort the bins by dist to median
         sorted_bins_dist = bin_dist[sorted_bins_dist_idx] # get the sorted distances
-        cumulative_sorted = this_pdf[sorted_bins_dist_idx[0:-1]].cumsum() # the cumulate PDF within the nearest bins
+        cumulative_sorted = this_pdf[sorted_bins_dist_idx].cumsum() # the cumulate PDF within the nearest bins
         median_sorted_bin = np.searchsorted(cumulative_sorted, 0.5) # which bins are the nearest 50% of the PDF
         dist_to_median = sorted_bins_dist[median_sorted_bin] # return the corresponding distance to the median
 

--- a/src/qp/metrics/point_estimate_metric_classes.py
+++ b/src/qp/metrics/point_estimate_metric_classes.py
@@ -279,10 +279,11 @@ class PointSigmaMAD(PointToPointMetricDigester):
         this_min = digest.inverse_cdf(0)
         this_max = digest.inverse_cdf(1)
         bins = np.linspace(this_min, this_max, self._num_bins)
+        bin_cents = (bins[0:-1] + bins[1:]) / 2.0
         this_pdf = digest.cdf(bins[1:]) - digest.cdf(bins[0:-1]) # len(this_pdf) = lots_of_bins - 1
-        bin_dist = np.fabs(bins - this_median) # get the distance to the center for each bin in the hist
+        bin_dist = np.fabs(bin_cents - this_median) # get the distance to the center for each bin in the hist
 
-        sorted_bins_dist_idx = np.argsort(bin_dist[0:-1]) # sort the bins by dist to median
+        sorted_bins_dist_idx = np.argsort(bin_dist) # sort the bins by dist to median
         sorted_bins_dist = bin_dist[sorted_bins_dist_idx] # get the sorted distances
         cumulative_sorted = this_pdf[sorted_bins_dist_idx].cumsum() # the cumulate PDF within the nearest bins
         median_sorted_bin = np.searchsorted(cumulative_sorted, 0.5) # which bins are the nearest 50% of the PDF

--- a/src/qp/metrics/point_estimate_metric_classes.py
+++ b/src/qp/metrics/point_estimate_metric_classes.py
@@ -219,7 +219,7 @@ class PointSigmaMAD(PointToPointMetric):
         centroids = digest.get_centroids()
         return centroids
 
-    def finalize(self, centroids=None):
+    def finalize(self, centroids=None, num_bins=1_000_000):
         digests = (
             TDigest.of_centroids(np.array(centroid), compression=1000)
             for centroid in centroids
@@ -229,11 +229,10 @@ class PointSigmaMAD(PointToPointMetric):
         SCALE_FACTOR = 1.4826
 
         # calculation of `np.median(np.fabs(ez - np.median(ez)))` as suggested by Eric Charles
-        this_median = digest.inverse_cdf([0.50])[0]
-        lots_of_bins = 100000
+        this_median = digest.inverse_cdf(0.50)
         this_min = digest.inverse_cdf(0)
         this_max = digest.inverse_cdf(1)
-        bins = np.linspace(this_min, this_max, lots_of_bins)
+        bins = np.linspace(this_min, this_max, num_bins)
         this_pdf = digest.cdf(bins[1:]) - digest.cdf(bins[0:-1]) # len(this_pdf) = lots_of_bins - 1
         bin_dist = np.fabs(bins - this_median) # get the distance to the center for each bin in the hist
 

--- a/src/qp/metrics/point_estimate_metric_classes.py
+++ b/src/qp/metrics/point_estimate_metric_classes.py
@@ -39,7 +39,7 @@ class PointStatsEz(PointToPointMetric):
         return (estimate - reference) / (1.0 + reference)
 
 
-class PointSigmaIQR(PointToPointMetricDigester):
+class PointSigmaIQR(PointToPointMetric):
     """Calculate sigmaIQR"""
 
     metric_name = "point_stats_iqr"
@@ -75,6 +75,22 @@ class PointSigmaIQR(PointToPointMetricDigester):
         digest = TDigest.compute(ez, compression=100)
         centroids = digest.get_centroids()
         return centroids
+
+    def finalize(self, comm=None, centroids=None):
+        # ents = comm.gather()
+        # meta_digest = TDigest.from_centroid(cents)  # Or something like this
+        # return self.compute_from_digest(meta_digest)
+        # centroids = comm.gather(centroids, root=0) # ???
+
+        #? Does this need to be the more complex version from the example? i.e.
+        # digests = (
+        #     TDigest.of_centroids(centroid, compression=COMPRESSION)
+        #     for centroid in chain.from_iterable(centroids)
+        # )
+        # digest = reduce(add, digests)
+        digest = TDigest.of_centroids(centroids, compression=100)
+
+        return self.compute_from_digest(digest)
 
     def compute_from_digest(self, digest):
         x75, x25 = digest.inverse_cdf([0.75,0.25])

--- a/src/qp/metrics/point_estimate_metric_classes.py
+++ b/src/qp/metrics/point_estimate_metric_classes.py
@@ -8,6 +8,72 @@ from functools import reduce
 from operator import add
 
 
+class PointToPointMetricDigester(PointToPointMetric):
+
+    def __init__(self, tdigest_compression: int = 1000, **kwargs) -> None:
+        super().__init__()
+        self._tdigest_compression = tdigest_compression
+
+    # ! Not entirely sure this function will be used, will keep it here for now.
+    def eval_from_iterator(self, estimate, reference):
+        self.initialize()
+        for estimate, reference in zip(estimate, reference):
+            self.accumulate(estimate, reference)
+        return self.finalize()
+
+    def initialize(self):
+        pass
+
+    def accumulate(self, estimate, reference):
+        """This function compresses the input into a TDigest and returns the
+        centroids.
+
+        Parameters
+        ----------
+        estimate : Numpy 1d array
+            Point estimate values
+        reference : Numpy 1d array
+            True values
+
+        Returns
+        -------
+        Numpy 2d array
+            The centroids of the TDigest. Roughly approximates a histogram with
+            centroid locations and weights.
+        """
+        ez = (estimate - reference) / (1.0 + reference)
+        digest = TDigest.compute(ez, compression=self._tdigest_compression)
+        centroids = digest.get_centroids()
+        return centroids
+
+    def finalize(self, centroids: np.ndarray = []):
+        """This function combines all the centroids that were calculated for the
+        input estimate and reference subsets and returns the resulting TDigest
+        object.
+
+        Parameters
+        ----------
+        centroids : Numpy 2d array, optional
+            The output collected from prior calls to `accumulate`, by default []
+
+        Returns
+        -------
+        float
+            The result of the specific metric calculation defined in the subclasses
+            `compute_from_digest` method.
+        """
+        digests = (
+            TDigest.of_centroids(np.array(centroid), compression=self._tdigest_compression)
+            for centroid in centroids
+        )
+        digest = reduce(add, digests)
+
+        return self.compute_from_digest(digest)
+
+    def compute_from_digest(self, digest):
+        raise NotImplementedError
+
+
 class PointStatsEz(PointToPointMetric):
     """Copied from PZDC1paper repo. Adapted to remove the cut based on
     magnitude."""
@@ -40,14 +106,14 @@ class PointStatsEz(PointToPointMetric):
         return (estimate - reference) / (1.0 + reference)
 
 
-class PointSigmaIQR(PointToPointMetric):
+class PointSigmaIQR(PointToPointMetricDigester):
     """Calculate sigmaIQR"""
 
     metric_name = "point_stats_iqr"
     metric_output_type = MetricOutputType.single_value
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
 
     def evaluate(self, estimate, reference):
         """Calculate the width of the e_z distribution
@@ -71,21 +137,6 @@ class PointSigmaIQR(PointToPointMetric):
         sigma_iqr = iqr / 1.349
         return sigma_iqr
 
-    def accumulate(self, estimate, reference):
-        ez = (estimate - reference) / (1.0 + reference)
-        digest = TDigest.compute(ez, compression=1000)
-        centroids = digest.get_centroids()
-        return centroids
-
-    def finalize(self, centroids=None):
-        digests = (
-            TDigest.of_centroids(np.array(centroid), compression=1000)
-            for centroid in centroids
-        )
-        digest = reduce(add, digests)
-
-        return self.compute_from_digest(digest)
-
     def compute_from_digest(self, digest):
         x75, x25 = digest.inverse_cdf([0.75,0.25])
         iqr = x75 - x25
@@ -93,7 +144,7 @@ class PointSigmaIQR(PointToPointMetric):
         return sigma_iqr
 
 
-class PointBias(PointToPointMetric):
+class PointBias(PointToPointMetricDigester):
     """calculates the bias of the point stats ez samples.
     In keeping with the Science Book, this is just the median of the ez values.
     """
@@ -101,8 +152,8 @@ class PointBias(PointToPointMetric):
     metric_name = "point_bias"
     metric_output_type = MetricOutputType.single_value
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
 
     def evaluate(self, estimate, reference):
         """The point bias, or median of the point stats ez samples.
@@ -121,26 +172,11 @@ class PointBias(PointToPointMetric):
         """
         return np.median((estimate - reference) / (1.0 + reference))
 
-    def accumulate(self, estimate, reference):
-        ez = (estimate - reference) / (1.0 + reference)
-        digest = TDigest.compute(ez, compression=1000)
-        centroids = digest.get_centroids()
-        return centroids
-
-    def finalize(self, centroids=None):
-        digests = (
-            TDigest.of_centroids(np.array(centroid), compression=1000)
-            for centroid in centroids
-        )
-        digest = reduce(add, digests)
-
-        return self.compute_from_digest(digest)
-
     def compute_from_digest(self, digest):
         return digest.inverse_cdf(0.50)
 
 
-class PointOutlierRate(PointToPointMetric):
+class PointOutlierRate(PointToPointMetricDigester):
     """Calculates the catastrophic outlier rate, defined in the
     Science Book as the number of galaxies with ez larger than
     max(0.06,3sigma).  This keeps the fraction reasonable when
@@ -150,8 +186,8 @@ class PointOutlierRate(PointToPointMetric):
     metric_name = "point_outlier_rate"
     metric_output_type = MetricOutputType.single_value
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
 
     def evaluate(self, estimate, reference):
         """Calculates the catastrophic outlier rate
@@ -178,19 +214,7 @@ class PointOutlierRate(PointToPointMetric):
         outlier = np.sum(mask)
         return float(outlier) / float(num)
 
-    def accumulate(self, estimate, reference):
-        ez = (estimate - reference) / (1.0 + reference)
-        digest = TDigest.compute(ez, compression=1000)
-        centroids = digest.get_centroids()
-        return centroids
-
-    def finalize(self, centroids=None):
-        digests = (
-            TDigest.of_centroids(np.array(centroid), compression=1000)
-            for centroid in centroids
-        )
-        digest = reduce(add, digests)
-
+    def compute_from_digest(self, digest):
         # this replaces the call to PointSigmaIQR().evaluate()
         x75, x25 = digest.inverse_cdf([0.75,0.25])
         iqr = x75 - x25
@@ -210,7 +234,7 @@ class PointOutlierRate(PointToPointMetric):
         return float(outlier) / digest.weight
 
 
-class PointSigmaMAD(PointToPointMetric):
+class PointSigmaMAD(PointToPointMetricDigester):
     """Function to calculate median absolute deviation and sigma
     based on MAD (just scaled up by 1.4826) for the full and
     magnitude trimmed samples of ez values
@@ -219,8 +243,11 @@ class PointSigmaMAD(PointToPointMetric):
     metric_name = "point_stats_sigma_mad"
     metric_output_type = MetricOutputType.single_value
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._num_bins = 1_000_000
+        if "num_bins" in kwargs:
+            self._num_bins = kwargs["num_bins"]
 
     def evaluate(self, estimate, reference):
         """Function to calculate SigmaMAD (the median absolute deviation scaled
@@ -244,26 +271,14 @@ class PointSigmaMAD(PointToPointMetric):
         mad = np.median(np.fabs(ez - np.median(ez)))
         return mad * SCALE_FACTOR
 
-    def accumulate(self, estimate, reference):
-        ez = (estimate - reference) / (1.0 + reference)
-        digest = TDigest.compute(ez, compression=1000)
-        centroids = digest.get_centroids()
-        return centroids
-
-    def finalize(self, centroids=None, num_bins=1_000_000):
-        digests = (
-            TDigest.of_centroids(np.array(centroid), compression=1000)
-            for centroid in centroids
-        )
-        digest = reduce(add, digests)
-
+    def compute_from_digest(self, digest):
         SCALE_FACTOR = 1.4826
 
         # calculation of `np.median(np.fabs(ez - np.median(ez)))` as suggested by Eric Charles
         this_median = digest.inverse_cdf(0.50)
         this_min = digest.inverse_cdf(0)
         this_max = digest.inverse_cdf(1)
-        bins = np.linspace(this_min, this_max, num_bins)
+        bins = np.linspace(this_min, this_max, self._num_bins)
         this_pdf = digest.cdf(bins[1:]) - digest.cdf(bins[0:-1]) # len(this_pdf) = lots_of_bins - 1
         bin_dist = np.fabs(bins - this_median) # get the distance to the center for each bin in the hist
 

--- a/tests/qp/test_point_metrics.py
+++ b/tests/qp/test_point_metrics.py
@@ -84,6 +84,13 @@ class test_point_metrics(unittest.TestCase):
         sig_mad = point_sigma_mad.finalize([centroids])
         assert np.isclose(sig_mad, SIGMAD, atol=1e-5)
 
+        configuration = {'tdigest_compression': 5000, 'num_bins': 1_000}
+        point_sigma_mad = PointSigmaMAD(**configuration)
+        centroids = point_sigma_mad.accumulate(zb, zspec)
+        sig_mad = point_sigma_mad.finalize([centroids])
+        assert np.isclose(sig_mad, SIGMAD, atol=1e-4)
+
+
 
     def test_cde_loss_metric(self):
         """Basic test to ensure that the CDE Loss metric class is working."""

--- a/tests/qp/test_point_metrics.py
+++ b/tests/qp/test_point_metrics.py
@@ -33,6 +33,11 @@ def construct_test_ensemble():
     return zgrid, true_zs, grid_ens, true_ez
 
 
+#generator that yields chunks from estimate and reference
+def chunker(seq, size):
+    return (seq[pos:pos + size] for pos in range(0, len(seq), size))
+
+
 class test_point_metrics(unittest.TestCase):
 
     def test_point_metrics(self):
@@ -42,6 +47,7 @@ class test_point_metrics(unittest.TestCase):
 
         ez = PointStatsEz().evaluate(zb, zspec)
         assert np.allclose(ez, true_ez, atol=1.0e-2)
+
         # grid limits ez vals to ~10^-2 tol
 
         sig_iqr = PointSigmaIQR().evaluate(zb, zspec)
@@ -68,6 +74,11 @@ class test_point_metrics(unittest.TestCase):
         centroids = point_sigma_iqr.accumulate(zb, zspec)
         sig_iqr = point_sigma_iqr.finalize([centroids])
         assert np.isclose(sig_iqr, SIGIQR, atol=1.0e-4)
+
+        zb_iter = chunker(zb, 100)
+        zspec_iter = chunker(zspec, 100)
+        
+        sig_iqr_v2 = point_sigma_iqr.eval_from_iterator(zb_iter, zspec_iter)
 
         point_bias = PointBias(**configuration)
         centroids = point_bias.accumulate(zb, zspec)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
