### PR TITLE
expand limits as needed in _prepare_for_brier

### DIFF
--- a/src/qp/metrics/metrics.py
+++ b/src/qp/metrics/metrics.py
@@ -226,10 +226,11 @@ def _prepare_for_brier(p, truth, limits, dx=0.01):
             % (p.npdf, len(truth))
         )
 
-    # Values of truth that are outside the defined limits will not appear truth_array.
-    # Consider expanding the limits or using numpy.clip to restrict truth values to the limits.
-    if np.any(np.less(truth, limits[0])) or np.any(np.greater(truth, limits[1])):
-        raise ValueError(f"Input truth values exceed the defined limits ({min(truth)}, {max(truth)}) ({limits[0]} {limits[1]})")
+    # Handle values of truth that are outside the defined limit
+    # by expanding the limits
+    if np.any(np.less(truth, limits[0])) or np.any(np.greater(truth, limits[1])):  # pragma: no cover
+        limits=(np.min([np.min(truth),limits[0]]), np.max([np.max(truth),limits[1]]))
+        print("Expanding limits to {limits}")
 
     # Make a grid object that defines grid values and histogram bin edges using limits and dx
     grid = _calculate_grid_parameters(limits, dx)

--- a/tests/qp/test_metrics.py
+++ b/tests/qp/test_metrics.py
@@ -322,11 +322,11 @@ class MetricTestCase(unittest.TestCase):
         truth = 2 * (np.random.uniform(size=(10, 1)) - 0.5)
         truth = np.append(truth, 100)
         limits = [-2.0, 2]
-        with self.assertRaises(ValueError) as context:
-            _ = calculate_brier(self.ens_n, truth, limits)
-
-        error_msg = "Input truth values exceed the defined limits"
-        self.assertTrue(error_msg in str(context.exception))
+        # this no longer raises, but rather expands the limits
+        # with self.assertRaises(ValueError) as context:
+        #     error_msg = "Input truth values exceed the defined limits"
+        # self.assertTrue(error_msg in str(context.exception))
+        _ = calculate_brier(self.ens_n, truth, limits)
 
     def test_calculate_outlier_rate(self):
         """Base case test. Ensure that the class wrapped


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

#239 

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
