### PR TITLE
Add tiny value to log(0)

### DIFF
--- a/src/qp/metrics/goodness_of_fit.py
+++ b/src/qp/metrics/goodness_of_fit.py
@@ -11,11 +11,11 @@ Once Scipy 1.10 is made available, we can swap out the copied functions for thos
 import numpy as np
 
 
-def _anderson_darling(dist, data):
+def _anderson_darling(dist, data, tiny = 1e-100):
     x = np.sort(data, axis=-1)
     n = data.shape[-1]
     i = np.arange(1, n + 1)
-    Si = (2 * i - 1) / n * (dist.logcdf(x) + dist.logsf(x[..., ::-1]))
+    Si = (2 * i - 1) / n * (np.log(dist.cdf(x)+tiny) + np.log(dist.sf(x) + tiny))
     S = np.sum(Si, axis=-1)
     return -n - S
 


### PR DESCRIPTION
AD matrix need to take log of cdf value, which can be 0. So add a tiny value before log

## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
