### PR TITLE
remove numpy.trapz

### DIFF
--- a/src/qp/metrics/concrete_metric_classes.py
+++ b/src/qp/metrics/concrete_metric_classes.py
@@ -329,7 +329,7 @@ class CDELossMetric(DistToPointMetricDigester):
         npdf = estimate.npdf
 
         # Calculate first term E[\int f*(z | X)^2 dz]
-        term1 = np.mean(np.trapz(pdfs**2, x=self._xvals))
+        term1 = np.mean(np.trapezoid(pdfs**2, x=self._xvals))
         # z bin closest to ztrue
         nns = [np.argmin(np.abs(self._xvals - z)) for z in reference]
         # Calculate second term E[f*(Z | X)]
@@ -340,7 +340,7 @@ class CDELossMetric(DistToPointMetricDigester):
     def accumulate(self, estimate, reference):
         pdfs = estimate.pdf(self._xvals)
         npdf = estimate.npdf
-        term1_sum = np.sum(np.trapz(pdfs**2, x=self._xvals))
+        term1_sum = np.sum(np.trapezoid(pdfs**2, x=self._xvals))
 
         nns = [np.argmin(np.abs(self._xvals - z)) for z in reference]
         term2_sum = np.sum(pdfs[range(npdf), nns])


### PR DESCRIPTION
To make qp numpy 2.0 compatible, remove trapz and replace it with trapezoid.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
