### PR TITLE
switch from np.product() to np.prod() as the former is deprecated

### DIFF
--- a/src/qp/pdf_gen.py
+++ b/src/qp/pdf_gen.py
@@ -179,7 +179,7 @@ class rv_frozen_func(rv_continuous_frozen):
             self._shape = 1
         else:
             self._shape = ss[1:-1]
-        self._npdf = np.product(self._shape).astype(int)
+        self._npdf = np.prod(self._shape).astype(int)
         self._ndim = np.size(self._shape)
 
     @property
@@ -227,7 +227,7 @@ class rv_frozen_rows(rv_continuous_frozen):
     def __init__(self, dist, shape, *args, **kwds):
         """C'tor"""
         self._shape = shape
-        self._npdf = np.product(shape).astype(int)
+        self._npdf = np.prod(shape).astype(int)
         self._ndim = np.size(shape)
         if self._npdf is not None:
             kwds.setdefault(
@@ -281,7 +281,7 @@ class Pdf_rows_gen(rv_continuous, Pdf_gen):
     def __init__(self, *args, **kwargs):
         """C'tor"""
         self._shape = kwargs.pop("shape", (1))
-        self._npdf = np.product(self._shape).astype(int)
+        self._npdf = np.prod(self._shape).astype(int)
         super().__init__(*args, **kwargs)
 
     @property

--- a/src/qp/utils.py
+++ b/src/qp/utils.py
@@ -888,7 +888,7 @@ def reshape_to_pdf_size(vals, split_dim):
         The reshaped array
     """
     in_shape = np.shape(vals)
-    npdf = np.product(in_shape[:split_dim]).astype(int)
+    npdf = np.prod(in_shape[:split_dim]).astype(int)
     per_pdf = in_shape[split_dim:]
     out_shape = np.hstack([npdf, per_pdf])
     return vals.reshape(out_shape)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
