### PR TITLE
fixed tables_io dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy>=2.0",
     "scipy>=1.13",
-    "tables-io",
+    "tables-io>=1.0.0",
     "deprecated"
 ]
 
@@ -29,7 +29,7 @@ dependencies = [
 full = ["tables-io[full]", "matplotlib","pytdigest","scikit-learn>=1.0"] # enables full code capability, including writing to all file formats and plottting
 
 dev = [
-    "tables-io@git+https://github.com/sidratresearch/tables_io@dev-working",
+    "tables-io[full]",
     "matplotlib",
     "scikit-learn>=1.0",
     "pytest",


### PR DESCRIPTION
tables_io version was still pointing to a specific branch, fixed to just refer to package and to require version>=1.0.0

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
