### PR TITLE
removed the numpy version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "numpy<2.0.0",
+    "numpy",
     "scipy",
     "tables-io",
     "deprecated",


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Removed the requirement for numpy version 1.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
