### PR TITLE
Remove-typing-extensions

### DIFF
--- a/src/qp/core/factory.py
+++ b/src/qp/core/factory.py
@@ -6,7 +6,7 @@ import os
 
 from collections import OrderedDict
 from collections.abc import Iterator
-from typing_extensions import Mapping, Union, Optional, Tuple
+from typing import Mapping, Union, Optional, Tuple
 
 import numpy as np
 


### PR DESCRIPTION
Changed one-time usage of typing_extensions in factory.py to use typing as in the rest of the code, to remove typing_extensions as an unwritten dependency 